### PR TITLE
feat: BoundsExtractor behind new-geometry

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4839,6 +4839,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "petgraph 0.8.3",
+ "pretty_assertions",
  "proj",
  "quick-xml 0.37.5",
  "rayon",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.87"
+version = "0.2.88"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "futures",
  "once_cell",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "approx",
  "async-trait",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "Inflector",
  "approx",
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "bytes",
  "clap",
@@ -5058,7 +5058,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5101,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5129,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5142,7 +5142,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "approx",
  "bvh",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5287,7 +5287,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "bytes",
  "futures",
@@ -5335,7 +5335,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "bytes",
  "futures",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "ahash",
  "bytes",
@@ -5438,7 +5438,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.455"
+version = "0.0.456"
 dependencies = [
  "async-trait",
  "axum",
@@ -8204,7 +8204,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.277"
+version = "0.1.278"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.455"
+version = "0.0.456"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/action-processor/Cargo.toml
+++ b/engine/runtime/action-processor/Cargo.toml
@@ -76,4 +76,5 @@ zstd.workspace = true
 
 [dev-dependencies]
 bytes.workspace = true
+pretty_assertions.workspace = true
 tracing-subscriber.workspace = true

--- a/engine/runtime/action-processor/src/geometry/bounds_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/bounds_extractor.rs
@@ -210,8 +210,8 @@ impl Processor for BoundsExtractor {
 
 impl BoundsExtractor {
     /// Write one bound under its configured attribute name, falling back to
-    /// `default`. A bound that is not representable as a JSON number is written
-    /// as zero.
+    /// `default`. `bound` must be finite; a bound that is not representable as a
+    /// JSON number is written as zero.
     fn insert_bound(
         &self,
         feature: &mut Feature,

--- a/engine/runtime/action-processor/src/geometry/bounds_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/bounds_extractor.rs
@@ -1,6 +1,12 @@
+#[cfg(feature = "new-geometry")]
+use reearth_flow_geometry::ops::{Aabb, BoundingBox};
+#[cfg(not(feature = "new-geometry"))]
 use reearth_flow_geometry::types::coordinate::Coordinate;
+#[cfg(not(feature = "new-geometry"))]
 use reearth_flow_geometry::types::coordnum::CoordNum;
+#[cfg(not(feature = "new-geometry"))]
 use reearth_flow_geometry::types::geometry::{Geometry, Geometry2D, Geometry3D};
+#[cfg(not(feature = "new-geometry"))]
 use reearth_flow_geometry::types::point::Point;
 use reearth_flow_runtime::{
     errors::BoxedError,
@@ -9,19 +15,26 @@ use reearth_flow_runtime::{
     forwarder::ProcessorChannelForwarder,
     node::{Port, Processor, ProcessorFactory, FEATURES_PORT, REJECTED_PORT},
 };
-use reearth_flow_types::{Attribute, AttributeValue};
+use reearth_flow_types::{Attribute, AttributeValue, Feature};
+#[cfg(not(feature = "new-geometry"))]
 use reearth_flow_types::{CityGmlGeometry, GeometryValue};
 
+#[cfg(not(feature = "new-geometry"))]
 use num_traits::NumCast;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Number, Value};
 use std::collections::HashMap;
+#[cfg(not(feature = "new-geometry"))]
 use std::fmt::Debug;
 
 use super::errors::GeometryProcessorError;
+#[cfg(not(feature = "new-geometry"))]
 use super::utils::finite_z;
 
+/// The extent of a geometry along each axis. `min_z` / `max_z` are absent when
+/// the extent is planar.
+#[cfg(not(feature = "new-geometry"))]
 #[derive(Debug, Clone)]
 pub struct Bounds {
     pub min_x: f64,
@@ -32,27 +45,15 @@ pub struct Bounds {
     pub max_z: Option<f64>,
 }
 
-impl Bounds {
-    fn min_x_value(&self) -> AttributeValue {
-        AttributeValue::Number(Number::from_f64(self.min_x).unwrap_or_else(|| Number::from(0)))
-    }
-    fn max_x_value(&self) -> AttributeValue {
-        AttributeValue::Number(Number::from_f64(self.max_x).unwrap_or_else(|| Number::from(0)))
-    }
-    fn min_y_value(&self) -> AttributeValue {
-        AttributeValue::Number(Number::from_f64(self.min_y).unwrap_or_else(|| Number::from(0)))
-    }
-    fn max_y_value(&self) -> AttributeValue {
-        AttributeValue::Number(Number::from_f64(self.max_y).unwrap_or_else(|| Number::from(0)))
-    }
-    fn min_z_value(&self) -> Option<AttributeValue> {
-        self.min_z
-            .and_then(|z| Number::from_f64(z).map(AttributeValue::Number))
-    }
-    fn max_z_value(&self) -> Option<AttributeValue> {
-        self.max_z
-            .and_then(|z| Number::from_f64(z).map(AttributeValue::Number))
-    }
+/// Whether every bound of the box is finite. A box with a non-finite bound
+/// cannot be expressed as a JSON number.
+#[cfg(feature = "new-geometry")]
+fn bounds_are_finite(aabb: &Aabb) -> bool {
+    let (min, max) = match aabb {
+        Aabb::D2 { min, max } => (&min[..], &max[..]),
+        Aabb::D3 { min, max } => (&min[..], &max[..]),
+    };
+    min.iter().chain(max).all(|v| v.is_finite())
 }
 
 #[derive(Debug, Clone, Default)]
@@ -159,36 +160,7 @@ impl Processor for BoundsExtractor {
         };
         if let Some(bounds) = bounds {
             let mut new_feature = feature.clone();
-
-            new_feature.insert(
-                self.params.xmin.clone().unwrap_or(Attribute::new("xmin")),
-                bounds.min_x_value(),
-            );
-            new_feature.insert(
-                self.params.xmax.clone().unwrap_or(Attribute::new("xmax")),
-                bounds.max_x_value(),
-            );
-            new_feature.insert(
-                self.params.ymin.clone().unwrap_or(Attribute::new("ymin")),
-                bounds.min_y_value(),
-            );
-            new_feature.insert(
-                self.params.ymax.clone().unwrap_or(Attribute::new("ymax")),
-                bounds.max_y_value(),
-            );
-            if let Some(min_z) = bounds.min_z_value() {
-                new_feature.insert(
-                    self.params.zmin.clone().unwrap_or(Attribute::new("zmin")),
-                    min_z,
-                );
-            }
-            if let Some(max_z) = bounds.max_z_value() {
-                new_feature.insert(
-                    self.params.zmax.clone().unwrap_or(Attribute::new("zmax")),
-                    max_z,
-                );
-            }
-
+            self.insert_bounds(&mut new_feature, &bounds);
             fw.send(ctx.new_with_feature_and_port(new_feature, FEATURES_PORT.clone()));
         } else {
             fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
@@ -196,7 +168,33 @@ impl Processor for BoundsExtractor {
         Ok(())
     }
 
-    #[cfg(not(feature = "new-geometry"))]
+    /// Attach the geometry's axis-aligned bounding box to the feature as
+    /// attributes. A feature whose geometry has no box (absent, empty, or a type
+    /// that does not support the operation) or whose box has a non-finite bound
+    /// is routed to `rejected`.
+    #[cfg(feature = "new-geometry")]
+    fn process(
+        &mut self,
+        ctx: ExecutorContext,
+        fw: &ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        let feature = &ctx.feature;
+        let aabb = feature
+            .geometry
+            .bounding_box()
+            .ok()
+            .filter(bounds_are_finite);
+        match aabb {
+            Some(aabb) => {
+                let mut new_feature = feature.clone();
+                self.insert_bounds(&mut new_feature, aabb);
+                fw.send(ctx.new_with_feature_and_port(new_feature, FEATURES_PORT.clone()));
+            }
+            None => fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone())),
+        }
+        Ok(())
+    }
+
     fn finish(
         &mut self,
         _ctx: NodeContext,
@@ -210,6 +208,59 @@ impl Processor for BoundsExtractor {
     }
 }
 
+impl BoundsExtractor {
+    /// Write one bound under its configured attribute name, falling back to
+    /// `default`. A bound that is not representable as a JSON number is written
+    /// as zero.
+    fn insert_bound(
+        &self,
+        feature: &mut Feature,
+        name: &Option<Attribute>,
+        default: &str,
+        bound: f64,
+    ) {
+        let attribute = name.clone().unwrap_or_else(|| Attribute::new(default));
+        let number = Number::from_f64(bound).unwrap_or_else(|| Number::from(0));
+        feature.insert(attribute, AttributeValue::Number(number));
+    }
+
+    /// Write the box onto the feature as one attribute per bound. A 2D box
+    /// writes no z attributes: the optional per-vertex elevation of a
+    /// 2D-embedded geometry is not part of its box.
+    #[cfg(feature = "new-geometry")]
+    fn insert_bounds(&self, feature: &mut Feature, aabb: Aabb) {
+        let (min, max, z) = match aabb {
+            Aabb::D2 { min, max } => (min, max, None),
+            Aabb::D3 { min, max } => ([min[0], min[1]], [max[0], max[1]], Some((min[2], max[2]))),
+        };
+        self.insert_bound(feature, &self.params.xmin, "xmin", min[0]);
+        self.insert_bound(feature, &self.params.xmax, "xmax", max[0]);
+        self.insert_bound(feature, &self.params.ymin, "ymin", min[1]);
+        self.insert_bound(feature, &self.params.ymax, "ymax", max[1]);
+        if let Some((min_z, max_z)) = z {
+            self.insert_bound(feature, &self.params.zmin, "zmin", min_z);
+            self.insert_bound(feature, &self.params.zmax, "zmax", max_z);
+        }
+    }
+
+    /// Write the bounds onto the feature as one attribute per bound. The z
+    /// attributes are written only when the bounds carry z.
+    #[cfg(not(feature = "new-geometry"))]
+    fn insert_bounds(&self, feature: &mut Feature, bounds: &Bounds) {
+        self.insert_bound(feature, &self.params.xmin, "xmin", bounds.min_x);
+        self.insert_bound(feature, &self.params.xmax, "xmax", bounds.max_x);
+        self.insert_bound(feature, &self.params.ymin, "ymin", bounds.min_y);
+        self.insert_bound(feature, &self.params.ymax, "ymax", bounds.max_y);
+        if let Some(min_z) = bounds.min_z {
+            self.insert_bound(feature, &self.params.zmin, "zmin", min_z);
+        }
+        if let Some(max_z) = bounds.max_z {
+            self.insert_bound(feature, &self.params.zmax, "zmax", max_z);
+        }
+    }
+}
+
+#[cfg(not(feature = "new-geometry"))]
 impl BoundsExtractor {
     fn update_bounds(current_bounds: Option<Bounds>, new_bounds: Option<Bounds>) -> Option<Bounds> {
         match (current_bounds, new_bounds) {
@@ -362,5 +413,128 @@ impl BoundsExtractor {
             _ => {}
         }
         bounds
+    }
+}
+
+#[cfg(all(test, feature = "new-geometry"))]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use reearth_flow_geometry::coordinate::CoordinateFrame;
+    use reearth_flow_geometry::line_string::{LineString2D, LineString3D};
+    use reearth_flow_geometry::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
+
+    fn extractor() -> BoundsExtractor {
+        BoundsExtractor {
+            params: BoundsExtractorParam {
+                xmin: None,
+                xmax: None,
+                ymin: None,
+                ymax: None,
+                zmin: None,
+                zmax: None,
+            },
+        }
+    }
+
+    fn number(feature: &Feature, key: &str) -> Option<f64> {
+        match feature.attributes.get(&Attribute::new(key))? {
+            AttributeValue::Number(n) => n.as_f64(),
+            _ => None,
+        }
+    }
+
+    fn extract(geometry: Geometry) -> Feature {
+        let aabb = geometry.bounding_box().unwrap();
+        let mut feature = Feature::from(geometry);
+        extractor().insert_bounds(&mut feature, aabb);
+        feature
+    }
+
+    #[test]
+    fn three_dimensional_geometry_yields_every_axis() {
+        let line = LineString3D::from_coords(
+            CoordinateFrame::Euclidean,
+            [[1.0, -2.0, 3.0], [-4.0, 5.0, -6.0]],
+        );
+        let feature = extract(Geometry::Euclidean3D(Euclidean3DGeometry::LineString(line)));
+        assert_eq!(number(&feature, "xmin"), Some(-4.0));
+        assert_eq!(number(&feature, "xmax"), Some(1.0));
+        assert_eq!(number(&feature, "ymin"), Some(-2.0));
+        assert_eq!(number(&feature, "ymax"), Some(5.0));
+        assert_eq!(number(&feature, "zmin"), Some(-6.0));
+        assert_eq!(number(&feature, "zmax"), Some(3.0));
+    }
+
+    #[test]
+    fn two_dimensional_geometry_yields_no_z() {
+        let line = LineString2D::from_coords(CoordinateFrame::Euclidean, [[1.0, 2.0], [3.0, 4.0]]);
+        let feature = extract(Geometry::Euclidean2D(Euclidean2DGeometry::LineString(line)));
+        assert_eq!(number(&feature, "xmin"), Some(1.0));
+        assert_eq!(number(&feature, "ymax"), Some(4.0));
+        assert!(feature.attributes.get(&Attribute::new("zmin")).is_none());
+        assert!(feature.attributes.get(&Attribute::new("zmax")).is_none());
+    }
+
+    #[test]
+    fn elevation_of_a_two_dimensional_geometry_is_not_folded_in() {
+        let line = LineString2D::from_coords_with_elevation(
+            CoordinateFrame::Euclidean,
+            [[1.0, 2.0, 10.0], [3.0, 4.0, 20.0]],
+        );
+        let feature = extract(Geometry::Euclidean2D(Euclidean2DGeometry::LineString(line)));
+        assert!(feature.attributes.get(&Attribute::new("zmin")).is_none());
+    }
+
+    #[test]
+    fn custom_attribute_names_are_honoured() {
+        let line = LineString3D::from_coords(
+            CoordinateFrame::Euclidean,
+            [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
+        );
+        let geometry = Geometry::Euclidean3D(Euclidean3DGeometry::LineString(line));
+        let aabb = geometry.bounding_box().unwrap();
+        let extractor = BoundsExtractor {
+            params: BoundsExtractorParam {
+                xmin: Some(Attribute::new("west")),
+                xmax: Some(Attribute::new("east")),
+                ymin: Some(Attribute::new("south")),
+                ymax: Some(Attribute::new("north")),
+                zmin: Some(Attribute::new("bottom")),
+                zmax: Some(Attribute::new("top")),
+            },
+        };
+        let mut feature = Feature::from(geometry);
+        extractor.insert_bounds(&mut feature, aabb);
+        assert_eq!(number(&feature, "west"), Some(0.0));
+        assert_eq!(number(&feature, "top"), Some(1.0));
+        assert!(feature.attributes.get(&Attribute::new("xmin")).is_none());
+    }
+
+    #[test]
+    fn geometry_without_an_extent_has_no_bounds() {
+        assert!(Geometry::None.bounding_box().is_err());
+        let empty = LineString3D::from_coords(CoordinateFrame::Euclidean, Vec::<[f64; 3]>::new());
+        assert!(
+            Geometry::Euclidean3D(Euclidean3DGeometry::LineString(empty))
+                .bounding_box()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn a_non_finite_bound_is_not_representable() {
+        assert!(!bounds_are_finite(&Aabb::D2 {
+            min: [f64::NAN, 0.0],
+            max: [1.0, 1.0],
+        }));
+        assert!(!bounds_are_finite(&Aabb::D3 {
+            min: [0.0, 0.0, 0.0],
+            max: [1.0, 1.0, f64::INFINITY],
+        }));
+        assert!(bounds_are_finite(&Aabb::D3 {
+            min: [0.0, 0.0, 0.0],
+            max: [1.0, 1.0, 1.0],
+        }));
     }
 }

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.87"
+version = "0.2.88"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.277"
+version = "0.1.278"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
# Overview
This PR implements `BoundsExtractor` behind `new-geometry`.

## Conventions
- For 2D geometry, bounding box is also 2D (rectangle). This applies to 2.5D geometry as well.
