### PR TITLE
feat(engine): migrate Two Dimension Forcer to new geometry

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.88"
+version = "0.2.89"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "futures",
  "once_cell",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "approx",
  "async-trait",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "Inflector",
  "approx",
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "bytes",
  "clap",
@@ -5058,7 +5058,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5101,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5129,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5142,7 +5142,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "approx",
  "bvh",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5287,7 +5287,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "bytes",
  "futures",
@@ -5335,7 +5335,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "bytes",
  "futures",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "ahash",
  "bytes",
@@ -5438,7 +5438,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "async-trait",
  "axum",
@@ -8204,7 +8204,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.278"
+version = "0.1.279"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.456"
+version = "0.0.457"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/action-processor/src/geometry/two_dimension_forcer.rs
+++ b/engine/runtime/action-processor/src/geometry/two_dimension_forcer.rs
@@ -1,7 +1,11 @@
 use std::collections::HashMap;
+#[cfg(not(feature = "new-geometry"))]
 use std::sync::Arc;
 
+#[cfg(not(feature = "new-geometry"))]
 use reearth_flow_geometry::types::geometry::Geometry2D;
+#[cfg(feature = "new-geometry")]
+use reearth_flow_runtime::node::REJECTED_PORT;
 use reearth_flow_runtime::{
     errors::BoxedError,
     event::EventHub,
@@ -9,6 +13,7 @@ use reearth_flow_runtime::{
     forwarder::ProcessorChannelForwarder,
     node::{Port, Processor, ProcessorFactory, FEATURES_PORT},
 };
+#[cfg(not(feature = "new-geometry"))]
 use reearth_flow_types::GeometryValue;
 use serde_json::Value;
 
@@ -40,8 +45,14 @@ impl ProcessorFactory for TwoDimensionForcerFactory {
         vec![FEATURES_PORT.clone()]
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn get_output_ports(&self) -> Vec<Port> {
         vec![FEATURES_PORT.clone()]
+    }
+
+    #[cfg(feature = "new-geometry")]
+    fn get_output_ports(&self) -> Vec<Port> {
+        vec![FEATURES_PORT.clone(), REJECTED_PORT.clone()]
     }
 
     fn build(
@@ -59,6 +70,42 @@ impl ProcessorFactory for TwoDimensionForcerFactory {
 pub struct TwoDimensionForcer;
 
 impl Processor for TwoDimensionForcer {
+    // Drops the Z coordinate, re-representing 3D geometry in a 2D embedding and
+    // clearing any 2.5D elevation. The coordinate frame (CRS tag) is preserved
+    // verbatim — no reprojection; use the Coordinate Frame Reprojector to change
+    // it. Geometry with no 2D counterpart is routed to the rejected port.
+    #[cfg(feature = "new-geometry")]
+    fn process(
+        &mut self,
+        ctx: ExecutorContext,
+        fw: &ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        let mut feature = ctx.feature.clone();
+        match feature.geometry_mut().force_2d() {
+            Ok(forced) => {
+                *feature.geometry_mut() = forced;
+                fw.send(ctx.new_with_feature_and_port(feature, FEATURES_PORT.clone()));
+            }
+            Err(e) => {
+                ctx.event_hub
+                    .debug_log(Some(ctx.error_span()), format!("force 2D rejected: {e}"));
+                // `feature` may be partially moved-from on a collection failure;
+                // forward a pristine copy of the input to the rejected port.
+                fw.send(ctx.new_with_feature_and_port(ctx.feature.clone(), REJECTED_PORT.clone()));
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "new-geometry")]
+    fn finish(
+        &mut self,
+        _ctx: NodeContext,
+        _fw: &ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        Ok(())
+    }
+
     #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,

--- a/engine/runtime/action-processor/src/geometry/two_dimension_forcer.rs
+++ b/engine/runtime/action-processor/src/geometry/two_dimension_forcer.rs
@@ -75,59 +75,48 @@ impl ProcessorFactory for TwoDimensionForcerFactory {
 #[derive(Debug, Clone, Default)]
 pub struct TwoDimensionForcer {
     /// CRSs already reported as unusable. An unusable CRS is a property of the
-    /// stream, not of one feature, so it is logged once per code instead of once
-    /// per feature.
+    /// stream rather than of one feature, so it is logged once per code.
     #[cfg(feature = "new-geometry")]
     reported_frames: HashSet<EpsgCode>,
 }
 
 impl Processor for TwoDimensionForcer {
     // Drops the Z coordinate and any 2.5D elevation, demoting the CRS tag with it
-    // (EPSG:6697 becomes EPSG:6668) so it still matches the coordinates. Geometry
-    // that cannot be flattened, by type or by CRS, goes to the rejected port.
+    // so it still matches the coordinates. Geometry that cannot be flattened,
+    // whether by type or by CRS, goes to the rejected port.
     #[cfg(feature = "new-geometry")]
     fn process(
         &mut self,
         ctx: ExecutorContext,
         fw: &ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
-        let mut feature = ctx.feature.clone();
-        match feature.geometry_mut().force_2d() {
+        // Forced on a copy: a failure part-way through a collection leaves the
+        // geometry moved-from, and the input must stay intact for the reject port.
+        let mut geometry = (*ctx.feature.geometry).clone();
+        match geometry.force_2d() {
             Ok(forced) => {
-                *feature.geometry_mut() = forced;
+                let mut feature = ctx.feature.clone();
+                feature.set_geometry(forced);
                 fw.send(ctx.new_with_feature_and_port(feature, FEATURES_PORT.clone()));
             }
             Err(e) => {
-                // An unsupported geometry type is a routing decision the workflow
-                // author made (feeding solids here is normal), but an unusable CRS
-                // is a data or installation problem they need told about. Warn on
-                // the first feature carrying each such CRS.
-                let first_of_this_frame = match &e {
+                // An unsupported type is this port's normal business, but an
+                // unusable CRS means broken data or a broken PROJ install.
+                let should_warn = match &e {
                     ForceTwoDimensionError::UnsupportedFrame(frame) => {
                         self.reported_frames.insert(frame.epsg)
                     }
                     ForceTwoDimensionError::UnsupportedGeometry(_) => false,
                 };
                 let message = format!("force 2D rejected: {e}");
-                if first_of_this_frame {
+                if should_warn {
                     ctx.event_hub.warn_log(Some(ctx.error_span()), message);
                 } else {
                     ctx.event_hub.debug_log(Some(ctx.error_span()), message);
                 }
-                // `feature` may be partially moved-from on a collection failure;
-                // forward a pristine copy of the input to the rejected port.
                 fw.send(ctx.new_with_feature_and_port(ctx.feature.clone(), REJECTED_PORT.clone()));
             }
         }
-        Ok(())
-    }
-
-    #[cfg(feature = "new-geometry")]
-    fn finish(
-        &mut self,
-        _ctx: NodeContext,
-        _fw: &ProcessorChannelForwarder,
-    ) -> Result<(), BoxedError> {
         Ok(())
     }
 
@@ -170,7 +159,6 @@ impl Processor for TwoDimensionForcer {
         Ok(())
     }
 
-    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/two_dimension_forcer.rs
+++ b/engine/runtime/action-processor/src/geometry/two_dimension_forcer.rs
@@ -1,7 +1,13 @@
 use std::collections::HashMap;
+#[cfg(feature = "new-geometry")]
+use std::collections::HashSet;
 #[cfg(not(feature = "new-geometry"))]
 use std::sync::Arc;
 
+#[cfg(feature = "new-geometry")]
+use reearth_flow_geometry::coordinate::EpsgCode;
+#[cfg(feature = "new-geometry")]
+use reearth_flow_geometry::ops::ForceTwoDimensionError;
 #[cfg(not(feature = "new-geometry"))]
 use reearth_flow_geometry::types::geometry::Geometry2D;
 #[cfg(feature = "new-geometry")]
@@ -62,20 +68,23 @@ impl ProcessorFactory for TwoDimensionForcerFactory {
         _action: String,
         _with: Option<HashMap<String, Value>>,
     ) -> Result<Box<dyn Processor>, BoxedError> {
-        Ok(Box::new(TwoDimensionForcer))
+        Ok(Box::new(TwoDimensionForcer::default()))
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct TwoDimensionForcer;
+#[derive(Debug, Clone, Default)]
+pub struct TwoDimensionForcer {
+    /// CRSs already reported as unusable. An unusable CRS is a property of the
+    /// stream, not of one feature, so it is logged once per code instead of once
+    /// per feature.
+    #[cfg(feature = "new-geometry")]
+    reported_frames: HashSet<EpsgCode>,
+}
 
 impl Processor for TwoDimensionForcer {
-    // Drops the Z coordinate, re-representing 3D geometry in a 2D embedding and
-    // clearing any 2.5D elevation. The CRS tag is demoted to its 2D counterpart
-    // so it keeps describing the coordinates (EPSG:6697 becomes EPSG:6668); the
-    // coordinate values themselves are not reprojected — use the Coordinate Frame
-    // Reprojector for that. Geometry with no 2D counterpart, by type or by CRS,
-    // is routed to the rejected port.
+    // Drops the Z coordinate and any 2.5D elevation, demoting the CRS tag with it
+    // (EPSG:6697 becomes EPSG:6668) so it still matches the coordinates. Geometry
+    // that cannot be flattened, by type or by CRS, goes to the rejected port.
     #[cfg(feature = "new-geometry")]
     fn process(
         &mut self,
@@ -89,8 +98,22 @@ impl Processor for TwoDimensionForcer {
                 fw.send(ctx.new_with_feature_and_port(feature, FEATURES_PORT.clone()));
             }
             Err(e) => {
-                ctx.event_hub
-                    .debug_log(Some(ctx.error_span()), format!("force 2D rejected: {e}"));
+                // An unsupported geometry type is a routing decision the workflow
+                // author made (feeding solids here is normal), but an unusable CRS
+                // is a data or installation problem they need told about. Warn on
+                // the first feature carrying each such CRS.
+                let first_of_this_frame = match &e {
+                    ForceTwoDimensionError::UnsupportedFrame(frame) => {
+                        self.reported_frames.insert(frame.epsg)
+                    }
+                    ForceTwoDimensionError::UnsupportedGeometry(_) => false,
+                };
+                let message = format!("force 2D rejected: {e}");
+                if first_of_this_frame {
+                    ctx.event_hub.warn_log(Some(ctx.error_span()), message);
+                } else {
+                    ctx.event_hub.debug_log(Some(ctx.error_span()), message);
+                }
                 // `feature` may be partially moved-from on a collection failure;
                 // forward a pristine copy of the input to the rejected port.
                 fw.send(ctx.new_with_feature_and_port(ctx.feature.clone(), REJECTED_PORT.clone()));

--- a/engine/runtime/action-processor/src/geometry/two_dimension_forcer.rs
+++ b/engine/runtime/action-processor/src/geometry/two_dimension_forcer.rs
@@ -71,9 +71,11 @@ pub struct TwoDimensionForcer;
 
 impl Processor for TwoDimensionForcer {
     // Drops the Z coordinate, re-representing 3D geometry in a 2D embedding and
-    // clearing any 2.5D elevation. The coordinate frame (CRS tag) is preserved
-    // verbatim — no reprojection; use the Coordinate Frame Reprojector to change
-    // it. Geometry with no 2D counterpart is routed to the rejected port.
+    // clearing any 2.5D elevation. The CRS tag is demoted to its 2D counterpart
+    // so it keeps describing the coordinates (EPSG:6697 becomes EPSG:6668); the
+    // coordinate values themselves are not reprojected — use the Coordinate Frame
+    // Reprojector for that. Geometry with no 2D counterpart, by type or by CRS,
+    // is routed to the rejected port.
     #[cfg(feature = "new-geometry")]
     fn process(
         &mut self,

--- a/engine/runtime/geometry/src/collection.rs
+++ b/engine/runtime/geometry/src/collection.rs
@@ -14,7 +14,8 @@ use crate::coordinate::EpsgCode;
 use crate::error::Error;
 use crate::ops::union_results;
 use crate::ops::{
-    Aabb, BoundingBox, ForceTwoDimension, Reproject, ReprojectionCache, UnsupportedOperation,
+    Aabb, BoundingBox, ForceTwoDimension, ForceTwoDimensionError, Reproject, ReprojectionCache,
+    UnsupportedOperation,
 };
 #[cfg(feature = "new-geometry")]
 use crate::validation_next::Validate;
@@ -253,7 +254,7 @@ impl crate::ops::Split for Collection3D {
 }
 
 impl ForceTwoDimension for Collection2D {
-    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, ForceTwoDimensionError> {
         // All-or-nothing: one member with no 2D counterpart fails the whole
         // collection; `members` stays 1:1 with the input, keeping `attrs` parallel.
         let mut members = Vec::with_capacity(self.members.len());
@@ -271,7 +272,7 @@ impl ForceTwoDimension for Collection2D {
 }
 
 impl ForceTwoDimension for Collection3D {
-    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, ForceTwoDimensionError> {
         // All-or-nothing: one member with no 2D counterpart fails the whole
         // collection; `members` stays 1:1 with the input, keeping `attrs` parallel.
         let mut members = Vec::with_capacity(self.members.len());

--- a/engine/runtime/geometry/src/collection.rs
+++ b/engine/runtime/geometry/src/collection.rs
@@ -255,37 +255,27 @@ impl crate::ops::Split for Collection3D {
 
 impl ForceTwoDimension for Collection2D {
     fn force_2d(&mut self) -> Result<Euclidean2DGeometry, ForceTwoDimensionError> {
-        // All-or-nothing: one member with no 2D counterpart fails the whole
-        // collection; `members` stays 1:1 with the input, keeping `attrs` parallel.
         let mut members = Vec::with_capacity(self.members.len());
         for member in &mut self.members {
             members.push(member.force_2d()?);
         }
-        let attrs = std::mem::take(&mut self.attrs);
-        let collection =
-            Collection2D::with_attributes(members, attrs).map_err(|_| UnsupportedOperation {
-                geometry: "Collection2D",
-                operation: "force_2d",
-            })?;
-        Ok(Euclidean2DGeometry::Collection(collection))
+        Ok(Euclidean2DGeometry::Collection(Collection2D {
+            members,
+            attrs: std::mem::take(&mut self.attrs),
+        }))
     }
 }
 
 impl ForceTwoDimension for Collection3D {
     fn force_2d(&mut self) -> Result<Euclidean2DGeometry, ForceTwoDimensionError> {
-        // All-or-nothing: one member with no 2D counterpart fails the whole
-        // collection; `members` stays 1:1 with the input, keeping `attrs` parallel.
         let mut members = Vec::with_capacity(self.members.len());
         for member in &mut self.members {
             members.push(member.force_2d()?);
         }
-        let attrs = std::mem::take(&mut self.attrs);
-        let collection =
-            Collection2D::with_attributes(members, attrs).map_err(|_| UnsupportedOperation {
-                geometry: "Collection3D",
-                operation: "force_2d",
-            })?;
-        Ok(Euclidean2DGeometry::Collection(collection))
+        Ok(Euclidean2DGeometry::Collection(Collection2D {
+            members,
+            attrs: std::mem::take(&mut self.attrs),
+        }))
     }
 }
 

--- a/engine/runtime/geometry/src/collection.rs
+++ b/engine/runtime/geometry/src/collection.rs
@@ -13,7 +13,9 @@ use serde::{Deserialize, Serialize};
 use crate::coordinate::EpsgCode;
 use crate::error::Error;
 use crate::ops::union_results;
-use crate::ops::{Aabb, BoundingBox, Reproject, ReprojectionCache, UnsupportedOperation};
+use crate::ops::{
+    Aabb, BoundingBox, ForceTwoDimension, Reproject, ReprojectionCache, UnsupportedOperation,
+};
 #[cfg(feature = "new-geometry")]
 use crate::validation_next::Validate;
 use crate::{Euclidean2DGeometry, Euclidean3DGeometry};
@@ -247,6 +249,42 @@ impl crate::ops::Split for Collection3D {
             .map(crate::Geometry::Euclidean3D);
         crate::ops::split::emit_members(members, std::mem::take(&mut self.attrs), emit);
         Ok(())
+    }
+}
+
+impl ForceTwoDimension for Collection2D {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+        // All-or-nothing: one member with no 2D counterpart fails the whole
+        // collection; `members` stays 1:1 with the input, keeping `attrs` parallel.
+        let mut members = Vec::with_capacity(self.members.len());
+        for member in &mut self.members {
+            members.push(member.force_2d()?);
+        }
+        let attrs = std::mem::take(&mut self.attrs);
+        let collection =
+            Collection2D::with_attributes(members, attrs).map_err(|_| UnsupportedOperation {
+                geometry: "Collection2D",
+                operation: "force_2d",
+            })?;
+        Ok(Euclidean2DGeometry::Collection(collection))
+    }
+}
+
+impl ForceTwoDimension for Collection3D {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+        // All-or-nothing: one member with no 2D counterpart fails the whole
+        // collection; `members` stays 1:1 with the input, keeping `attrs` parallel.
+        let mut members = Vec::with_capacity(self.members.len());
+        for member in &mut self.members {
+            members.push(member.force_2d()?);
+        }
+        let attrs = std::mem::take(&mut self.attrs);
+        let collection =
+            Collection2D::with_attributes(members, attrs).map_err(|_| UnsupportedOperation {
+                geometry: "Collection3D",
+                operation: "force_2d",
+            })?;
+        Ok(Euclidean2DGeometry::Collection(collection))
     }
 }
 

--- a/engine/runtime/geometry/src/coordinate.rs
+++ b/engine/runtime/geometry/src/coordinate.rs
@@ -118,22 +118,19 @@ impl CoordinateFrame {
         }
     }
 
-    /// The frame a geometry must carry once it is re-represented in a pure 2D
-    /// embedding: a frame whose dimensionality matches the coordinates'.
+    /// This frame with its vertical axis dropped, for coordinates that have just
+    /// been flattened to 2D.
     ///
-    /// A `Crs` frame is demoted to its 2D counterpart — the horizontal component
-    /// of a compound CRS (EPSG:6697 becomes EPSG:6668), the 2D form of a
-    /// geographic 3D one (EPSG:4979 becomes EPSG:4326) — and an already-2D CRS
-    /// maps to itself, so the operation is idempotent. Coordinate values are
-    /// unaffected: the counterpart shares the datum, the axis order and the
-    /// units, only the vertical axis is gone. `Euclidean` and `Tangent` carry no
-    /// vertical axis to shed and are returned unchanged.
+    /// A `Crs` frame becomes its 2D counterpart: the horizontal component of a
+    /// compound CRS (EPSG:6697 becomes EPSG:6668), the 2D form of a geographic 3D
+    /// one (EPSG:4979 becomes EPSG:4326), or itself when already 2D — so the
+    /// operation is idempotent. The counterpart shares the datum, axis order and
+    /// units, so coordinate values are unaffected. `Euclidean` and `Tangent` have
+    /// no vertical axis to shed and come back unchanged.
     ///
-    /// Errors when the CRS has no 2D counterpart, and equally when PROJ cannot
-    /// resolve the CRS at all: a frame that cannot be shown to be 2D must not be
-    /// attached to 2D coordinates. [`FrameDemotionError`] keeps the two cases
-    /// apart, since they call for different fixes.
-    pub fn demote_to_2d(&self) -> std::result::Result<CoordinateFrame, FrameDemotionError> {
+    /// Errors per [`FrameDemotionError`]: a frame that cannot be shown to be 2D
+    /// must not be attached to 2D coordinates.
+    pub fn demote_to_2d(&self) -> Result<CoordinateFrame, FrameDemotionError> {
         let CoordinateFrame::Crs(epsg) = self else {
             return Ok(self.clone());
         };
@@ -142,7 +139,7 @@ impl CoordinateFrame {
             Ok(crate::ops::TwoDimensionalCrs::None(why)) => {
                 FrameDemotionReason::NoTwoDimensionalForm(why)
             }
-            Err(e) => FrameDemotionReason::Unresolvable(e.to_string()),
+            Err(why) => FrameDemotionReason::Unresolvable(why),
         };
         Err(FrameDemotionError {
             epsg: *epsg,
@@ -189,30 +186,59 @@ pub struct FrameDemotionError {
     pub reason: FrameDemotionReason,
 }
 
-/// The two ways demoting a CRS frame fails. They call for different fixes — one
-/// is the wrong CRS for the operation, the other is a CRS the installation
-/// cannot look up — so they are kept apart rather than flattened to one message.
+/// The two ways demoting a CRS frame fails. Kept apart because they call for
+/// different fixes: the wrong CRS for the operation, versus a CRS the
+/// installation cannot look up.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum FrameDemotionReason {
-    /// PROJ resolved the CRS and it has no 2D form. Carries the specific reason.
-    NoTwoDimensionalForm(&'static str),
-    /// PROJ could not resolve the CRS, leaving its dimensionality unknown.
-    /// Carries PROJ's failure message.
+    NoTwoDimensionalForm(MissingTwoDimensionalForm),
+    /// PROJ's own failure message, verbatim.
     Unresolvable(String),
+}
+
+/// PROJ's grounds for a resolved CRS having no 2D form, each a fixed property of
+/// the CRS. The [`Display`](fmt::Display) arms are the wording users see.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MissingTwoDimensionalForm {
+    Geocentric,
+    Unidentified,
+    StillThreeDimensional,
+    NoCoordinateSystem,
+}
+
+impl fmt::Display for MissingTwoDimensionalForm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            MissingTwoDimensionalForm::Geocentric => {
+                "it is geocentric (ECEF), so its third axis is the rotation axis rather than a vertical one"
+            }
+            MissingTwoDimensionalForm::Unidentified => "its 2D form carries no EPSG identifier",
+            MissingTwoDimensionalForm::StillThreeDimensional => {
+                "its 2D form still has more than two axes"
+            }
+            MissingTwoDimensionalForm::NoCoordinateSystem => {
+                "its 2D form reports no coordinate system"
+            }
+        })
+    }
+}
+
+impl fmt::Display for FrameDemotionReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FrameDemotionReason::NoTwoDimensionalForm(cause) => cause.fmt(f),
+            FrameDemotionReason::Unresolvable(why) => f.write_str(why),
+        }
+    }
 }
 
 impl fmt::Display for FrameDemotionError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.reason {
-            FrameDemotionReason::NoTwoDimensionalForm(why) => {
-                write!(f, "EPSG:{} has no 2D counterpart: {why}", self.epsg)
-            }
-            FrameDemotionReason::Unresolvable(why) => write!(
-                f,
-                "EPSG:{} cannot be demoted to 2D because PROJ could not resolve it: {why}",
-                self.epsg
-            ),
-        }
+        write!(
+            f,
+            "EPSG:{} cannot be demoted to 2D: {}",
+            self.epsg, self.reason
+        )
     }
 }
 
@@ -295,18 +321,6 @@ mod tests {
     }
 
     #[test]
-    fn demote_to_2d_drops_the_vertical_axis() {
-        let demote = |code: u16| CoordinateFrame::Crs(EpsgCode::new(code)).demote_to_2d();
-        // Compound -> its horizontal component; geographic 3D -> its 2D form.
-        assert_eq!(demote(6697), Ok(CoordinateFrame::Crs(EpsgCode::new(6668))));
-        assert_eq!(demote(4979), Ok(CoordinateFrame::Crs(EpsgCode::new(4326))));
-        // A CRS with no vertical axis maps to itself, which is what makes forcing
-        // a geometry to 2D twice stable.
-        assert_eq!(demote(6668), Ok(CoordinateFrame::Crs(EpsgCode::new(6668))));
-        assert_eq!(demote(6677), Ok(CoordinateFrame::Crs(EpsgCode::new(6677))));
-    }
-
-    #[test]
     fn demote_to_2d_rejects_a_crs_with_no_2d_form() {
         // A geocentric CRS's third axis is the rotation axis, so there is no
         // horizontal component to fall back to.
@@ -314,13 +328,9 @@ mod tests {
             .demote_to_2d()
             .unwrap_err();
         assert_eq!(err.epsg, EpsgCode::new(4978));
-        assert!(matches!(
+        assert_eq!(
             err.reason,
-            FrameDemotionReason::NoTwoDimensionalForm(_)
-        ));
-        assert!(
-            err.to_string().contains("has no 2D counterpart"),
-            "unexpected message: {err}"
+            FrameDemotionReason::NoTwoDimensionalForm(MissingTwoDimensionalForm::Geocentric)
         );
     }
 
@@ -332,8 +342,8 @@ mod tests {
             CoordinateFrame::Euclidean.demote_to_2d(),
             Ok(CoordinateFrame::Euclidean)
         );
-        // A tangent plane stays put even when anchored in a 3D CRS: the base
-        // frame describes the plane, not the geometry's coordinates.
+        // The base frame describes the plane, not the geometry's coordinates, so
+        // a 3D base changes nothing.
         let tangent = CoordinateFrame::Tangent(Box::new(TangentPlane {
             base: BaseFrame::Crs(EpsgCode::new(6697)),
             origin: [0.0, 0.0, 0.0],
@@ -346,18 +356,13 @@ mod tests {
     #[test]
     fn an_unresolvable_crs_is_rejected() {
         // EPSG:1 is not a real CRS, so PROJ cannot say whether it has a 2D form.
-        // "Unknown" must not become "keep the 3D tag": that is exactly the
-        // mismatch demotion exists to prevent. Reported apart from a
-        // resolved-but-2D-less CRS because the fix differs.
+        // "Unknown" must reject rather than keep the 3D tag, and must stay
+        // distinguishable from a resolved CRS that simply has no 2D form.
         let err = CoordinateFrame::Crs(EpsgCode::new(1))
             .demote_to_2d()
             .unwrap_err();
         assert_eq!(err.epsg, EpsgCode::new(1));
         assert!(matches!(err.reason, FrameDemotionReason::Unresolvable(_)));
-        assert!(
-            err.to_string().contains("PROJ could not resolve it"),
-            "unexpected message: {err}"
-        );
     }
 
     #[test]

--- a/engine/runtime/geometry/src/coordinate.rs
+++ b/engine/runtime/geometry/src/coordinate.rs
@@ -118,6 +118,35 @@ impl CoordinateFrame {
         }
     }
 
+    /// The frame a geometry must carry once it is re-represented in a pure 2D
+    /// embedding: a frame whose dimensionality matches the coordinates'.
+    ///
+    /// A `Crs` frame is demoted to its 2D counterpart — the horizontal component
+    /// of a compound CRS (EPSG:6697 becomes EPSG:6668), the 2D form of a
+    /// geographic 3D one (EPSG:4979 becomes EPSG:4326) — and an already-2D CRS
+    /// maps to itself, so the operation is idempotent. Coordinate values are
+    /// unaffected: the counterpart shares the datum, the axis order and the
+    /// units, only the vertical axis is gone. `Euclidean` and `Tangent` carry no
+    /// vertical axis to shed and are returned unchanged.
+    ///
+    /// Errors only when the CRS definitively has no 2D counterpart. When PROJ
+    /// cannot classify the CRS at all the frame is returned verbatim, matching
+    /// [`UnitKind::Undeterminable`]: an indeterminate answer is not evidence of a
+    /// bad frame.
+    pub fn demote_to_2d(&self) -> std::result::Result<CoordinateFrame, FrameDemotionError> {
+        let CoordinateFrame::Crs(epsg) = self else {
+            return Ok(self.clone());
+        };
+        match crate::ops::crs_demote_to_2d(*epsg) {
+            Ok(crate::ops::TwoDimensionalCrs::Code(code)) => Ok(CoordinateFrame::Crs(code)),
+            Ok(crate::ops::TwoDimensionalCrs::None(reason)) => Err(FrameDemotionError {
+                epsg: *epsg,
+                reason,
+            }),
+            Err(_) => Ok(self.clone()),
+        }
+    }
+
     /// Whether coordinates in this frame are in linear (length) units, so that
     /// unit-sensitive checks (planarity, surface triangulation) are meaningful.
     /// True only for a definitely-linear frame; an angular or undeterminable
@@ -145,6 +174,29 @@ impl CoordinateFrame {
         }
     }
 }
+
+/// A CRS that has no 2D counterpart, so no frame can describe its coordinates
+/// once the vertical axis is dropped. Returned by
+/// [`demote_to_2d`](CoordinateFrame::demote_to_2d).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FrameDemotionError {
+    /// The CRS that could not be demoted.
+    pub epsg: EpsgCode,
+    /// Why it could not be.
+    pub reason: &'static str,
+}
+
+impl fmt::Display for FrameDemotionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "EPSG:{} has no 2D counterpart: {}",
+            self.epsg, self.reason
+        )
+    }
+}
+
+impl std::error::Error for FrameDemotionError {}
 
 /// How a coordinate frame's horizontal units classify: linear (length), angular
 /// (degrees), or unclassifiable. "Linear" rather than "metric" because a length
@@ -220,6 +272,33 @@ mod tests {
             v: [0.0, 1.0, 0.0],
         }));
         assert_eq!(tangent_over_geographic.unit_kind(), UnitKind::Linear);
+    }
+
+    #[test]
+    fn demote_to_2d_drops_the_vertical_axis() {
+        let demote = |code: u16| CoordinateFrame::Crs(EpsgCode::new(code)).demote_to_2d();
+        // Compound -> its horizontal component; geographic 3D -> its 2D form.
+        assert_eq!(demote(6697), Ok(CoordinateFrame::Crs(EpsgCode::new(6668))));
+        assert_eq!(demote(4979), Ok(CoordinateFrame::Crs(EpsgCode::new(4326))));
+        // Already 2D: idempotent, so forcing twice is stable.
+        assert_eq!(demote(6668), Ok(CoordinateFrame::Crs(EpsgCode::new(6668))));
+        assert_eq!(demote(6677), Ok(CoordinateFrame::Crs(EpsgCode::new(6677))));
+        // Geocentric: no 2D form exists.
+        assert_eq!(demote(4978).unwrap_err().epsg, EpsgCode::new(4978));
+        // Non-CRS frames have no vertical axis to shed.
+        assert_eq!(
+            CoordinateFrame::Euclidean.demote_to_2d(),
+            Ok(CoordinateFrame::Euclidean)
+        );
+    }
+
+    #[test]
+    fn an_unclassifiable_crs_keeps_its_frame() {
+        // EPSG:1 is not a real CRS. PROJ cannot say whether it has a 2D form, and
+        // an indeterminate answer is not evidence of a bad frame, so it passes
+        // through rather than failing the geometry.
+        let unknown = CoordinateFrame::Crs(EpsgCode::new(1));
+        assert_eq!(unknown.demote_to_2d(), Ok(unknown.clone()));
     }
 
     #[test]

--- a/engine/runtime/geometry/src/coordinate.rs
+++ b/engine/runtime/geometry/src/coordinate.rs
@@ -129,22 +129,25 @@ impl CoordinateFrame {
     /// units, only the vertical axis is gone. `Euclidean` and `Tangent` carry no
     /// vertical axis to shed and are returned unchanged.
     ///
-    /// Errors only when the CRS definitively has no 2D counterpart. When PROJ
-    /// cannot classify the CRS at all the frame is returned verbatim, matching
-    /// [`UnitKind::Undeterminable`]: an indeterminate answer is not evidence of a
-    /// bad frame.
+    /// Errors when the CRS has no 2D counterpart, and equally when PROJ cannot
+    /// resolve the CRS at all: a frame that cannot be shown to be 2D must not be
+    /// attached to 2D coordinates. [`FrameDemotionError`] keeps the two cases
+    /// apart, since they call for different fixes.
     pub fn demote_to_2d(&self) -> std::result::Result<CoordinateFrame, FrameDemotionError> {
         let CoordinateFrame::Crs(epsg) = self else {
             return Ok(self.clone());
         };
-        match crate::ops::crs_demote_to_2d(*epsg) {
-            Ok(crate::ops::TwoDimensionalCrs::Code(code)) => Ok(CoordinateFrame::Crs(code)),
-            Ok(crate::ops::TwoDimensionalCrs::None(reason)) => Err(FrameDemotionError {
-                epsg: *epsg,
-                reason,
-            }),
-            Err(_) => Ok(self.clone()),
-        }
+        let reason = match crate::ops::crs_demote_to_2d(*epsg) {
+            Ok(crate::ops::TwoDimensionalCrs::Code(code)) => return Ok(CoordinateFrame::Crs(code)),
+            Ok(crate::ops::TwoDimensionalCrs::None(why)) => {
+                FrameDemotionReason::NoTwoDimensionalForm(why)
+            }
+            Err(e) => FrameDemotionReason::Unresolvable(e.to_string()),
+        };
+        Err(FrameDemotionError {
+            epsg: *epsg,
+            reason,
+        })
     }
 
     /// Whether coordinates in this frame are in linear (length) units, so that
@@ -175,24 +178,41 @@ impl CoordinateFrame {
     }
 }
 
-/// A CRS that has no 2D counterpart, so no frame can describe its coordinates
-/// once the vertical axis is dropped. Returned by
+/// A CRS whose 2D counterpart could not be established, so no frame can describe
+/// its coordinates once the vertical axis is dropped. Returned by
 /// [`demote_to_2d`](CoordinateFrame::demote_to_2d).
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FrameDemotionError {
     /// The CRS that could not be demoted.
     pub epsg: EpsgCode,
     /// Why it could not be.
-    pub reason: &'static str,
+    pub reason: FrameDemotionReason,
+}
+
+/// The two ways demoting a CRS frame fails. They call for different fixes — one
+/// is the wrong CRS for the operation, the other is a CRS the installation
+/// cannot look up — so they are kept apart rather than flattened to one message.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FrameDemotionReason {
+    /// PROJ resolved the CRS and it has no 2D form. Carries the specific reason.
+    NoTwoDimensionalForm(&'static str),
+    /// PROJ could not resolve the CRS, leaving its dimensionality unknown.
+    /// Carries PROJ's failure message.
+    Unresolvable(String),
 }
 
 impl fmt::Display for FrameDemotionError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "EPSG:{} has no 2D counterpart: {}",
-            self.epsg, self.reason
-        )
+        match &self.reason {
+            FrameDemotionReason::NoTwoDimensionalForm(why) => {
+                write!(f, "EPSG:{} has no 2D counterpart: {why}", self.epsg)
+            }
+            FrameDemotionReason::Unresolvable(why) => write!(
+                f,
+                "EPSG:{} cannot be demoted to 2D because PROJ could not resolve it: {why}",
+                self.epsg
+            ),
+        }
     }
 }
 
@@ -280,25 +300,64 @@ mod tests {
         // Compound -> its horizontal component; geographic 3D -> its 2D form.
         assert_eq!(demote(6697), Ok(CoordinateFrame::Crs(EpsgCode::new(6668))));
         assert_eq!(demote(4979), Ok(CoordinateFrame::Crs(EpsgCode::new(4326))));
-        // Already 2D: idempotent, so forcing twice is stable.
+        // A CRS with no vertical axis maps to itself, which is what makes forcing
+        // a geometry to 2D twice stable.
         assert_eq!(demote(6668), Ok(CoordinateFrame::Crs(EpsgCode::new(6668))));
         assert_eq!(demote(6677), Ok(CoordinateFrame::Crs(EpsgCode::new(6677))));
-        // Geocentric: no 2D form exists.
-        assert_eq!(demote(4978).unwrap_err().epsg, EpsgCode::new(4978));
-        // Non-CRS frames have no vertical axis to shed.
-        assert_eq!(
-            CoordinateFrame::Euclidean.demote_to_2d(),
-            Ok(CoordinateFrame::Euclidean)
+    }
+
+    #[test]
+    fn demote_to_2d_rejects_a_crs_with_no_2d_form() {
+        // A geocentric CRS's third axis is the rotation axis, so there is no
+        // horizontal component to fall back to.
+        let err = CoordinateFrame::Crs(EpsgCode::new(4978))
+            .demote_to_2d()
+            .unwrap_err();
+        assert_eq!(err.epsg, EpsgCode::new(4978));
+        assert!(matches!(
+            err.reason,
+            FrameDemotionReason::NoTwoDimensionalForm(_)
+        ));
+        assert!(
+            err.to_string().contains("has no 2D counterpart"),
+            "unexpected message: {err}"
         );
     }
 
     #[test]
-    fn an_unclassifiable_crs_keeps_its_frame() {
-        // EPSG:1 is not a real CRS. PROJ cannot say whether it has a 2D form, and
-        // an indeterminate answer is not evidence of a bad frame, so it passes
-        // through rather than failing the geometry.
-        let unknown = CoordinateFrame::Crs(EpsgCode::new(1));
-        assert_eq!(unknown.demote_to_2d(), Ok(unknown.clone()));
+    fn demote_to_2d_leaves_non_crs_frames_alone() {
+        // Neither frame declares a vertical axis to shed: Euclidean coordinates
+        // are dimensionless, and a tangent plane's are in-plane by construction.
+        assert_eq!(
+            CoordinateFrame::Euclidean.demote_to_2d(),
+            Ok(CoordinateFrame::Euclidean)
+        );
+        // A tangent plane stays put even when anchored in a 3D CRS: the base
+        // frame describes the plane, not the geometry's coordinates.
+        let tangent = CoordinateFrame::Tangent(Box::new(TangentPlane {
+            base: BaseFrame::Crs(EpsgCode::new(6697)),
+            origin: [0.0, 0.0, 0.0],
+            u: [1.0, 0.0, 0.0],
+            v: [0.0, 1.0, 0.0],
+        }));
+        assert_eq!(tangent.demote_to_2d(), Ok(tangent.clone()));
+    }
+
+    #[test]
+    fn an_unresolvable_crs_is_rejected() {
+        // EPSG:1 is not a real CRS, so PROJ cannot say whether it has a 2D form.
+        // "Unknown" must not become "keep the 3D tag": that is exactly the
+        // mismatch demotion exists to prevent. Reported apart from a
+        // resolved-but-2D-less CRS because the fix differs.
+        let err = CoordinateFrame::Crs(EpsgCode::new(1))
+            .demote_to_2d()
+            .unwrap_err();
+        assert_eq!(err.epsg, EpsgCode::new(1));
+        assert!(matches!(err.reason, FrameDemotionReason::Unresolvable(_)));
+        assert!(
+            err.to_string().contains("PROJ could not resolve it"),
+            "unexpected message: {err}"
+        );
     }
 
     #[test]

--- a/engine/runtime/geometry/src/csg/mod.rs
+++ b/engine/runtime/geometry/src/csg/mod.rs
@@ -33,7 +33,7 @@ pub enum Csg {
 }
 
 // Tessellation is defined only for `Polygon` / `PolygonMesh`.
-crate::unsupported!(Csg: Triangulate, Reproject, ConvertFrame, Translate);
+crate::unsupported!(Csg: Triangulate, Reproject, ConvertFrame, Translate, ForceTwoDimension);
 
 // A boolean tree is one logical solid, not a multi-part container.
 crate::unsupported!(Csg: Split);

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -53,8 +53,8 @@ use serde::{Deserialize, Serialize};
 
 use ops::triangulation::Cache;
 use ops::{
-    Aabb, BoundingBox, ConvertFrame, ForceTwoDimension, Reproject, ReprojectionCache, Translate,
-    Triangulate, UnsupportedOperation,
+    Aabb, BoundingBox, ConvertFrame, ForceTwoDimension, ForceTwoDimensionError, Reproject,
+    ReprojectionCache, Translate, Triangulate, UnsupportedOperation,
 };
 // `ValidationParams` / `ValidationType` / `ValidationReport` are named by the
 // `enum_dispatch`-generated `Validate` impls on the geometry enums, so they must
@@ -410,12 +410,14 @@ impl Geometry {
     ///
     /// `None` passes through; a leaf delegates to [`ForceTwoDimension`]; a
     /// [`GeometryCollection`] recurses over its members. Recursion is
-    /// all-or-nothing: a single member with no 2D counterpart (`Solid`, `Csg`,
-    /// `PointCloud`) fails the whole geometry rather than dropping members. See
-    /// the [`ForceTwoDimension`] trait for the frame- and elevation-handling
-    /// contract. Like the trait, this consumes coordinate buffers, so on success
-    /// `self` is left moved-from and must be overwritten with the result.
-    pub fn force_2d(&mut self) -> Result<Geometry, UnsupportedOperation> {
+    /// all-or-nothing: a single member that cannot be flattened — because its
+    /// type has no 2D counterpart (`Solid`, `Csg`, `PointCloud`) or its
+    /// coordinate frame has none — fails the whole geometry rather than dropping
+    /// members. See the [`ForceTwoDimension`] trait for the frame- and
+    /// elevation-handling contract. Like the trait, this consumes coordinate
+    /// buffers, so on success `self` is left moved-from and must be overwritten
+    /// with the result.
+    pub fn force_2d(&mut self) -> Result<Geometry, ForceTwoDimensionError> {
         match self {
             Geometry::None => Ok(Geometry::None),
             Geometry::Euclidean2D(g) => Ok(Geometry::Euclidean2D(g.force_2d()?)),
@@ -426,18 +428,23 @@ impl Geometry {
 }
 
 impl GeometryCollection {
-    /// Force every member to 2D, preserving per-member attributes.
-    fn force_2d(&mut self) -> Result<GeometryCollection, UnsupportedOperation> {
+    /// Force every member to 2D, preserving per-member attributes. Members may
+    /// differ in coordinate frame, so each is demoted on its own.
+    fn force_2d(&mut self) -> Result<GeometryCollection, ForceTwoDimensionError> {
         let mut members = Vec::with_capacity(self.members.len());
         for member in &mut self.members {
             members.push(member.force_2d()?);
         }
         let attrs = std::mem::take(&mut self.attrs);
         // `members` stays 1:1 with the input, so `attrs` remains parallel.
-        GeometryCollection::with_attributes(members, attrs).map_err(|_| UnsupportedOperation {
-            geometry: "GeometryCollection",
-            operation: "force_2d",
-        })
+        Ok(
+            GeometryCollection::with_attributes(members, attrs).map_err(|_| {
+                UnsupportedOperation {
+                    geometry: "GeometryCollection",
+                    operation: "force_2d",
+                }
+            })?,
+        )
     }
 }
 
@@ -704,8 +711,15 @@ mod force_2d_tests {
     use std::sync::Arc;
     use triangular_mesh::TriangularMesh3DData;
 
+    /// EPSG:6697 (JGD2011 + height) — the compound CRS PLATEAU CityGML uses.
     fn crs() -> CoordinateFrame {
         CoordinateFrame::Crs(EpsgCode::new(6697))
+    }
+
+    /// EPSG:6668 (JGD2011) — the horizontal component of [`crs`], and so the
+    /// frame a geometry read in EPSG:6697 must carry once flattened.
+    fn crs_2d() -> CoordinateFrame {
+        CoordinateFrame::Crs(EpsgCode::new(6668))
     }
 
     /// A colour-only Phong material (no textures, so no UV is required).
@@ -724,17 +738,73 @@ mod force_2d_tests {
     }
 
     #[test]
-    fn point3d_drops_z_and_keeps_frame() {
+    fn point3d_drops_z_and_demotes_the_frame() {
         let mut g = Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
             crs(),
             [1.0, 2.0, 3.0],
         )));
         match g.force_2d().unwrap() {
             Geometry::Euclidean2D(Euclidean2DGeometry::Point(p)) => {
+                // Coordinates are untouched apart from losing z; only the frame's
+                // vertical axis goes with it.
                 assert_eq!(p.position(), [1.0, 2.0]);
-                assert_eq!(p.frame(), &crs());
+                assert_eq!(p.frame(), &crs_2d());
             }
             other => panic!("expected a 2D point, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn geographic_3d_demotes_to_its_2d_form() {
+        // EPSG:4979 is WGS84 3D; its 2D form is EPSG:4326.
+        let mut g = Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
+            CoordinateFrame::Crs(EpsgCode::new(4979)),
+            [35.0, 139.0, 10.0],
+        )));
+        match g.force_2d().unwrap() {
+            Geometry::Euclidean2D(Euclidean2DGeometry::Point(p)) => {
+                assert_eq!(p.position(), [35.0, 139.0]);
+                assert_eq!(p.frame(), &CoordinateFrame::Crs(EpsgCode::new(4326)));
+            }
+            other => panic!("expected a 2D point, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn geocentric_frame_is_rejected() {
+        // A geocentric CRS's third axis is the rotation axis, so dropping it
+        // projects onto the equatorial plane instead of removing a height. There
+        // is no 2D form of the CRS either, so the geometry must be rejected
+        // rather than silently retagged.
+        for code in [4978u16, 6666] {
+            let mut g = Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
+                CoordinateFrame::Crs(EpsgCode::new(code)),
+                [-3_957_314.0, 3_310_254.0, 3_737_540.0],
+            )));
+            let err = g.force_2d().unwrap_err();
+            assert!(
+                matches!(err, ForceTwoDimensionError::UnsupportedFrame(e) if e.epsg.get() == code),
+                "EPSG:{code} should be rejected for its frame, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn already_2d_frame_is_left_alone() {
+        // EPSG:6668 (geographic 2D) and EPSG:6677 (projected) have no vertical
+        // axis to shed, so the frame comes back unchanged.
+        for code in [6668u16, 6677] {
+            let frame = CoordinateFrame::Crs(EpsgCode::new(code));
+            let mut g = Geometry::Euclidean2D(Euclidean2DGeometry::Point(point::Point2D::new(
+                frame.clone(),
+                [1.0, 2.0],
+            )));
+            match g.force_2d().unwrap() {
+                Geometry::Euclidean2D(Euclidean2DGeometry::Point(p)) => {
+                    assert_eq!(p.frame(), &frame);
+                }
+                other => panic!("expected a 2D point, got {other:?}"),
+            }
         }
     }
 
@@ -746,7 +816,7 @@ mod force_2d_tests {
         match g.force_2d().unwrap() {
             Geometry::Euclidean2D(Euclidean2DGeometry::LineString(ls)) => {
                 assert_eq!(ls.coords(), &[[0.0, 0.0], [2.0, 1.0]]);
-                assert_eq!(ls.frame(), &crs());
+                assert_eq!(ls.frame(), &crs_2d());
             }
             other => panic!("expected a 2D line string, got {other:?}"),
         }
@@ -754,17 +824,19 @@ mod force_2d_tests {
 
     #[test]
     fn two_and_a_half_d_elevation_is_cleared_and_idempotent() {
-        // A 2.5D input must lose its elevation, yielding the same pure-2D result
-        // a fresh 2D line string would.
+        // A 2.5D input must lose its elevation and, with it, the vertical axis of
+        // its frame — yielding the same pure-2D result a fresh 2D line string in
+        // the demoted frame would.
         let mut g = Geometry::Euclidean2D(Euclidean2DGeometry::LineString(
             LineString2D::from_coords_with_elevation(crs(), [[0.0, 0.0, 5.0], [2.0, 1.0, 9.0]]),
         ));
         let forced = g.force_2d().unwrap();
         let expected = Geometry::Euclidean2D(Euclidean2DGeometry::LineString(
-            LineString2D::from_coords(crs(), [[0.0, 0.0], [2.0, 1.0]]),
+            LineString2D::from_coords(crs_2d(), [[0.0, 0.0], [2.0, 1.0]]),
         ));
         assert_eq!(forced, expected);
-        // Idempotent: forcing again is a no-op.
+        // Idempotent: the demoted frame demotes to itself, so forcing again is a
+        // no-op.
         let mut forced2 = forced.clone();
         assert_eq!(forced2.force_2d().unwrap(), expected);
     }
@@ -790,7 +862,7 @@ mod force_2d_tests {
         let mut g = Geometry::Euclidean3D(Euclidean3DGeometry::Polygon(Box::new(poly)));
         match g.force_2d().unwrap() {
             Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(p)) => {
-                assert_eq!(p.frame(), &crs());
+                assert_eq!(p.frame(), &crs_2d());
                 assert_eq!(p.exterior().len(), 5);
                 assert_eq!(p.interiors().count(), 1);
                 assert!(p.appearance().is_some(), "appearance must survive");
@@ -827,11 +899,10 @@ mod force_2d_tests {
     }
 
     #[test]
-    fn collection_forces_members_and_preserves_frames() {
-        let a = Euclidean3DGeometry::Point(Point3D::new(
-            CoordinateFrame::Crs(EpsgCode::new(6697)),
-            [1.0, 2.0, 3.0],
-        ));
+    fn collection_forces_members_and_demotes_each_frame() {
+        // Members may differ in frame, so each is demoted on its own; a
+        // Euclidean member has no vertical axis to shed and stays as it is.
+        let a = Euclidean3DGeometry::Point(Point3D::new(crs(), [1.0, 2.0, 3.0]));
         let b =
             Euclidean3DGeometry::Point(Point3D::new(CoordinateFrame::Euclidean, [4.0, 5.0, 6.0]));
         let mut g =
@@ -847,11 +918,26 @@ mod force_2d_tests {
                         other => panic!("expected a 2D point member, got {other:?}"),
                     })
                     .collect();
-                assert_eq!(frames[0], CoordinateFrame::Crs(EpsgCode::new(6697)));
+                assert_eq!(frames[0], crs_2d());
                 assert_eq!(frames[1], CoordinateFrame::Euclidean);
             }
             other => panic!("expected a 2D collection, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn collection_is_all_or_nothing_on_an_unsupported_frame() {
+        // One geocentric member fails the whole collection, exactly as an
+        // unsupported member type does.
+        let ok = Euclidean3DGeometry::Point(Point3D::new(crs(), [1.0, 2.0, 3.0]));
+        let geocentric = Euclidean3DGeometry::Point(Point3D::new(
+            CoordinateFrame::Crs(EpsgCode::new(4978)),
+            [0.0, 0.0, 0.0],
+        ));
+        let mut g = Geometry::Euclidean3D(Euclidean3DGeometry::Collection(Collection3D::new([
+            ok, geocentric,
+        ])));
+        assert!(g.force_2d().is_err());
     }
 
     fn sample_solid() -> Solid {

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -406,17 +406,13 @@ impl Split for GeometryCollection {
 }
 
 impl Geometry {
-    /// Force this geometry into a 2D embedding by dropping the Z coordinate.
+    /// Force this geometry into a 2D embedding by dropping the Z coordinate,
+    /// recursing into collection members. All-or-nothing: one member that cannot
+    /// be flattened fails the whole geometry rather than being dropped.
     ///
-    /// `None` passes through; a leaf delegates to [`ForceTwoDimension`]; a
-    /// [`GeometryCollection`] recurses over its members. Recursion is
-    /// all-or-nothing: a single member that cannot be flattened — because its
-    /// type has no 2D counterpart (`Solid`, `Csg`, `PointCloud`) or its
-    /// coordinate frame has none — fails the whole geometry rather than dropping
-    /// members. See the [`ForceTwoDimension`] trait for the frame- and
-    /// elevation-handling contract. Like the trait, this consumes coordinate
-    /// buffers, so on success `self` is left moved-from and must be overwritten
-    /// with the result.
+    /// See [`ForceTwoDimension`] for the frame and elevation contract. Like the
+    /// trait, this consumes coordinate buffers, leaving `self` moved-from on
+    /// success.
     pub fn force_2d(&mut self) -> Result<Geometry, ForceTwoDimensionError> {
         match self {
             Geometry::None => Ok(Geometry::None),
@@ -428,23 +424,17 @@ impl Geometry {
 }
 
 impl GeometryCollection {
-    /// Force every member to 2D, preserving per-member attributes. Members may
-    /// differ in coordinate frame, so each is demoted on its own.
+    /// Force every member to 2D. Members may differ in coordinate frame, so each
+    /// is demoted on its own.
     fn force_2d(&mut self) -> Result<GeometryCollection, ForceTwoDimensionError> {
         let mut members = Vec::with_capacity(self.members.len());
         for member in &mut self.members {
             members.push(member.force_2d()?);
         }
-        let attrs = std::mem::take(&mut self.attrs);
-        // `members` stays 1:1 with the input, so `attrs` remains parallel.
-        Ok(
-            GeometryCollection::with_attributes(members, attrs).map_err(|_| {
-                UnsupportedOperation {
-                    geometry: "GeometryCollection",
-                    operation: "force_2d",
-                }
-            })?,
-        )
+        Ok(GeometryCollection {
+            members,
+            attrs: std::mem::take(&mut self.attrs),
+        })
     }
 }
 
@@ -707,6 +697,7 @@ mod force_2d_tests {
     use point::Point3D;
     use polygon::Polygon3D;
     use polygon_mesh::PolygonMesh3DData;
+    use reearth_flow_common::attribute::{Attribute, AttributeValue};
     use solid::Solid;
     use std::sync::Arc;
     use triangular_mesh::TriangularMesh3DData;
@@ -716,8 +707,8 @@ mod force_2d_tests {
         CoordinateFrame::Crs(EpsgCode::new(6697))
     }
 
-    /// EPSG:6668 (JGD2011) — the horizontal component of [`crs`], and so the
-    /// frame a geometry read in EPSG:6697 must carry once flattened.
+    /// EPSG:6668 (JGD2011) — the horizontal component of [`crs`], so the frame
+    /// every geometry below must carry once flattened.
     fn crs_2d() -> CoordinateFrame {
         CoordinateFrame::Crs(EpsgCode::new(6668))
     }
@@ -745,8 +736,7 @@ mod force_2d_tests {
         )));
         match g.force_2d().unwrap() {
             Geometry::Euclidean2D(Euclidean2DGeometry::Point(p)) => {
-                // Coordinates are untouched apart from losing z; only the frame's
-                // vertical axis goes with it.
+                // x and y survive verbatim; only z and the frame's vertical axis go.
                 assert_eq!(p.position(), [1.0, 2.0]);
                 assert_eq!(p.frame(), &crs_2d());
             }
@@ -755,27 +745,10 @@ mod force_2d_tests {
     }
 
     #[test]
-    fn geographic_3d_demotes_to_its_2d_form() {
-        // EPSG:4979 is WGS84 3D; its 2D form is EPSG:4326.
-        let mut g = Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
-            CoordinateFrame::Crs(EpsgCode::new(4979)),
-            [35.0, 139.0, 10.0],
-        )));
-        match g.force_2d().unwrap() {
-            Geometry::Euclidean2D(Euclidean2DGeometry::Point(p)) => {
-                assert_eq!(p.position(), [35.0, 139.0]);
-                assert_eq!(p.frame(), &CoordinateFrame::Crs(EpsgCode::new(4326)));
-            }
-            other => panic!("expected a 2D point, got {other:?}"),
-        }
-    }
-
-    #[test]
     fn geocentric_frame_is_rejected() {
-        // A geocentric CRS's third axis is the rotation axis, so dropping it
-        // projects onto the equatorial plane instead of removing a height. There
-        // is no 2D form of the CRS either, so the geometry must be rejected
-        // rather than silently retagged.
+        // Dropping a geocentric CRS's third axis projects onto the equatorial
+        // plane rather than removing a height, so the geometry must be rejected
+        // instead of silently retagged.
         for code in [4978u16, 6666] {
             let mut g = Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
                 CoordinateFrame::Crs(EpsgCode::new(code)),
@@ -786,40 +759,6 @@ mod force_2d_tests {
                 matches!(&err, ForceTwoDimensionError::UnsupportedFrame(e) if e.epsg.get() == code),
                 "EPSG:{code} should be rejected for its frame, got {err:?}"
             );
-        }
-    }
-
-    #[test]
-    fn unresolvable_frame_is_rejected() {
-        // PROJ cannot classify EPSG:1, so its dimensionality is unknown. Passing
-        // the tag through would risk emitting the very 2D-coordinates-with-a-3D-
-        // frame mismatch that demotion exists to prevent, so it rejects instead.
-        let mut g = Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
-            CoordinateFrame::Crs(EpsgCode::new(1)),
-            [1.0, 2.0, 3.0],
-        )));
-        assert!(matches!(
-            g.force_2d().unwrap_err(),
-            ForceTwoDimensionError::UnsupportedFrame(_)
-        ));
-    }
-
-    #[test]
-    fn already_2d_frame_is_left_alone() {
-        // EPSG:6668 (geographic 2D) and EPSG:6677 (projected) have no vertical
-        // axis to shed, so the frame comes back unchanged.
-        for code in [6668u16, 6677] {
-            let frame = CoordinateFrame::Crs(EpsgCode::new(code));
-            let mut g = Geometry::Euclidean2D(Euclidean2DGeometry::Point(point::Point2D::new(
-                frame.clone(),
-                [1.0, 2.0],
-            )));
-            match g.force_2d().unwrap() {
-                Geometry::Euclidean2D(Euclidean2DGeometry::Point(p)) => {
-                    assert_eq!(p.frame(), &frame);
-                }
-                other => panic!("expected a 2D point, got {other:?}"),
-            }
         }
     }
 
@@ -839,9 +778,8 @@ mod force_2d_tests {
 
     #[test]
     fn two_and_a_half_d_elevation_is_cleared_and_idempotent() {
-        // A 2.5D input must lose its elevation and, with it, the vertical axis of
-        // its frame — yielding the same pure-2D result a fresh 2D line string in
-        // the demoted frame would.
+        // A 2.5D input loses its elevation and its frame's vertical axis, giving
+        // exactly what a natively 2D line string in the demoted frame would.
         let mut g = Geometry::Euclidean2D(Euclidean2DGeometry::LineString(
             LineString2D::from_coords_with_elevation(crs(), [[0.0, 0.0, 5.0], [2.0, 1.0, 9.0]]),
         ));
@@ -850,8 +788,7 @@ mod force_2d_tests {
             LineString2D::from_coords(crs_2d(), [[0.0, 0.0], [2.0, 1.0]]),
         ));
         assert_eq!(forced, expected);
-        // Idempotent: the demoted frame demotes to itself, so forcing again is a
-        // no-op.
+        // The demoted frame demotes to itself, so a second pass is a no-op.
         let mut forced2 = forced.clone();
         assert_eq!(forced2.force_2d().unwrap(), expected);
     }
@@ -940,21 +877,6 @@ mod force_2d_tests {
         }
     }
 
-    #[test]
-    fn collection_is_all_or_nothing_on_an_unsupported_frame() {
-        // One geocentric member fails the whole collection, exactly as an
-        // unsupported member type does.
-        let ok = Euclidean3DGeometry::Point(Point3D::new(crs(), [1.0, 2.0, 3.0]));
-        let geocentric = Euclidean3DGeometry::Point(Point3D::new(
-            CoordinateFrame::Crs(EpsgCode::new(4978)),
-            [0.0, 0.0, 0.0],
-        ));
-        let mut g = Geometry::Euclidean3D(Euclidean3DGeometry::Collection(Collection3D::new([
-            ok, geocentric,
-        ])));
-        assert!(g.force_2d().is_err());
-    }
-
     fn sample_solid() -> Solid {
         Solid::new(
             CoordinateFrame::Euclidean,
@@ -997,5 +919,49 @@ mod force_2d_tests {
     fn none_passes_through() {
         let mut g = Geometry::None;
         assert_eq!(g.force_2d().unwrap(), Geometry::None);
+    }
+
+    #[test]
+    fn geometry_collection_forces_members_and_keeps_attributes() {
+        let members = vec![
+            Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
+                crs(),
+                [1.0, 2.0, 3.0],
+            ))),
+            Geometry::None,
+        ];
+        let attrs = vec![
+            Attributes::from([(Attribute::new("a"), AttributeValue::Number(1.into()))]),
+            Attributes::from([(Attribute::new("b"), AttributeValue::Number(2.into()))]),
+        ];
+        let mut g = Geometry::GeometryCollection(
+            GeometryCollection::with_attributes(members, attrs.clone()).unwrap(),
+        );
+        match g.force_2d().unwrap() {
+            Geometry::GeometryCollection(c) => {
+                assert_eq!(c.member_attributes(), attrs.as_slice());
+                match c.members() {
+                    [Geometry::Euclidean2D(Euclidean2DGeometry::Point(p)), Geometry::None] => {
+                        assert_eq!(p.position(), [1.0, 2.0]);
+                        assert_eq!(p.frame(), &crs_2d());
+                    }
+                    other => panic!("expected a 2D point then None, got {other:?}"),
+                }
+            }
+            other => panic!("expected a geometry collection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn geometry_collection_is_all_or_nothing() {
+        let members = vec![
+            Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
+                crs(),
+                [1.0, 2.0, 3.0],
+            ))),
+            Geometry::Euclidean3D(Euclidean3DGeometry::Solid(Box::new(sample_solid()))),
+        ];
+        let mut g = Geometry::GeometryCollection(GeometryCollection::new(members));
+        assert!(g.force_2d().is_err());
     }
 }

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -783,10 +783,25 @@ mod force_2d_tests {
             )));
             let err = g.force_2d().unwrap_err();
             assert!(
-                matches!(err, ForceTwoDimensionError::UnsupportedFrame(e) if e.epsg.get() == code),
+                matches!(&err, ForceTwoDimensionError::UnsupportedFrame(e) if e.epsg.get() == code),
                 "EPSG:{code} should be rejected for its frame, got {err:?}"
             );
         }
+    }
+
+    #[test]
+    fn unresolvable_frame_is_rejected() {
+        // PROJ cannot classify EPSG:1, so its dimensionality is unknown. Passing
+        // the tag through would risk emitting the very 2D-coordinates-with-a-3D-
+        // frame mismatch that demotion exists to prevent, so it rejects instead.
+        let mut g = Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
+            CoordinateFrame::Crs(EpsgCode::new(1)),
+            [1.0, 2.0, 3.0],
+        )));
+        assert!(matches!(
+            g.force_2d().unwrap_err(),
+            ForceTwoDimensionError::UnsupportedFrame(_)
+        ));
     }
 
     #[test]

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -53,8 +53,8 @@ use serde::{Deserialize, Serialize};
 
 use ops::triangulation::Cache;
 use ops::{
-    Aabb, BoundingBox, ConvertFrame, Reproject, ReprojectionCache, Translate, Triangulate,
-    UnsupportedOperation,
+    Aabb, BoundingBox, ConvertFrame, ForceTwoDimension, Reproject, ReprojectionCache, Translate,
+    Triangulate, UnsupportedOperation,
 };
 // `ValidationParams` / `ValidationType` / `ValidationReport` are named by the
 // `enum_dispatch`-generated `Validate` impls on the geometry enums, so they must
@@ -159,7 +159,15 @@ impl GeometryCollection {
 /// `Collection`) stays inline.
 #[cfg_attr(
     not(feature = "new-geometry"),
-    enum_dispatch(BoundingBox, Triangulate, Reproject, ConvertFrame, Translate, Split)
+    enum_dispatch(
+        BoundingBox,
+        Triangulate,
+        Reproject,
+        ConvertFrame,
+        Translate,
+        Split,
+        ForceTwoDimension
+    )
 )]
 #[cfg_attr(
     feature = "new-geometry",
@@ -170,7 +178,8 @@ impl GeometryCollection {
         Validate,
         ConvertFrame,
         Translate,
-        Split
+        Split,
+        ForceTwoDimension
     )
 )]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -196,7 +205,15 @@ pub enum Euclidean2DGeometry {
 /// operands.
 #[cfg_attr(
     not(feature = "new-geometry"),
-    enum_dispatch(BoundingBox, Triangulate, Reproject, ConvertFrame, Translate, Split)
+    enum_dispatch(
+        BoundingBox,
+        Triangulate,
+        Reproject,
+        ConvertFrame,
+        Translate,
+        Split,
+        ForceTwoDimension
+    )
 )]
 #[cfg_attr(
     feature = "new-geometry",
@@ -207,7 +224,8 @@ pub enum Euclidean2DGeometry {
         Validate,
         ConvertFrame,
         Translate,
-        Split
+        Split,
+        ForceTwoDimension
     )
 )]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -384,6 +402,42 @@ impl Split for GeometryCollection {
             emit,
         );
         Ok(())
+    }
+}
+
+impl Geometry {
+    /// Force this geometry into a 2D embedding by dropping the Z coordinate.
+    ///
+    /// `None` passes through; a leaf delegates to [`ForceTwoDimension`]; a
+    /// [`GeometryCollection`] recurses over its members. Recursion is
+    /// all-or-nothing: a single member with no 2D counterpart (`Solid`, `Csg`,
+    /// `PointCloud`) fails the whole geometry rather than dropping members. See
+    /// the [`ForceTwoDimension`] trait for the frame- and elevation-handling
+    /// contract. Like the trait, this consumes coordinate buffers, so on success
+    /// `self` is left moved-from and must be overwritten with the result.
+    pub fn force_2d(&mut self) -> Result<Geometry, UnsupportedOperation> {
+        match self {
+            Geometry::None => Ok(Geometry::None),
+            Geometry::Euclidean2D(g) => Ok(Geometry::Euclidean2D(g.force_2d()?)),
+            Geometry::Euclidean3D(g) => Ok(Geometry::Euclidean2D(g.force_2d()?)),
+            Geometry::GeometryCollection(c) => Ok(Geometry::GeometryCollection(c.force_2d()?)),
+        }
+    }
+}
+
+impl GeometryCollection {
+    /// Force every member to 2D, preserving per-member attributes.
+    fn force_2d(&mut self) -> Result<GeometryCollection, UnsupportedOperation> {
+        let mut members = Vec::with_capacity(self.members.len());
+        for member in &mut self.members {
+            members.push(member.force_2d()?);
+        }
+        let attrs = std::mem::take(&mut self.attrs);
+        // `members` stays 1:1 with the input, so `attrs` remains parallel.
+        GeometryCollection::with_attributes(members, attrs).map_err(|_| UnsupportedOperation {
+            geometry: "GeometryCollection",
+            operation: "force_2d",
+        })
     }
 }
 
@@ -633,5 +687,214 @@ mod triangulate_tests {
 
         let mut collection = Geometry::GeometryCollection(GeometryCollection::new([]));
         assert!(collection.triangulate(&mut Cache::new()).is_err());
+    }
+}
+
+#[cfg(test)]
+mod force_2d_tests {
+    use super::*;
+    use appearance::{Material, PhongMaterial, ThemeId};
+    use collection::Collection3D;
+    use coordinate::{CoordinateFrame, EpsgCode};
+    use line_string::{LineString2D, LineString3D};
+    use point::Point3D;
+    use polygon::Polygon3D;
+    use polygon_mesh::PolygonMesh3DData;
+    use solid::Solid;
+    use std::sync::Arc;
+    use triangular_mesh::TriangularMesh3DData;
+
+    fn crs() -> CoordinateFrame {
+        CoordinateFrame::Crs(EpsgCode::new(6697))
+    }
+
+    /// A colour-only Phong material (no textures, so no UV is required).
+    fn plain_material() -> Material {
+        Material::Phong(PhongMaterial {
+            diffuse: [1.0, 0.0, 0.0],
+            specular: [0.0; 3],
+            emissive: [0.0; 3],
+            ambient_intensity: 0.0,
+            shininess: 0.0,
+            transparency: 0.0,
+            diffuse_map: None,
+            emissive_map: None,
+            normal_map: None,
+        })
+    }
+
+    #[test]
+    fn point3d_drops_z_and_keeps_frame() {
+        let mut g = Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
+            crs(),
+            [1.0, 2.0, 3.0],
+        )));
+        match g.force_2d().unwrap() {
+            Geometry::Euclidean2D(Euclidean2DGeometry::Point(p)) => {
+                assert_eq!(p.position(), [1.0, 2.0]);
+                assert_eq!(p.frame(), &crs());
+            }
+            other => panic!("expected a 2D point, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn linestring3d_drops_z() {
+        let mut g = Geometry::Euclidean3D(Euclidean3DGeometry::LineString(
+            LineString3D::from_coords(crs(), [[0.0, 0.0, 5.0], [2.0, 1.0, 9.0]]),
+        ));
+        match g.force_2d().unwrap() {
+            Geometry::Euclidean2D(Euclidean2DGeometry::LineString(ls)) => {
+                assert_eq!(ls.coords(), &[[0.0, 0.0], [2.0, 1.0]]);
+                assert_eq!(ls.frame(), &crs());
+            }
+            other => panic!("expected a 2D line string, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn two_and_a_half_d_elevation_is_cleared_and_idempotent() {
+        // A 2.5D input must lose its elevation, yielding the same pure-2D result
+        // a fresh 2D line string would.
+        let mut g = Geometry::Euclidean2D(Euclidean2DGeometry::LineString(
+            LineString2D::from_coords_with_elevation(crs(), [[0.0, 0.0, 5.0], [2.0, 1.0, 9.0]]),
+        ));
+        let forced = g.force_2d().unwrap();
+        let expected = Geometry::Euclidean2D(Euclidean2DGeometry::LineString(
+            LineString2D::from_coords(crs(), [[0.0, 0.0], [2.0, 1.0]]),
+        ));
+        assert_eq!(forced, expected);
+        // Idempotent: forcing again is a no-op.
+        let mut forced2 = forced.clone();
+        assert_eq!(forced2.force_2d().unwrap(), expected);
+    }
+
+    #[test]
+    fn polygon3d_preserves_rings_holes_and_appearance() {
+        let exterior = [
+            [0.0, 0.0, 0.0],
+            [4.0, 0.0, 1.0],
+            [4.0, 4.0, 2.0],
+            [0.0, 4.0, 3.0],
+            [0.0, 0.0, 0.0],
+        ];
+        let hole = vec![
+            [1.0, 1.0, 0.0],
+            [3.0, 1.0, 0.0],
+            [3.0, 3.0, 0.0],
+            [1.0, 1.0, 0.0],
+        ];
+        let mut poly = Polygon3D::from_rings(crs(), exterior, vec![hole]);
+        poly.set_appearance(ThemeId(Arc::from("t")), plain_material(), None)
+            .unwrap();
+        let mut g = Geometry::Euclidean3D(Euclidean3DGeometry::Polygon(Box::new(poly)));
+        match g.force_2d().unwrap() {
+            Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(p)) => {
+                assert_eq!(p.frame(), &crs());
+                assert_eq!(p.exterior().len(), 5);
+                assert_eq!(p.interiors().count(), 1);
+                assert!(p.appearance().is_some(), "appearance must survive");
+            }
+            other => panic!("expected a 2D polygon, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vertical_polygon_projects_to_a_degenerate_footprint() {
+        // A wall in the x = 0 plane collapses onto the y axis; the conversion
+        // still succeeds (degeneracy is allowed, matching FME).
+        let wall = [
+            [0.0, 0.0, 0.0],
+            [0.0, 4.0, 0.0],
+            [0.0, 4.0, 4.0],
+            [0.0, 0.0, 4.0],
+            [0.0, 0.0, 0.0],
+        ];
+        let mut g = Geometry::Euclidean3D(Euclidean3DGeometry::Polygon(Box::new(
+            Polygon3D::from_rings(
+                CoordinateFrame::Euclidean,
+                wall,
+                Vec::<Vec<[f64; 3]>>::new(),
+            ),
+        )));
+        match g.force_2d().unwrap() {
+            Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(p)) => {
+                // All x are 0: the footprint has zero area but is still returned.
+                assert!(p.exterior().iter().all(|&[x, _]| x == 0.0));
+            }
+            other => panic!("expected a 2D polygon, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn collection_forces_members_and_preserves_frames() {
+        let a = Euclidean3DGeometry::Point(Point3D::new(
+            CoordinateFrame::Crs(EpsgCode::new(6697)),
+            [1.0, 2.0, 3.0],
+        ));
+        let b =
+            Euclidean3DGeometry::Point(Point3D::new(CoordinateFrame::Euclidean, [4.0, 5.0, 6.0]));
+        let mut g =
+            Geometry::Euclidean3D(Euclidean3DGeometry::Collection(Collection3D::new([a, b])));
+        match g.force_2d().unwrap() {
+            Geometry::Euclidean2D(Euclidean2DGeometry::Collection(c)) => {
+                assert_eq!(c.members().len(), 2);
+                let frames: Vec<_> = c
+                    .members()
+                    .iter()
+                    .map(|m| match m {
+                        Euclidean2DGeometry::Point(p) => p.frame().clone(),
+                        other => panic!("expected a 2D point member, got {other:?}"),
+                    })
+                    .collect();
+                assert_eq!(frames[0], CoordinateFrame::Crs(EpsgCode::new(6697)));
+                assert_eq!(frames[1], CoordinateFrame::Euclidean);
+            }
+            other => panic!("expected a 2D collection, got {other:?}"),
+        }
+    }
+
+    fn sample_solid() -> Solid {
+        Solid::new(
+            CoordinateFrame::Euclidean,
+            PolygonMesh3DData::from_parts(
+                vec![
+                    [0.0, 0.0, 0.0],
+                    [2.0, 0.0, 0.0],
+                    [2.0, 2.0, 0.0],
+                    [0.0, 2.0, 0.0],
+                ],
+                vec![vec![0u32, 1, 2, 3]],
+            )
+            .unwrap(),
+            vec![TriangularMesh3DData::from_parts(
+                vec![[5.0, 5.0, 5.0], [6.0, 5.0, 5.0], [5.0, 6.0, 5.0]],
+                [0u32, 1, 2],
+            )
+            .unwrap()
+            .into()],
+        )
+    }
+
+    #[test]
+    fn solid_has_no_2d_counterpart() {
+        let mut g = Geometry::Euclidean3D(Euclidean3DGeometry::Solid(Box::new(sample_solid())));
+        assert!(g.force_2d().is_err());
+    }
+
+    #[test]
+    fn collection_is_all_or_nothing_on_an_unsupported_member() {
+        let point = Euclidean3DGeometry::Point(Point3D::new(CoordinateFrame::Euclidean, [0.0; 3]));
+        let solid = Euclidean3DGeometry::Solid(Box::new(sample_solid()));
+        let mut g = Geometry::Euclidean3D(Euclidean3DGeometry::Collection(Collection3D::new([
+            point, solid,
+        ])));
+        assert!(g.force_2d().is_err());
+    }
+
+    #[test]
+    fn none_passes_through() {
+        let mut g = Geometry::None;
+        assert_eq!(g.force_2d().unwrap(), Geometry::None);
     }
 }

--- a/engine/runtime/geometry/src/line_string/ops.rs
+++ b/engine/runtime/geometry/src/line_string/ops.rs
@@ -106,6 +106,34 @@ impl ConvertFrame for LineString3D {
     }
 }
 
+use crate::ops::ForceTwoDimension;
+use crate::Euclidean2DGeometry;
+
+impl ForceTwoDimension for LineString2D {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+        self.z = None; // drop any 2.5D elevation; already 2D otherwise
+        Ok(Euclidean2DGeometry::LineString(LineString2D {
+            frame: self.frame.clone(),
+            coords: std::mem::take(&mut self.coords),
+            z: None,
+        }))
+    }
+}
+
+impl ForceTwoDimension for LineString3D {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+        let coords = std::mem::take(&mut self.coords)
+            .iter()
+            .map(|&[x, y, _]| [x, y])
+            .collect();
+        Ok(Euclidean2DGeometry::LineString(LineString2D {
+            frame: self.frame.clone(),
+            coords,
+            z: None,
+        }))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/line_string/ops.rs
+++ b/engine/runtime/geometry/src/line_string/ops.rs
@@ -106,14 +106,15 @@ impl ConvertFrame for LineString3D {
     }
 }
 
-use crate::ops::ForceTwoDimension;
+use crate::ops::{ForceTwoDimension, ForceTwoDimensionError};
 use crate::Euclidean2DGeometry;
 
 impl ForceTwoDimension for LineString2D {
-    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, ForceTwoDimensionError> {
+        let frame = self.frame.demote_to_2d()?;
         self.z = None; // drop any 2.5D elevation; already 2D otherwise
         Ok(Euclidean2DGeometry::LineString(LineString2D {
-            frame: self.frame.clone(),
+            frame,
             coords: std::mem::take(&mut self.coords),
             z: None,
         }))
@@ -121,13 +122,14 @@ impl ForceTwoDimension for LineString2D {
 }
 
 impl ForceTwoDimension for LineString3D {
-    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, ForceTwoDimensionError> {
+        let frame = self.frame.demote_to_2d()?;
         let coords = std::mem::take(&mut self.coords)
             .iter()
             .map(|&[x, y, _]| [x, y])
             .collect();
         Ok(Euclidean2DGeometry::LineString(LineString2D {
-            frame: self.frame.clone(),
+            frame,
             coords,
             z: None,
         }))

--- a/engine/runtime/geometry/src/ops/mod.rs
+++ b/engine/runtime/geometry/src/ops/mod.rs
@@ -287,29 +287,26 @@ impl From<FrameDemotionError> for ForceTwoDimensionError {
 
 /// Force a geometry into a pure 2D embedding by dropping the Z coordinate.
 ///
-/// Any 2.5D per-vertex elevation is cleared, so the op is idempotent. The
-/// coordinate frame is demoted to its 2D counterpart rather than kept verbatim,
-/// keeping the frame's dimensionality equal to the coordinates': a geometry in
-/// EPSG:6697 comes back in EPSG:6668, one in EPSG:4979 in EPSG:4326. Coordinate
-/// values are untouched by the retag — see
+/// Any 2.5D per-vertex elevation is cleared too, so the op is idempotent. The
+/// coordinate frame is demoted alongside the coordinates so the two keep matching
+/// dimensionality: EPSG:6697 comes back as EPSG:6668, EPSG:4979 as EPSG:4326.
+/// Coordinate values are untouched by the retag — see
 /// [`CoordinateFrame::demote_to_2d`](crate::coordinate::CoordinateFrame::demote_to_2d).
 ///
-/// Two things reject. Leaves with no 2D counterpart (`Solid`, `Csg`,
-/// `PointCloud`) opt out via [`unsupported!`](crate::unsupported), and a frame
-/// whose 2D counterpart cannot be established — a geocentric (ECEF) CRS, whose Z
-/// is the rotation axis rather than a height, so dropping it would silently
-/// project onto the equatorial plane; or a CRS PROJ cannot resolve, whose
-/// dimensionality is then unknown.
+/// Rejects a type with no 2D counterpart (`Solid`, `Csg`, `PointCloud`, which opt
+/// out via [`unsupported!`](crate::unsupported)) and a frame with none, such as a
+/// geocentric CRS whose Z is the rotation axis rather than a height. A rejected
+/// member rejects the collection containing it; the op never returns a partially
+/// converted collection.
 ///
 /// Like [`Triangulate`], this consumes the leaf's buffers, leaving `self`
-/// moved-from on success (discard or overwrite it); a leaf that empties `coords`
-/// must also clear `z` to preserve the `z.len() == coords.len()` invariant. A
-/// leaf therefore resolves its frame before touching its buffers, so a rejected
-/// frame leaves it intact.
+/// moved-from on success. A leaf that empties `coords` must clear `z` with it to
+/// keep the two the same length, and must resolve its frame before touching
+/// either, so a rejected frame leaves it intact.
 #[enum_dispatch::enum_dispatch]
 pub trait ForceTwoDimension {
-    /// Re-represent this geometry in a 2D embedding. The default body reports the
-    /// type as unsupported; a leaf opts in by overriding it.
+    /// Re-represent this geometry in a 2D embedding. The default reports the type
+    /// as unsupported; a leaf opts in by overriding it.
     fn force_2d(&mut self) -> Result<crate::Euclidean2DGeometry, ForceTwoDimensionError> {
         Err(UnsupportedOperation {
             geometry: core::any::type_name::<Self>(),

--- a/engine/runtime/geometry/src/ops/mod.rs
+++ b/engine/runtime/geometry/src/ops/mod.rs
@@ -12,11 +12,11 @@ pub mod reproject;
 pub mod split;
 pub mod triangulation;
 
-pub(crate) use reproject::{axis_order_sign, crs_is_linear};
+pub(crate) use reproject::{axis_order_sign, crs_demote_to_2d, crs_is_linear, TwoDimensionalCrs};
 pub use reproject::{Reproject, ReprojectionCache};
 pub use split::Split;
 
-use crate::coordinate::{CoordinateFrame, EpsgCode};
+use crate::coordinate::{CoordinateFrame, EpsgCode, FrameDemotionError};
 use crate::error::Error;
 
 /// Returned by an operation a given geometry type does not support. Carries the
@@ -252,30 +252,74 @@ impl<T: Triangulate + ?Sized> Triangulate for Box<T> {
     }
 }
 
+/// Why a geometry could not be re-represented in a pure 2D embedding.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ForceTwoDimensionError {
+    /// The geometry type has no 2D counterpart (`Solid`, `Csg`, `PointCloud`).
+    UnsupportedGeometry(UnsupportedOperation),
+    /// The coordinate frame has no 2D counterpart, so the flattened coordinates
+    /// could not be tagged with a frame of matching dimensionality.
+    UnsupportedFrame(FrameDemotionError),
+}
+
+impl core::fmt::Display for ForceTwoDimensionError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ForceTwoDimensionError::UnsupportedGeometry(e) => e.fmt(f),
+            ForceTwoDimensionError::UnsupportedFrame(e) => e.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for ForceTwoDimensionError {}
+
+impl From<UnsupportedOperation> for ForceTwoDimensionError {
+    fn from(e: UnsupportedOperation) -> Self {
+        ForceTwoDimensionError::UnsupportedGeometry(e)
+    }
+}
+
+impl From<FrameDemotionError> for ForceTwoDimensionError {
+    fn from(e: FrameDemotionError) -> Self {
+        ForceTwoDimensionError::UnsupportedFrame(e)
+    }
+}
+
 /// Force a geometry into a pure 2D embedding by dropping the Z coordinate.
 ///
-/// The coordinate frame is preserved verbatim (no reprojection), and any 2.5D
-/// per-vertex elevation is cleared, so the op is idempotent. Leaves with no 2D
-/// counterpart (`Solid`, `Csg`, `PointCloud`) opt out via
-/// [`unsupported!`](crate::unsupported).
+/// Any 2.5D per-vertex elevation is cleared, so the op is idempotent. The
+/// coordinate frame is demoted to its 2D counterpart rather than kept verbatim,
+/// keeping the frame's dimensionality equal to the coordinates': a geometry in
+/// EPSG:6697 comes back in EPSG:6668, one in EPSG:4979 in EPSG:4326. Coordinate
+/// values are untouched by the retag — see
+/// [`CoordinateFrame::demote_to_2d`](crate::coordinate::CoordinateFrame::demote_to_2d).
+///
+/// Two things reject. Leaves with no 2D counterpart (`Solid`, `Csg`,
+/// `PointCloud`) opt out via [`unsupported!`](crate::unsupported), and a frame
+/// with no 2D counterpart — a geocentric (ECEF) CRS, whose Z is the rotation axis
+/// rather than a height, so dropping it would silently project onto the
+/// equatorial plane.
 ///
 /// Like [`Triangulate`], this consumes the leaf's buffers, leaving `self`
 /// moved-from on success (discard or overwrite it); a leaf that empties `coords`
-/// must also clear `z` to preserve the `z.len() == coords.len()` invariant.
+/// must also clear `z` to preserve the `z.len() == coords.len()` invariant. A
+/// leaf therefore resolves its frame before touching its buffers, so a rejected
+/// frame leaves it intact.
 #[enum_dispatch::enum_dispatch]
 pub trait ForceTwoDimension {
     /// Re-represent this geometry in a 2D embedding. The default body reports the
     /// type as unsupported; a leaf opts in by overriding it.
-    fn force_2d(&mut self) -> Result<crate::Euclidean2DGeometry, UnsupportedOperation> {
+    fn force_2d(&mut self) -> Result<crate::Euclidean2DGeometry, ForceTwoDimensionError> {
         Err(UnsupportedOperation {
             geometry: core::any::type_name::<Self>(),
             operation: "force_2d",
-        })
+        }
+        .into())
     }
 }
 
 impl<T: ForceTwoDimension + ?Sized> ForceTwoDimension for Box<T> {
-    fn force_2d(&mut self) -> Result<crate::Euclidean2DGeometry, UnsupportedOperation> {
+    fn force_2d(&mut self) -> Result<crate::Euclidean2DGeometry, ForceTwoDimensionError> {
         (**self).force_2d()
     }
 }

--- a/engine/runtime/geometry/src/ops/mod.rs
+++ b/engine/runtime/geometry/src/ops/mod.rs
@@ -253,7 +253,7 @@ impl<T: Triangulate + ?Sized> Triangulate for Box<T> {
 }
 
 /// Why a geometry could not be re-represented in a pure 2D embedding.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ForceTwoDimensionError {
     /// The geometry type has no 2D counterpart (`Solid`, `Csg`, `PointCloud`).
     UnsupportedGeometry(UnsupportedOperation),
@@ -296,9 +296,10 @@ impl From<FrameDemotionError> for ForceTwoDimensionError {
 ///
 /// Two things reject. Leaves with no 2D counterpart (`Solid`, `Csg`,
 /// `PointCloud`) opt out via [`unsupported!`](crate::unsupported), and a frame
-/// with no 2D counterpart — a geocentric (ECEF) CRS, whose Z is the rotation axis
-/// rather than a height, so dropping it would silently project onto the
-/// equatorial plane.
+/// whose 2D counterpart cannot be established — a geocentric (ECEF) CRS, whose Z
+/// is the rotation axis rather than a height, so dropping it would silently
+/// project onto the equatorial plane; or a CRS PROJ cannot resolve, whose
+/// dimensionality is then unknown.
 ///
 /// Like [`Triangulate`], this consumes the leaf's buffers, leaving `self`
 /// moved-from on success (discard or overwrite it); a leaf that empties `coords`

--- a/engine/runtime/geometry/src/ops/mod.rs
+++ b/engine/runtime/geometry/src/ops/mod.rs
@@ -252,6 +252,34 @@ impl<T: Triangulate + ?Sized> Triangulate for Box<T> {
     }
 }
 
+/// Force a geometry into a pure 2D embedding by dropping the Z coordinate.
+///
+/// The coordinate frame is preserved verbatim (no reprojection), and any 2.5D
+/// per-vertex elevation is cleared, so the op is idempotent. Leaves with no 2D
+/// counterpart (`Solid`, `Csg`, `PointCloud`) opt out via
+/// [`unsupported!`](crate::unsupported).
+///
+/// Like [`Triangulate`], this consumes the leaf's buffers, leaving `self`
+/// moved-from on success (discard or overwrite it); a leaf that empties `coords`
+/// must also clear `z` to preserve the `z.len() == coords.len()` invariant.
+#[enum_dispatch::enum_dispatch]
+pub trait ForceTwoDimension {
+    /// Re-represent this geometry in a 2D embedding. The default body reports the
+    /// type as unsupported; a leaf opts in by overriding it.
+    fn force_2d(&mut self) -> Result<crate::Euclidean2DGeometry, UnsupportedOperation> {
+        Err(UnsupportedOperation {
+            geometry: core::any::type_name::<Self>(),
+            operation: "force_2d",
+        })
+    }
+}
+
+impl<T: ForceTwoDimension + ?Sized> ForceTwoDimension for Box<T> {
+    fn force_2d(&mut self) -> Result<crate::Euclidean2DGeometry, UnsupportedOperation> {
+        (**self).force_2d()
+    }
+}
+
 /// Shift every coordinate by a vector.
 ///
 /// A general primitive carrying no frame semantics: translating a CRS geometry

--- a/engine/runtime/geometry/src/ops/reproject/ffi.rs
+++ b/engine/runtime/geometry/src/ops/reproject/ffi.rs
@@ -457,11 +457,19 @@ const UNNAMED_REASON: &str = "its 2D form carries no EPSG identifier";
 /// The demoted CRS still has a third axis, so it is not a 2D frame.
 const STILL_3D_REASON: &str = "its demoted form still has more than two axes";
 
+/// A remembered demotion outcome: what PROJ answered, or the message explaining
+/// why it could not answer. Both are fixed properties of the EPSG code.
+type CachedDemotion = std::result::Result<TwoDimensionalCrs, String>;
+
 /// Process-wide memoization of 2D counterparts, keyed by EPSG code. Like the
-/// orientation sign, the answer is a fixed property of a CRS. Only determinate
-/// answers are cached; an unresolvable CRS is a rare error path.
-fn demote_cache() -> &'static RwLock<HashMap<EpsgCode, TwoDimensionalCrs>> {
-    static CACHE: OnceLock<RwLock<HashMap<EpsgCode, TwoDimensionalCrs>>> = OnceLock::new();
+/// orientation sign, the answer is a fixed property of a CRS.
+///
+/// Failures are remembered too, unlike in the caches above: a failed demotion
+/// routes one feature to the rejected port and processing continues, so a stream
+/// sharing an unusable CRS would otherwise re-ask PROJ per feature — two orders
+/// of magnitude slower than a cache hit.
+fn demote_cache() -> &'static RwLock<HashMap<EpsgCode, CachedDemotion>> {
+    static CACHE: OnceLock<RwLock<HashMap<EpsgCode, CachedDemotion>>> = OnceLock::new();
     CACHE.get_or_init(|| RwLock::new(HashMap::new()))
 }
 
@@ -470,39 +478,46 @@ fn demote_cache() -> &'static RwLock<HashMap<EpsgCode, TwoDimensionalCrs>> {
 ///
 /// [`TwoDimensionalCrs::None`] is a definitive "there is none". `Err` means PROJ
 /// could not answer at all (unknown code, missing PROJ data), which the caller
-/// must distinguish: an indeterminate answer is not evidence of a bad frame.
+/// must distinguish: the two mean different things to a user, even though both
+/// leave the frame's dimensionality unusable.
 ///
 /// Memoized per EPSG code, so a CRS costs one PROJ lookup per process.
 pub(crate) fn crs_demote_to_2d(epsg: EpsgCode) -> Result<TwoDimensionalCrs> {
-    if let Some(&demoted) = demote_cache().read().get(&epsg) {
-        return Ok(demoted);
+    if let Some(cached) = demote_cache().read().get(&epsg) {
+        return cached.clone().map_err(Error::projection);
     }
-    let demoted = crs_demote_to_2d_uncached(epsg)?;
-    demote_cache().write().insert(epsg, demoted);
-    Ok(demoted)
+    let outcome = lookup_demotion(epsg)?;
+    demote_cache().write().insert(epsg, outcome.clone());
+    outcome.map_err(Error::projection)
 }
 
 /// Ask PROJ for `epsg`'s 2D counterpart directly, without the cache.
-fn crs_demote_to_2d_uncached(epsg: EpsgCode) -> Result<TwoDimensionalCrs> {
+///
+/// The two error channels differ in whether the answer is worth remembering.
+/// `Err` is a transient failure of the PROJ context itself, which says nothing
+/// about `epsg` and must not be cached; the inner `Err` is PROJ's stable verdict
+/// on this code.
+fn lookup_demotion(epsg: EpsgCode) -> Result<CachedDemotion> {
+    let def = CString::new(format!("EPSG:{epsg}")).map_err(Error::projection)?;
     // SAFETY: every PROJ object is null-checked and freed on all paths.
     unsafe {
         let ctx = proj_context_create();
         if ctx.is_null() {
             return Err(Error::projection("proj_context_create returned null"));
         }
-        let def = CString::new(format!("EPSG:{epsg}")).map_err(Error::projection)?;
         let crs = proj_create(ctx, def.as_ptr());
-        if crs.is_null() {
-            let msg = ctx_errno_string(ctx);
-            proj_context_destroy(ctx);
-            return Err(Error::projection(format!(
-                "failed to create CRS EPSG:{epsg}: {msg}"
-            )));
-        }
-        let result = demote_and_classify(ctx, crs, epsg);
-        proj_destroy(crs);
+        let outcome = if crs.is_null() {
+            Err(format!(
+                "failed to create CRS EPSG:{epsg}: {}",
+                ctx_errno_string(ctx)
+            ))
+        } else {
+            let outcome = demote_and_classify(ctx, crs, epsg);
+            proj_destroy(crs);
+            outcome
+        };
         proj_context_destroy(ctx);
-        result
+        Ok(outcome)
     }
 }
 
@@ -512,18 +527,18 @@ unsafe fn demote_and_classify(
     ctx: *mut PJ_CONTEXT,
     crs: *const PJ,
     epsg: EpsgCode,
-) -> Result<TwoDimensionalCrs> {
+) -> CachedDemotion {
     // A null name asks PROJ to derive the 2D CRS's name from the input's.
     let demoted = proj_crs_demote_to_2D(ctx, ptr::null(), crs);
     if demoted.is_null() {
-        return Err(Error::projection(format!(
+        return Err(format!(
             "failed to demote EPSG:{epsg} to 2D: {}",
             ctx_errno_string(ctx)
-        )));
+        ));
     }
     let result = classify_demoted(ctx, demoted);
     proj_destroy(demoted);
-    result
+    Ok(result)
 }
 
 /// Classify a demoted CRS: a two-axis CRS carrying an EPSG identifier is a usable
@@ -533,23 +548,23 @@ unsafe fn demote_and_classify(
 /// CRS — so the axis count alone would already reject it; it is matched first only
 /// to report the specific reason.
 // SAFETY: `ctx` and `crs` must be valid, non-null PROJ objects.
-unsafe fn classify_demoted(ctx: *mut PJ_CONTEXT, crs: *const PJ) -> Result<TwoDimensionalCrs> {
+unsafe fn classify_demoted(ctx: *mut PJ_CONTEXT, crs: *const PJ) -> TwoDimensionalCrs {
     if proj_get_type(crs) == PJ_TYPE_PJ_TYPE_GEOCENTRIC_CRS {
-        return Ok(TwoDimensionalCrs::None(GEOCENTRIC_REASON));
+        return TwoDimensionalCrs::None(GEOCENTRIC_REASON);
     }
     let cs = proj_crs_get_coordinate_system(ctx, crs);
     if cs.is_null() {
-        return Ok(TwoDimensionalCrs::None(STILL_3D_REASON));
+        return TwoDimensionalCrs::None(STILL_3D_REASON);
     }
     let axes = proj_cs_get_axis_count(ctx, cs);
     proj_destroy(cs);
     if axes != 2 {
-        return Ok(TwoDimensionalCrs::None(STILL_3D_REASON));
+        return TwoDimensionalCrs::None(STILL_3D_REASON);
     }
-    Ok(match epsg_identifier(crs) {
+    match epsg_identifier(crs) {
         Some(code) => TwoDimensionalCrs::Code(code),
         None => TwoDimensionalCrs::None(UNNAMED_REASON),
-    })
+    }
 }
 
 /// The EPSG code `crs` declares as its first identifier, or `None` when it has
@@ -703,8 +718,20 @@ mod tests {
     fn demotion_is_memoized_per_code() {
         let code = EpsgCode::new(4979);
         let computed = crs_demote_to_2d(code).unwrap();
-        assert_eq!(demote_cache().read().get(&code), Some(&computed));
+        assert_eq!(demote_cache().read().get(&code), Some(&Ok(computed)));
         assert_eq!(crs_demote_to_2d(code).unwrap(), computed);
+    }
+
+    #[test]
+    fn an_unresolvable_code_is_memoized_too() {
+        // The failure path is a steady state, not a one-off abort: a whole stream
+        // can share an unusable CRS and each feature asks again. EPSG:2 is not a
+        // real CRS and is used by no other test, so the cache entry is this
+        // test's own.
+        let code = EpsgCode::new(2);
+        let first = crs_demote_to_2d(code).unwrap_err().to_string();
+        assert!(matches!(demote_cache().read().get(&code), Some(Err(_))));
+        assert_eq!(crs_demote_to_2d(code).unwrap_err().to_string(), first);
     }
 
     #[test]

--- a/engine/runtime/geometry/src/ops/reproject/ffi.rs
+++ b/engine/runtime/geometry/src/ops/reproject/ffi.rs
@@ -11,12 +11,14 @@ use parking_lot::RwLock;
 use crate::coordinate::EpsgCode;
 use proj_sys::{
     proj_context_create, proj_context_destroy, proj_context_errno, proj_context_errno_string,
-    proj_create, proj_create_crs_to_crs_from_pj, proj_crs_get_coordinate_system,
-    proj_crs_get_sub_crs, proj_cs_get_axis_count, proj_cs_get_axis_info, proj_cs_get_type,
-    proj_destroy, proj_errno, proj_errno_reset, proj_trans, PJ, PJ_CONTEXT, PJ_COORD,
+    proj_create, proj_create_crs_to_crs_from_pj, proj_crs_demote_to_2D,
+    proj_crs_get_coordinate_system, proj_crs_get_sub_crs, proj_cs_get_axis_count,
+    proj_cs_get_axis_info, proj_cs_get_type, proj_destroy, proj_errno, proj_errno_reset,
+    proj_get_id_auth_name, proj_get_id_code, proj_get_type, proj_trans, PJ, PJ_CONTEXT, PJ_COORD,
     PJ_COORDINATE_SYSTEM_TYPE_PJ_CS_TYPE_CARTESIAN,
     PJ_COORDINATE_SYSTEM_TYPE_PJ_CS_TYPE_ELLIPSOIDAL,
-    PJ_COORDINATE_SYSTEM_TYPE_PJ_CS_TYPE_SPHERICAL, PJ_DIRECTION_PJ_FWD, PJ_XYZT,
+    PJ_COORDINATE_SYSTEM_TYPE_PJ_CS_TYPE_SPHERICAL, PJ_DIRECTION_PJ_FWD,
+    PJ_TYPE_PJ_TYPE_GEOCENTRIC_CRS, PJ_XYZT,
 };
 
 use crate::error::{Error, Result};
@@ -434,6 +436,142 @@ unsafe fn cs_type_is_linear(ctx: *mut PJ_CONTEXT, cs: *const PJ, epsg: EpsgCode)
     }
 }
 
+/// PROJ's determinate answer to "what is this CRS's 2D counterpart?".
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TwoDimensionalCrs {
+    /// The 2D counterpart's EPSG code — the input code itself when it is already 2D.
+    Code(EpsgCode),
+    /// No usable 2D counterpart exists, with the reason why.
+    None(&'static str),
+}
+
+/// A geocentric CRS's third axis is the rotation axis, so dropping it projects
+/// onto the equatorial plane instead of removing a height. Neither the operation
+/// nor a 2D form of the CRS is defined.
+const GEOCENTRIC_REASON: &str =
+    "it is a geocentric (ECEF) CRS, whose third axis is the rotation axis rather than a vertical one";
+
+/// The 2D form exists but is unnamed in EPSG, so no code can tag the result.
+const UNNAMED_REASON: &str = "its 2D form carries no EPSG identifier";
+
+/// The demoted CRS still has a third axis, so it is not a 2D frame.
+const STILL_3D_REASON: &str = "its demoted form still has more than two axes";
+
+/// Process-wide memoization of 2D counterparts, keyed by EPSG code. Like the
+/// orientation sign, the answer is a fixed property of a CRS. Only determinate
+/// answers are cached; an unresolvable CRS is a rare error path.
+fn demote_cache() -> &'static RwLock<HashMap<EpsgCode, TwoDimensionalCrs>> {
+    static CACHE: OnceLock<RwLock<HashMap<EpsgCode, TwoDimensionalCrs>>> = OnceLock::new();
+    CACHE.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// The 2D counterpart of `epsg`: the horizontal component of a compound CRS, the
+/// 2D form of a geographic 3D one, and the code itself when it is already 2D.
+///
+/// [`TwoDimensionalCrs::None`] is a definitive "there is none". `Err` means PROJ
+/// could not answer at all (unknown code, missing PROJ data), which the caller
+/// must distinguish: an indeterminate answer is not evidence of a bad frame.
+///
+/// Memoized per EPSG code, so a CRS costs one PROJ lookup per process.
+pub(crate) fn crs_demote_to_2d(epsg: EpsgCode) -> Result<TwoDimensionalCrs> {
+    if let Some(&demoted) = demote_cache().read().get(&epsg) {
+        return Ok(demoted);
+    }
+    let demoted = crs_demote_to_2d_uncached(epsg)?;
+    demote_cache().write().insert(epsg, demoted);
+    Ok(demoted)
+}
+
+/// Ask PROJ for `epsg`'s 2D counterpart directly, without the cache.
+fn crs_demote_to_2d_uncached(epsg: EpsgCode) -> Result<TwoDimensionalCrs> {
+    // SAFETY: every PROJ object is null-checked and freed on all paths.
+    unsafe {
+        let ctx = proj_context_create();
+        if ctx.is_null() {
+            return Err(Error::projection("proj_context_create returned null"));
+        }
+        let def = CString::new(format!("EPSG:{epsg}")).map_err(Error::projection)?;
+        let crs = proj_create(ctx, def.as_ptr());
+        if crs.is_null() {
+            let msg = ctx_errno_string(ctx);
+            proj_context_destroy(ctx);
+            return Err(Error::projection(format!(
+                "failed to create CRS EPSG:{epsg}: {msg}"
+            )));
+        }
+        let result = demote_and_classify(ctx, crs, epsg);
+        proj_destroy(crs);
+        proj_context_destroy(ctx);
+        result
+    }
+}
+
+/// Demote `crs` to 2D and classify what came back.
+// SAFETY: `ctx` and `crs` must be valid, non-null PROJ objects.
+unsafe fn demote_and_classify(
+    ctx: *mut PJ_CONTEXT,
+    crs: *const PJ,
+    epsg: EpsgCode,
+) -> Result<TwoDimensionalCrs> {
+    // A null name asks PROJ to derive the 2D CRS's name from the input's.
+    let demoted = proj_crs_demote_to_2D(ctx, ptr::null(), crs);
+    if demoted.is_null() {
+        return Err(Error::projection(format!(
+            "failed to demote EPSG:{epsg} to 2D: {}",
+            ctx_errno_string(ctx)
+        )));
+    }
+    let result = classify_demoted(ctx, demoted);
+    proj_destroy(demoted);
+    result
+}
+
+/// Classify a demoted CRS: a two-axis CRS carrying an EPSG identifier is a usable
+/// 2D frame, anything else is not.
+///
+/// Demoting a geocentric CRS is a no-op in PROJ — it hands back the same 3-axis
+/// CRS — so the axis count alone would already reject it; it is matched first only
+/// to report the specific reason.
+// SAFETY: `ctx` and `crs` must be valid, non-null PROJ objects.
+unsafe fn classify_demoted(ctx: *mut PJ_CONTEXT, crs: *const PJ) -> Result<TwoDimensionalCrs> {
+    if proj_get_type(crs) == PJ_TYPE_PJ_TYPE_GEOCENTRIC_CRS {
+        return Ok(TwoDimensionalCrs::None(GEOCENTRIC_REASON));
+    }
+    let cs = proj_crs_get_coordinate_system(ctx, crs);
+    if cs.is_null() {
+        return Ok(TwoDimensionalCrs::None(STILL_3D_REASON));
+    }
+    let axes = proj_cs_get_axis_count(ctx, cs);
+    proj_destroy(cs);
+    if axes != 2 {
+        return Ok(TwoDimensionalCrs::None(STILL_3D_REASON));
+    }
+    Ok(match epsg_identifier(crs) {
+        Some(code) => TwoDimensionalCrs::Code(code),
+        None => TwoDimensionalCrs::None(UNNAMED_REASON),
+    })
+}
+
+/// The EPSG code `crs` declares as its first identifier, or `None` when it has
+/// none, the authority is not EPSG, or the code does not fit an [`EpsgCode`].
+// SAFETY: `crs` must be a valid, non-null PROJ object; the returned strings are
+// owned by it and are read while it is alive.
+unsafe fn epsg_identifier(crs: *const PJ) -> Option<EpsgCode> {
+    let authority = proj_get_id_auth_name(crs, 0);
+    let code = proj_get_id_code(crs, 0);
+    if authority.is_null() || code.is_null() {
+        return None;
+    }
+    if CStr::from_ptr(authority).to_string_lossy() != "EPSG" {
+        return None;
+    }
+    CStr::from_ptr(code)
+        .to_string_lossy()
+        .parse::<u16>()
+        .ok()
+        .map(EpsgCode::new)
+}
+
 /// Map a PROJ axis direction to its `(row, sign)` in the canonical
 /// `(East, North, Up)` basis, or `None` if it is not aligned to an axis.
 ///
@@ -522,6 +660,51 @@ mod tests {
             ),
             Err(e) => assert!(e.to_string().contains("7415"), "unexpected error: {e}"),
         }
+    }
+
+    fn demote(code: u16) -> TwoDimensionalCrs {
+        crs_demote_to_2d(EpsgCode::new(code)).unwrap()
+    }
+
+    #[test]
+    fn three_dimensional_crs_demotes_to_its_horizontal_component() {
+        // Geographic 3D -> geographic 2D on the same datum.
+        assert_eq!(demote(4979), TwoDimensionalCrs::Code(EpsgCode::new(4326)));
+        // Compound -> its horizontal sub-CRS: EPSG:6697 is 6668 + 6695.
+        assert_eq!(demote(6697), TwoDimensionalCrs::Code(EpsgCode::new(6668)));
+        // A compound over a projected CRS resolves to that projected CRS.
+        assert_eq!(demote(5698), TwoDimensionalCrs::Code(EpsgCode::new(2154)));
+    }
+
+    #[test]
+    fn already_2d_crs_demotes_to_itself() {
+        for code in [4326u16, 6668, 6677, 3857] {
+            assert_eq!(demote(code), TwoDimensionalCrs::Code(EpsgCode::new(code)));
+        }
+    }
+
+    #[test]
+    fn geocentric_crs_has_no_2d_counterpart() {
+        // ECEF axes are not (horizontal, horizontal, vertical), so there is no
+        // 2D form to demote to: PROJ hands the same CRS back.
+        for code in [4978u16, 6666, 4936] {
+            assert_eq!(demote(code), TwoDimensionalCrs::None(GEOCENTRIC_REASON));
+        }
+    }
+
+    #[test]
+    fn unknown_crs_is_indeterminate_rather_than_absent() {
+        // An unresolvable code must error, not report "no 2D counterpart": the
+        // caller treats the two differently.
+        assert!(crs_demote_to_2d(EpsgCode::new(1)).is_err());
+    }
+
+    #[test]
+    fn demotion_is_memoized_per_code() {
+        let code = EpsgCode::new(4979);
+        let computed = crs_demote_to_2d(code).unwrap();
+        assert_eq!(demote_cache().read().get(&code), Some(&computed));
+        assert_eq!(crs_demote_to_2d(code).unwrap(), computed);
     }
 
     #[test]

--- a/engine/runtime/geometry/src/ops/reproject/ffi.rs
+++ b/engine/runtime/geometry/src/ops/reproject/ffi.rs
@@ -8,7 +8,7 @@ use std::sync::OnceLock;
 
 use parking_lot::RwLock;
 
-use crate::coordinate::EpsgCode;
+use crate::coordinate::{EpsgCode, MissingTwoDimensionalForm};
 use proj_sys::{
     proj_context_create, proj_context_destroy, proj_context_errno, proj_context_errno_string,
     proj_create, proj_create_crs_to_crs_from_pj, proj_crs_demote_to_2D,
@@ -442,32 +442,19 @@ pub(crate) enum TwoDimensionalCrs {
     /// The 2D counterpart's EPSG code — the input code itself when it is already 2D.
     Code(EpsgCode),
     /// No usable 2D counterpart exists, with the reason why.
-    None(&'static str),
+    None(MissingTwoDimensionalForm),
 }
-
-/// A geocentric CRS's third axis is the rotation axis, so dropping it projects
-/// onto the equatorial plane instead of removing a height. Neither the operation
-/// nor a 2D form of the CRS is defined.
-const GEOCENTRIC_REASON: &str =
-    "it is a geocentric (ECEF) CRS, whose third axis is the rotation axis rather than a vertical one";
-
-/// The 2D form exists but is unnamed in EPSG, so no code can tag the result.
-const UNNAMED_REASON: &str = "its 2D form carries no EPSG identifier";
-
-/// The demoted CRS still has a third axis, so it is not a 2D frame.
-const STILL_3D_REASON: &str = "its demoted form still has more than two axes";
 
 /// A remembered demotion outcome: what PROJ answered, or the message explaining
 /// why it could not answer. Both are fixed properties of the EPSG code.
-type CachedDemotion = std::result::Result<TwoDimensionalCrs, String>;
+type CachedDemotion = Result<TwoDimensionalCrs, String>;
 
 /// Process-wide memoization of 2D counterparts, keyed by EPSG code. Like the
 /// orientation sign, the answer is a fixed property of a CRS.
 ///
-/// Failures are remembered too, unlike in the caches above: a failed demotion
-/// routes one feature to the rejected port and processing continues, so a stream
-/// sharing an unusable CRS would otherwise re-ask PROJ per feature — two orders
-/// of magnitude slower than a cache hit.
+/// Failures are remembered too, unlike in the caches above: a rejection does not
+/// stop the run, so a stream sharing one unusable CRS would otherwise re-ask PROJ
+/// for every feature.
 fn demote_cache() -> &'static RwLock<HashMap<EpsgCode, CachedDemotion>> {
     static CACHE: OnceLock<RwLock<HashMap<EpsgCode, CachedDemotion>>> = OnceLock::new();
     CACHE.get_or_init(|| RwLock::new(HashMap::new()))
@@ -476,43 +463,42 @@ fn demote_cache() -> &'static RwLock<HashMap<EpsgCode, CachedDemotion>> {
 /// The 2D counterpart of `epsg`: the horizontal component of a compound CRS, the
 /// 2D form of a geographic 3D one, and the code itself when it is already 2D.
 ///
-/// [`TwoDimensionalCrs::None`] is a definitive "there is none". `Err` means PROJ
-/// could not answer at all (unknown code, missing PROJ data), which the caller
-/// must distinguish: the two mean different things to a user, even though both
-/// leave the frame's dimensionality unusable.
+/// [`TwoDimensionalCrs::None`] means there definitively is none, whereas `Err`
+/// means PROJ could not answer (unknown code, missing PROJ data). Callers report
+/// the two differently. Memoized, so a CRS costs one PROJ lookup per process.
 ///
-/// Memoized per EPSG code, so a CRS costs one PROJ lookup per process.
-pub(crate) fn crs_demote_to_2d(epsg: EpsgCode) -> Result<TwoDimensionalCrs> {
+/// The error is PROJ's bare message: the caller already names the EPSG code and
+/// the operation, so neither is repeated here.
+pub(crate) fn crs_demote_to_2d(epsg: EpsgCode) -> Result<TwoDimensionalCrs, String> {
     if let Some(cached) = demote_cache().read().get(&epsg) {
-        return cached.clone().map_err(Error::projection);
+        return cached.clone();
     }
     let outcome = lookup_demotion(epsg)?;
     demote_cache().write().insert(epsg, outcome.clone());
-    outcome.map_err(Error::projection)
+    outcome
 }
 
 /// Ask PROJ for `epsg`'s 2D counterpart directly, without the cache.
 ///
-/// The two error channels differ in whether the answer is worth remembering.
-/// `Err` is a transient failure of the PROJ context itself, which says nothing
-/// about `epsg` and must not be cached; the inner `Err` is PROJ's stable verdict
-/// on this code.
-fn lookup_demotion(epsg: EpsgCode) -> Result<CachedDemotion> {
-    let def = CString::new(format!("EPSG:{epsg}")).map_err(Error::projection)?;
+/// The outer `Err` is a failure of the PROJ context itself, which says nothing
+/// about `epsg` and so must not be cached; the inner `Err` is PROJ's verdict on
+/// this code, which may be.
+fn lookup_demotion(epsg: EpsgCode) -> Result<CachedDemotion, String> {
+    let def = CString::new(format!("EPSG:{epsg}")).map_err(|e| e.to_string())?;
     // SAFETY: every PROJ object is null-checked and freed on all paths.
     unsafe {
         let ctx = proj_context_create();
         if ctx.is_null() {
-            return Err(Error::projection("proj_context_create returned null"));
+            return Err("proj_context_create returned null".to_string());
         }
         let crs = proj_create(ctx, def.as_ptr());
         let outcome = if crs.is_null() {
             Err(format!(
-                "failed to create CRS EPSG:{epsg}: {}",
+                "PROJ could not create it: {}",
                 ctx_errno_string(ctx)
             ))
         } else {
-            let outcome = demote_and_classify(ctx, crs, epsg);
+            let outcome = demote_and_classify(ctx, crs);
             proj_destroy(crs);
             outcome
         };
@@ -523,16 +509,12 @@ fn lookup_demotion(epsg: EpsgCode) -> Result<CachedDemotion> {
 
 /// Demote `crs` to 2D and classify what came back.
 // SAFETY: `ctx` and `crs` must be valid, non-null PROJ objects.
-unsafe fn demote_and_classify(
-    ctx: *mut PJ_CONTEXT,
-    crs: *const PJ,
-    epsg: EpsgCode,
-) -> CachedDemotion {
+unsafe fn demote_and_classify(ctx: *mut PJ_CONTEXT, crs: *const PJ) -> CachedDemotion {
     // A null name asks PROJ to derive the 2D CRS's name from the input's.
     let demoted = proj_crs_demote_to_2D(ctx, ptr::null(), crs);
     if demoted.is_null() {
         return Err(format!(
-            "failed to demote EPSG:{epsg} to 2D: {}",
+            "PROJ could not demote it: {}",
             ctx_errno_string(ctx)
         ));
     }
@@ -544,26 +526,25 @@ unsafe fn demote_and_classify(
 /// Classify a demoted CRS: a two-axis CRS carrying an EPSG identifier is a usable
 /// 2D frame, anything else is not.
 ///
-/// Demoting a geocentric CRS is a no-op in PROJ — it hands back the same 3-axis
-/// CRS — so the axis count alone would already reject it; it is matched first only
-/// to report the specific reason.
+/// The geocentric case is matched first only for its specific message; PROJ
+/// demotes such a CRS to itself, so the axis count would reject it anyway.
 // SAFETY: `ctx` and `crs` must be valid, non-null PROJ objects.
 unsafe fn classify_demoted(ctx: *mut PJ_CONTEXT, crs: *const PJ) -> TwoDimensionalCrs {
     if proj_get_type(crs) == PJ_TYPE_PJ_TYPE_GEOCENTRIC_CRS {
-        return TwoDimensionalCrs::None(GEOCENTRIC_REASON);
+        return TwoDimensionalCrs::None(MissingTwoDimensionalForm::Geocentric);
     }
     let cs = proj_crs_get_coordinate_system(ctx, crs);
     if cs.is_null() {
-        return TwoDimensionalCrs::None(STILL_3D_REASON);
+        return TwoDimensionalCrs::None(MissingTwoDimensionalForm::NoCoordinateSystem);
     }
     let axes = proj_cs_get_axis_count(ctx, cs);
     proj_destroy(cs);
     if axes != 2 {
-        return TwoDimensionalCrs::None(STILL_3D_REASON);
+        return TwoDimensionalCrs::None(MissingTwoDimensionalForm::StillThreeDimensional);
     }
     match epsg_identifier(crs) {
         Some(code) => TwoDimensionalCrs::Code(code),
-        None => TwoDimensionalCrs::None(UNNAMED_REASON),
+        None => TwoDimensionalCrs::None(MissingTwoDimensionalForm::Unidentified),
     }
 }
 
@@ -700,10 +681,13 @@ mod tests {
 
     #[test]
     fn geocentric_crs_has_no_2d_counterpart() {
-        // ECEF axes are not (horizontal, horizontal, vertical), so there is no
-        // 2D form to demote to: PROJ hands the same CRS back.
+        // ECEF axes are not (horizontal, horizontal, vertical), so PROJ has no 2D
+        // form to hand back.
         for code in [4978u16, 6666, 4936] {
-            assert_eq!(demote(code), TwoDimensionalCrs::None(GEOCENTRIC_REASON));
+            assert_eq!(
+                demote(code),
+                TwoDimensionalCrs::None(MissingTwoDimensionalForm::Geocentric)
+            );
         }
     }
 
@@ -715,19 +699,9 @@ mod tests {
     }
 
     #[test]
-    fn demotion_is_memoized_per_code() {
-        let code = EpsgCode::new(4979);
-        let computed = crs_demote_to_2d(code).unwrap();
-        assert_eq!(demote_cache().read().get(&code), Some(&Ok(computed)));
-        assert_eq!(crs_demote_to_2d(code).unwrap(), computed);
-    }
-
-    #[test]
-    fn an_unresolvable_code_is_memoized_too() {
-        // The failure path is a steady state, not a one-off abort: a whole stream
-        // can share an unusable CRS and each feature asks again. EPSG:2 is not a
-        // real CRS and is used by no other test, so the cache entry is this
-        // test's own.
+    fn an_unresolvable_code_is_memoized() {
+        // EPSG:2 is not a real CRS and is used by no other test, so the cache
+        // entry observed here is this test's own.
         let code = EpsgCode::new(2);
         let first = crs_demote_to_2d(code).unwrap_err().to_string();
         assert!(matches!(demote_cache().read().get(&code), Some(Err(_))));

--- a/engine/runtime/geometry/src/ops/reproject/mod.rs
+++ b/engine/runtime/geometry/src/ops/reproject/mod.rs
@@ -6,7 +6,7 @@ use crate::error::{Error, Result};
 mod ffi;
 
 pub use ffi::ReprojectionCache;
-pub(crate) use ffi::{axis_order_sign, crs_is_linear};
+pub(crate) use ffi::{axis_order_sign, crs_demote_to_2d, crs_is_linear, TwoDimensionalCrs};
 
 /// Reproject a geometry's coordinates to a target CRS.
 #[enum_dispatch::enum_dispatch]

--- a/engine/runtime/geometry/src/point/ops.rs
+++ b/engine/runtime/geometry/src/point/ops.rs
@@ -103,6 +103,29 @@ impl ConvertFrame for Point3D {
     }
 }
 
+use crate::ops::ForceTwoDimension;
+use crate::Euclidean2DGeometry;
+
+impl ForceTwoDimension for Point2D {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+        // Already 2D and carries no elevation; hand back an equivalent point.
+        Ok(Euclidean2DGeometry::Point(Point2D {
+            frame: self.frame.clone(),
+            position: self.position,
+        }))
+    }
+}
+
+impl ForceTwoDimension for Point3D {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+        let [x, y, _] = self.position;
+        Ok(Euclidean2DGeometry::Point(Point2D {
+            frame: self.frame.clone(),
+            position: [x, y],
+        }))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/point/ops.rs
+++ b/engine/runtime/geometry/src/point/ops.rs
@@ -103,24 +103,25 @@ impl ConvertFrame for Point3D {
     }
 }
 
-use crate::ops::ForceTwoDimension;
+use crate::ops::{ForceTwoDimension, ForceTwoDimensionError};
 use crate::Euclidean2DGeometry;
 
 impl ForceTwoDimension for Point2D {
-    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, ForceTwoDimensionError> {
         // Already 2D and carries no elevation; hand back an equivalent point.
         Ok(Euclidean2DGeometry::Point(Point2D {
-            frame: self.frame.clone(),
+            frame: self.frame.demote_to_2d()?,
             position: self.position,
         }))
     }
 }
 
 impl ForceTwoDimension for Point3D {
-    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, ForceTwoDimensionError> {
+        let frame = self.frame.demote_to_2d()?;
         let [x, y, _] = self.position;
         Ok(Euclidean2DGeometry::Point(Point2D {
-            frame: self.frame.clone(),
+            frame,
             position: [x, y],
         }))
     }

--- a/engine/runtime/geometry/src/point_cloud/mod.rs
+++ b/engine/runtime/geometry/src/point_cloud/mod.rs
@@ -150,4 +150,4 @@ impl fmt::Debug for PointCloud {
     }
 }
 
-crate::unsupported!(PointCloud: Triangulate, Reproject, ConvertFrame, Translate);
+crate::unsupported!(PointCloud: Triangulate, Reproject, ConvertFrame, Translate, ForceTwoDimension);

--- a/engine/runtime/geometry/src/polygon/ops.rs
+++ b/engine/runtime/geometry/src/polygon/ops.rs
@@ -281,6 +281,39 @@ fn open_ring_positions<const N: usize>(
     num_outer
 }
 
+use crate::ops::ForceTwoDimension;
+
+impl ForceTwoDimension for Polygon2D {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+        self.z = None; // drop any 2.5D elevation; rings and appearance carry over
+        Ok(Euclidean2DGeometry::Polygon(Box::new(Polygon2D {
+            frame: self.frame.clone(),
+            coords: std::mem::take(&mut self.coords),
+            interior_offsets: std::mem::take(&mut self.interior_offsets),
+            z: None,
+            appearance: self.appearance.take(),
+        })))
+    }
+}
+
+impl ForceTwoDimension for Polygon3D {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+        // Only the coordinate embedding changes; ring offsets and appearance
+        // (including per-corner UV, which is not indexed by Z) carry over.
+        let coords = std::mem::take(&mut self.coords)
+            .iter()
+            .map(|&[x, y, _]| [x, y])
+            .collect();
+        Ok(Euclidean2DGeometry::Polygon(Box::new(Polygon2D {
+            frame: self.frame.clone(),
+            coords,
+            interior_offsets: std::mem::take(&mut self.interior_offsets),
+            z: None,
+            appearance: self.appearance.take(),
+        })))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/polygon/ops.rs
+++ b/engine/runtime/geometry/src/polygon/ops.rs
@@ -281,13 +281,14 @@ fn open_ring_positions<const N: usize>(
     num_outer
 }
 
-use crate::ops::ForceTwoDimension;
+use crate::ops::{ForceTwoDimension, ForceTwoDimensionError};
 
 impl ForceTwoDimension for Polygon2D {
-    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, ForceTwoDimensionError> {
+        let frame = self.frame.demote_to_2d()?;
         self.z = None; // drop any 2.5D elevation; rings and appearance carry over
         Ok(Euclidean2DGeometry::Polygon(Box::new(Polygon2D {
-            frame: self.frame.clone(),
+            frame,
             coords: std::mem::take(&mut self.coords),
             interior_offsets: std::mem::take(&mut self.interior_offsets),
             z: None,
@@ -297,15 +298,17 @@ impl ForceTwoDimension for Polygon2D {
 }
 
 impl ForceTwoDimension for Polygon3D {
-    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
-        // Only the coordinate embedding changes; ring offsets and appearance
-        // (including per-corner UV, which is not indexed by Z) carry over.
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, ForceTwoDimensionError> {
+        // Only the coordinate embedding and the frame's dimensionality change;
+        // ring offsets and appearance (including per-corner UV, which is not
+        // indexed by Z) carry over.
+        let frame = self.frame.demote_to_2d()?;
         let coords = std::mem::take(&mut self.coords)
             .iter()
             .map(|&[x, y, _]| [x, y])
             .collect();
         Ok(Euclidean2DGeometry::Polygon(Box::new(Polygon2D {
-            frame: self.frame.clone(),
+            frame,
             coords,
             interior_offsets: std::mem::take(&mut self.interior_offsets),
             z: None,

--- a/engine/runtime/geometry/src/polygon_mesh/ops.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/ops.rs
@@ -451,6 +451,53 @@ impl Split for PolygonMesh3D {
     }
 }
 
+use crate::ops::ForceTwoDimension;
+
+impl ForceTwoDimension for PolygonMesh2D {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+        self.z = None; // drop any 2.5D elevation; topology and appearance carry over
+        Ok(Euclidean2DGeometry::PolygonMesh(Box::new(PolygonMesh2D {
+            frame: self.frame.clone(),
+            vertices: std::mem::take(&mut self.vertices),
+            z: None,
+            face_indices: std::mem::replace(&mut self.face_indices, IndexBuffer::U8(Vec::new())),
+            face_offsets: std::mem::replace(&mut self.face_offsets, IndexBuffer::U8(Vec::new())),
+            interior_offsets: std::mem::replace(
+                &mut self.interior_offsets,
+                IndexBuffer::U8(Vec::new()),
+            ),
+            appearance: self.appearance.take(),
+        })))
+    }
+}
+
+impl ForceTwoDimension for PolygonMesh3D {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+        let vertices = std::mem::take(&mut self.data.vertices)
+            .into_iter()
+            .map(|[x, y, _]| [x, y])
+            .collect();
+        Ok(Euclidean2DGeometry::PolygonMesh(Box::new(PolygonMesh2D {
+            frame: self.frame.clone(),
+            vertices,
+            z: None,
+            face_indices: std::mem::replace(
+                &mut self.data.face_indices,
+                IndexBuffer::U8(Vec::new()),
+            ),
+            face_offsets: std::mem::replace(
+                &mut self.data.face_offsets,
+                IndexBuffer::U8(Vec::new()),
+            ),
+            interior_offsets: std::mem::replace(
+                &mut self.data.interior_offsets,
+                IndexBuffer::U8(Vec::new()),
+            ),
+            appearance: self.data.appearance.take(),
+        })))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/polygon_mesh/ops.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/ops.rs
@@ -451,13 +451,14 @@ impl Split for PolygonMesh3D {
     }
 }
 
-use crate::ops::ForceTwoDimension;
+use crate::ops::{ForceTwoDimension, ForceTwoDimensionError};
 
 impl ForceTwoDimension for PolygonMesh2D {
-    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, ForceTwoDimensionError> {
+        let frame = self.frame.demote_to_2d()?;
         self.z = None; // drop any 2.5D elevation; topology and appearance carry over
         Ok(Euclidean2DGeometry::PolygonMesh(Box::new(PolygonMesh2D {
-            frame: self.frame.clone(),
+            frame,
             vertices: std::mem::take(&mut self.vertices),
             z: None,
             face_indices: std::mem::replace(&mut self.face_indices, IndexBuffer::U8(Vec::new())),
@@ -472,13 +473,14 @@ impl ForceTwoDimension for PolygonMesh2D {
 }
 
 impl ForceTwoDimension for PolygonMesh3D {
-    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, ForceTwoDimensionError> {
+        let frame = self.frame.demote_to_2d()?;
         let vertices = std::mem::take(&mut self.data.vertices)
             .into_iter()
             .map(|[x, y, _]| [x, y])
             .collect();
         Ok(Euclidean2DGeometry::PolygonMesh(Box::new(PolygonMesh2D {
-            frame: self.frame.clone(),
+            frame,
             vertices,
             z: None,
             face_indices: std::mem::replace(

--- a/engine/runtime/geometry/src/polygon_mesh/ops.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/ops.rs
@@ -797,4 +797,62 @@ mod tests {
             FaceBinding::Uniform(_)
         ));
     }
+
+    #[test]
+    fn polygon_mesh3d_force_2d_keeps_topology_and_demotes_the_frame() {
+        // One square face with one square hole, so all three CSR buffers carry
+        // content that must land back in the matching field.
+        let mut mesh = PolygonMesh3D::from_raw_parts(
+            CoordinateFrame::Crs(EpsgCode::new(6697)),
+            vec![
+                [0.0, 0.0, 9.0],
+                [4.0, 0.0, 9.0],
+                [4.0, 4.0, 9.0],
+                [0.0, 4.0, 9.0],
+                [1.0, 1.0, 9.0],
+                [3.0, 1.0, 9.0],
+                [3.0, 3.0, 9.0],
+                [1.0, 3.0, 9.0],
+            ],
+            vec![0, 1, 2, 3, 4, 5, 6, 7],
+            vec![],
+            vec![4],
+        )
+        .unwrap();
+        let forced = match mesh.force_2d().unwrap() {
+            Euclidean2DGeometry::PolygonMesh(m) => m,
+            other => panic!("expected a 2D polygon mesh, got {other:?}"),
+        };
+        assert_eq!(forced.frame(), &CoordinateFrame::Crs(EpsgCode::new(6668)));
+        assert_eq!(forced.vertices()[0], [0.0, 0.0]);
+        assert_eq!(forced.vertices()[4], [1.0, 1.0]);
+        assert_eq!(forced.num_faces(), 1);
+        let mut faces = Vec::new();
+        forced.for_each_face_polygon(|p| faces.push(p));
+        assert_eq!(faces[0].exterior().len(), 4);
+        assert_eq!(faces[0].interiors().count(), 1);
+    }
+
+    #[test]
+    fn polygon_mesh2d_force_2d_clears_elevation() {
+        let mut mesh = PolygonMesh2D::from_parts_with_elevation(
+            CoordinateFrame::Crs(EpsgCode::new(6697)),
+            vec![[0.0, 0.0, 5.0], [2.0, 0.0, 6.0], [2.0, 2.0, 7.0]],
+            vec![vec![0u32, 1, 2]],
+        )
+        .unwrap();
+        let forced = match mesh.force_2d().unwrap() {
+            Euclidean2DGeometry::PolygonMesh(m) => m,
+            other => panic!("expected a 2D polygon mesh, got {other:?}"),
+        };
+        assert_eq!(forced.frame(), &CoordinateFrame::Crs(EpsgCode::new(6668)));
+        assert_eq!(forced.num_faces(), 1);
+        assert_eq!(
+            forced.bounding_box().unwrap(),
+            Aabb::D2 {
+                min: [0.0, 0.0],
+                max: [2.0, 2.0]
+            }
+        );
+    }
 }

--- a/engine/runtime/geometry/src/solid/ops.rs
+++ b/engine/runtime/geometry/src/solid/ops.rs
@@ -116,6 +116,10 @@ impl ConvertFrame for Solid {
     }
 }
 
+// A solid is a volume; flattening its boundary to 2D has no single well-defined
+// result, so it has no 2D counterpart.
+crate::unsupported!(Solid: ForceTwoDimension);
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/triangular_mesh/ops.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/ops.rs
@@ -237,4 +237,60 @@ mod tests {
             }
         );
     }
+
+    #[test]
+    fn triangular_mesh3d_force_2d_keeps_triangles_and_demotes_the_frame() {
+        use crate::coordinate::EpsgCode;
+
+        let mut mesh = TriangularMesh3D::from_parts(
+            CoordinateFrame::Crs(EpsgCode::new(6697)),
+            vec![
+                [0.0, 0.0, 9.0],
+                [2.0, 0.0, 8.0],
+                [2.0, 2.0, 7.0],
+                [0.0, 2.0, 6.0],
+            ],
+            [0u32, 1, 2, 0, 2, 3],
+        )
+        .unwrap();
+        let forced = match mesh.force_2d().unwrap() {
+            Euclidean2DGeometry::TriangularMesh(m) => m,
+            other => panic!("expected a 2D triangular mesh, got {other:?}"),
+        };
+        assert_eq!(forced.frame(), &CoordinateFrame::Crs(EpsgCode::new(6668)));
+        assert_eq!(
+            forced.vertices(),
+            &[[0.0, 0.0], [2.0, 0.0], [2.0, 2.0], [0.0, 2.0]]
+        );
+        assert_eq!(
+            forced.triangles().collect::<Vec<_>>(),
+            vec![[0, 1, 2], [0, 2, 3]]
+        );
+    }
+
+    #[test]
+    fn triangular_mesh2d_force_2d_clears_elevation() {
+        use crate::coordinate::EpsgCode;
+
+        let mut mesh = TriangularMesh2D::from_parts_with_elevation(
+            CoordinateFrame::Crs(EpsgCode::new(6697)),
+            vec![[0.0, 0.0, 5.0], [2.0, 0.0, 6.0], [2.0, 2.0, 7.0]],
+            [0u32, 1, 2],
+        )
+        .unwrap();
+        let forced = match mesh.force_2d().unwrap() {
+            Euclidean2DGeometry::TriangularMesh(m) => m,
+            other => panic!("expected a 2D triangular mesh, got {other:?}"),
+        };
+        assert_eq!(forced.frame(), &CoordinateFrame::Crs(EpsgCode::new(6668)));
+        assert_eq!(forced.num_triangles(), 1);
+        // The elevation is gone, so the box is purely 2D.
+        assert_eq!(
+            forced.bounding_box().unwrap(),
+            Aabb::D2 {
+                min: [0.0, 0.0],
+                max: [2.0, 2.0]
+            }
+        );
+    }
 }

--- a/engine/runtime/geometry/src/triangular_mesh/ops.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/ops.rs
@@ -165,6 +165,42 @@ impl Split for TriangularMesh3D {
     }
 }
 
+use crate::index::IndexBuffer;
+use crate::ops::ForceTwoDimension;
+
+impl ForceTwoDimension for TriangularMesh2D {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+        self.z = None; // drop any 2.5D elevation; indices and appearance carry over
+        Ok(Euclidean2DGeometry::TriangularMesh(Box::new(
+            TriangularMesh2D {
+                frame: self.frame.clone(),
+                vertices: std::mem::take(&mut self.vertices),
+                z: None,
+                indices: std::mem::replace(&mut self.indices, IndexBuffer::U8(Vec::new())),
+                appearance: self.appearance.take(),
+            },
+        )))
+    }
+}
+
+impl ForceTwoDimension for TriangularMesh3D {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+        let vertices = std::mem::take(&mut self.data.vertices)
+            .into_iter()
+            .map(|[x, y, _]| [x, y])
+            .collect();
+        Ok(Euclidean2DGeometry::TriangularMesh(Box::new(
+            TriangularMesh2D {
+                frame: self.frame.clone(),
+                vertices,
+                z: None,
+                indices: std::mem::replace(&mut self.data.indices, IndexBuffer::U8(Vec::new())),
+                appearance: self.data.appearance.take(),
+            },
+        )))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/triangular_mesh/ops.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/ops.rs
@@ -166,14 +166,15 @@ impl Split for TriangularMesh3D {
 }
 
 use crate::index::IndexBuffer;
-use crate::ops::ForceTwoDimension;
+use crate::ops::{ForceTwoDimension, ForceTwoDimensionError};
 
 impl ForceTwoDimension for TriangularMesh2D {
-    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, ForceTwoDimensionError> {
+        let frame = self.frame.demote_to_2d()?;
         self.z = None; // drop any 2.5D elevation; indices and appearance carry over
         Ok(Euclidean2DGeometry::TriangularMesh(Box::new(
             TriangularMesh2D {
-                frame: self.frame.clone(),
+                frame,
                 vertices: std::mem::take(&mut self.vertices),
                 z: None,
                 indices: std::mem::replace(&mut self.indices, IndexBuffer::U8(Vec::new())),
@@ -184,14 +185,15 @@ impl ForceTwoDimension for TriangularMesh2D {
 }
 
 impl ForceTwoDimension for TriangularMesh3D {
-    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, UnsupportedOperation> {
+    fn force_2d(&mut self) -> Result<Euclidean2DGeometry, ForceTwoDimensionError> {
+        let frame = self.frame.demote_to_2d()?;
         let vertices = std::mem::take(&mut self.data.vertices)
             .into_iter()
             .map(|[x, y, _]| [x, y])
             .collect();
         Ok(Euclidean2DGeometry::TriangularMesh(Box::new(
             TriangularMesh2D {
-                frame: self.frame.clone(),
+                frame,
                 vertices,
                 z: None,
                 indices: std::mem::replace(&mut self.data.indices, IndexBuffer::U8(Vec::new())),

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.88"
+version = "0.2.89"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.278"
+version = "0.1.279"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
# Overview

Migrates the `Two Dimension Forcer` processor to the new geometry stack (`new-geometry` feature), backed by a new `ForceTwoDimension` geometry op that drops the Z coordinate to produce pure 2D geometry.

## What I've done

- Added a `ForceTwoDimension` trait (`engine/runtime/geometry/src/ops/mod.rs`) that re-represents a 3D leaf as its matching 2D leaf (`Point3D` -> `Point2D`, etc.), keeping topology, appearance, and UV intact. Any 2.5D per-vertex elevation is cleared, so the op is idempotent.
- Implemented `force_2d` for `point`, `line_string`, `polygon`, `polygon_mesh`, and `triangular_mesh`; `Solid`, `Csg`, and `PointCloud` opt out via the trait default and report `UnsupportedOperation`.
- The coordinate frame (CRS tag) is preserved verbatim — no reprojection. This matches FME's `2DForcer`, which also only drops Z and offers no CRS option. Frame changes remain the responsibility of `Coordinate Frame Reprojector`.
- Wired the op into `enum_dispatch` and added `Geometry::force_2d` / `GeometryCollection::force_2d` (`engine/runtime/geometry/src/lib.rs`). Collection recursion is all-or-nothing: one member with no 2D counterpart fails the whole feature rather than silently dropping members.
- Added a `new-geometry` path to the processor that routes geometry with no 2D counterpart to a new `rejected` output port. The legacy path is unchanged.

## What I haven't done

- `PointCloud` opts out; a 2D bounding-box footprint (as FME does) is deferred.

## How I tested

- Added `force_2d` unit tests (`engine/runtime/geometry/src/lib.rs`) covering Z-drop, frame preservation, and appearance handling.
- Ran `cargo make schema-base` / `cargo make schema-translated`; no diff, so action schemas/i18n are in sync.

## Screenshot

## Which point I want you to review particularly

## Memo