### PR TITLE
feat(engine): port OBJ Reader to new-geometry (PolygonMesh3D + MTL Phong appearances)

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.92"
+version = "0.2.93"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "futures",
  "once_cell",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "approx",
  "async-trait",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "Inflector",
  "approx",
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "bytes",
  "clap",
@@ -5058,7 +5058,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5101,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5129,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5142,7 +5142,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "approx",
  "bvh",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5287,7 +5287,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "bytes",
  "futures",
@@ -5335,7 +5335,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "bytes",
  "futures",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "ahash",
  "bytes",
@@ -5438,7 +5438,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.460"
+version = "0.0.461"
 dependencies = [
  "async-trait",
  "axum",
@@ -8204,7 +8204,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.282"
+version = "0.1.283"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.94"
+version = "0.2.95"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "futures",
  "once_cell",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "approx",
  "async-trait",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "Inflector",
  "approx",
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "bytes",
  "clap",
@@ -5058,7 +5058,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5101,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5129,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5142,7 +5142,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "approx",
  "bvh",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5287,7 +5287,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "bytes",
  "futures",
@@ -5335,7 +5335,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "bytes",
  "futures",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "ahash",
  "bytes",
@@ -5438,7 +5438,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.462"
+version = "0.0.463"
 dependencies = [
  "async-trait",
  "axum",
@@ -8204,7 +8204,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.284"
+version = "0.1.285"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "futures",
  "once_cell",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "approx",
  "async-trait",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "Inflector",
  "approx",
@@ -4870,7 +4870,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4890,7 +4890,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4957,7 +4957,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5006,7 +5006,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5017,7 +5017,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "bytes",
  "clap",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5100,7 +5100,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5141,7 +5141,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "approx",
  "bvh",
@@ -5177,7 +5177,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5212,7 +5212,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5250,7 +5250,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5286,7 +5286,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5303,7 +5303,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5317,7 +5317,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "bytes",
  "futures",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "bytes",
  "futures",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5367,7 +5367,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "ahash",
  "bytes",
@@ -5437,7 +5437,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.454"
+version = "0.0.455"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "futures",
  "once_cell",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "approx",
  "async-trait",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "Inflector",
  "approx",
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "bytes",
  "clap",
@@ -5058,7 +5058,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5101,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5129,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5142,7 +5142,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "approx",
  "bvh",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5287,7 +5287,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "bytes",
  "futures",
@@ -5335,7 +5335,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "bytes",
  "futures",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "ahash",
  "bytes",
@@ -5438,7 +5438,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.456"
+version = "0.0.457"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.89"
+version = "0.2.90"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "futures",
  "once_cell",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "approx",
  "async-trait",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "Inflector",
  "approx",
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "bytes",
  "clap",
@@ -5058,7 +5058,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5101,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5129,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5142,7 +5142,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "approx",
  "bvh",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5287,7 +5287,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "bytes",
  "futures",
@@ -5335,7 +5335,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "bytes",
  "futures",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "ahash",
  "bytes",
@@ -5438,7 +5438,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "async-trait",
  "axum",
@@ -8204,7 +8204,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.279"
+version = "0.1.280"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.95"
+version = "0.2.96"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "futures",
  "once_cell",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "approx",
  "async-trait",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "Inflector",
  "approx",
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "bytes",
  "clap",
@@ -5058,7 +5058,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5101,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5129,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5142,7 +5142,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "approx",
  "bvh",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5287,7 +5287,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "bytes",
  "futures",
@@ -5335,7 +5335,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "bytes",
  "futures",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "ahash",
  "bytes",
@@ -5438,7 +5438,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.463"
+version = "0.0.464"
 dependencies = [
  "async-trait",
  "axum",
@@ -8204,7 +8204,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.285"
+version = "0.1.286"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.463"
+version = "0.0.464"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.457"
+version = "0.0.458"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.454"
+version = "0.0.455"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.460"
+version = "0.0.461"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.462"
+version = "0.0.463"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/mesh.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/mesh.rs
@@ -590,10 +590,13 @@ mod tests {
         }
     }
 
-    // An OBJ-shaped PolygonMesh (Euclidean-frame face, Phong material with a
-    // file-backed diffuse_map and per-corner UVs, as produced by the new-geometry
-    // OBJ reader) must extract with its material carried through unchanged — this
-    // proves the writer needs no OBJ-specific changes.
+    // An OBJ-shaped PolygonMesh with a Phong material, a file-backed diffuse_map,
+    // and per-corner UVs, as produced by the new-geometry OBJ reader, must extract
+    // with its material carried through unchanged, which proves the writer needs
+    // no OBJ-specific changes. A CRS frame (EPSG:4979) is used here deliberately,
+    // since the writer skips Euclidean (model-space) meshes: the OBJ reader itself
+    // emits Euclidean geometry, but placing it on a CRS is the separate
+    // georeferencing concern, not what this test is checking.
     #[test]
     fn obj_shaped_polygon_mesh_with_phong_texture_is_extracted() {
         use reearth_flow_geometry::appearance::{

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/mesh.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/mesh.rs
@@ -590,6 +590,65 @@ mod tests {
         }
     }
 
+    // An OBJ-shaped PolygonMesh (Euclidean-frame face, Phong material with a
+    // file-backed diffuse_map and per-corner UVs, as produced by the new-geometry
+    // OBJ reader) must extract with its material carried through unchanged — this
+    // proves the writer needs no OBJ-specific changes.
+    #[test]
+    fn obj_shaped_polygon_mesh_with_phong_texture_is_extracted() {
+        use reearth_flow_geometry::appearance::{
+            ChannelId, Material, PhongMaterial, Raster, Sampler, Texture, ThemeId, UvSource,
+        };
+        use reearth_flow_geometry::polygon::Polygon3D;
+        use reearth_flow_geometry::polygon_mesh::PolygonMesh3D;
+        use std::str::FromStr;
+        use std::sync::Arc;
+
+        let frame = CoordinateFrame::Crs(EpsgCode::new(4979));
+        let ring = vec![
+            [35.0, 139.0, 0.0],
+            [35.0, 139.001, 0.0],
+            [35.001, 139.0, 0.0],
+        ];
+        let mut poly =
+            Polygon3D::from_rings(frame.clone(), ring, std::iter::empty::<Vec<[f64; 3]>>());
+        poly.set_appearance(
+            ThemeId(Arc::from("default")),
+            Material::Phong(PhongMaterial {
+                diffuse: [0.2, 0.4, 0.6],
+                specular: [0.0; 3],
+                emissive: [0.0; 3],
+                ambient_intensity: 0.0,
+                shininess: 0.0,
+                transparency: 0.0,
+                diffuse_map: Some(Texture {
+                    raster: Arc::new(Raster::Uri(
+                        reearth_flow_common::uri::Uri::from_str("file:///t.png").unwrap(),
+                    )),
+                    sampler: Sampler::default(),
+                    transform: None,
+                    uv_channel: ChannelId(0),
+                }),
+                emissive_map: None,
+                normal_map: None,
+            }),
+            Some(UvSource::Explicit(
+                vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]].into_boxed_slice(),
+            )),
+        )
+        .unwrap();
+        let mesh = PolygonMesh3D::from_polygons(frame, &[poly]).unwrap();
+        let geometry = Geometry::Euclidean3D(Euclidean3DGeometry::PolygonMesh(Box::new(mesh)));
+
+        let mut caches = ExtractCaches::default();
+        let extracted = extract(&geometry, &mut caches).expect("mesh extracts");
+        assert_eq!(
+            extracted.materials.len(),
+            1,
+            "OBJ-shaped Phong material flows through the writer"
+        );
+    }
+
     // A face whose canonical orientation is outward, stored in a lat-first frame
     // (EPSG:4979, orientation sign -1), must emit an ECEF normal that points away
     // from the earth's centre. Triangulating in ECEF gives this for free: the

--- a/engine/runtime/action-source/src/file/obj.rs
+++ b/engine/runtime/action-source/src/file/obj.rs
@@ -34,6 +34,10 @@ use crate::{
     },
 };
 
+#[cfg(feature = "new-geometry")]
+#[path = "obj_next.rs"]
+mod obj_next;
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ObjReaderFactory;
 
@@ -103,14 +107,14 @@ impl SourceFactory for ObjReaderFactory {
 }
 
 #[derive(Debug, Clone)]
-struct ObjReaderCompiledParam {
-    common: FileReaderCompiledParam,
-    parse_materials: bool,
-    material_file: Option<CompiledCode>,
-    triangulate: bool,
-    merge_groups: bool,
-    _include_normals: bool,
-    _include_texcoords: bool,
+pub(super) struct ObjReaderCompiledParam {
+    pub(super) common: FileReaderCompiledParam,
+    pub(super) parse_materials: bool,
+    pub(super) material_file: Option<CompiledCode>,
+    pub(super) triangulate: bool,
+    pub(super) merge_groups: bool,
+    pub(super) _include_normals: bool,
+    pub(super) _include_texcoords: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -188,48 +192,61 @@ impl Source for ObjReader {
             .await
             .map_err(Into::<BoxedError>::into)
     }
+
+    #[cfg(feature = "new-geometry")]
+    async fn start(
+        &mut self,
+        ctx: NodeContext,
+        sender: Sender<(Port, IngestionMessage)>,
+    ) -> Result<(), BoxedError> {
+        let storage_resolver = Arc::clone(&ctx.storage_resolver);
+        let content = get_content(&self.params.common, storage_resolver.clone()).await?;
+        obj_next::read(&ctx, storage_resolver, &content, &self.params, &sender)
+            .await
+            .map_err(Into::<BoxedError>::into)
+    }
 }
 
 #[derive(Debug, Clone, Default)]
-struct ObjData {
-    vertices: Vec<[f64; 3]>,
-    normals: Vec<[f64; 3]>,
-    texcoords: Vec<[f64; 3]>,
-    faces: Vec<Face>,
-    groups: Vec<String>,
-    objects: Vec<String>,
-    material_libs: Vec<String>,
-    comments: Vec<String>,
+pub(super) struct ObjData {
+    pub(super) vertices: Vec<[f64; 3]>,
+    pub(super) normals: Vec<[f64; 3]>,
+    pub(super) texcoords: Vec<[f64; 3]>,
+    pub(super) faces: Vec<Face>,
+    pub(super) groups: Vec<String>,
+    pub(super) objects: Vec<String>,
+    pub(super) material_libs: Vec<String>,
+    pub(super) comments: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
-struct Face {
-    vertices: Vec<FaceVertex>,
-    group: Option<String>,
-    object: Option<String>,
-    material: Option<String>,
-    smoothing_group: Option<String>,
+pub(super) struct Face {
+    pub(super) vertices: Vec<FaceVertex>,
+    pub(super) group: Option<String>,
+    pub(super) object: Option<String>,
+    pub(super) material: Option<String>,
+    pub(super) smoothing_group: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy)]
 #[allow(dead_code)]
-struct FaceVertex {
-    vertex_index: i32,
-    texture_index: Option<i32>,
-    normal_index: Option<i32>,
+pub(super) struct FaceVertex {
+    pub(super) vertex_index: i32,
+    pub(super) texture_index: Option<i32>,
+    pub(super) normal_index: Option<i32>,
 }
 
 #[derive(Debug, Clone, Default)]
-struct Material {
-    name: String,
-    ambient: Option<[f32; 3]>,
-    diffuse: Option<[f32; 3]>,
-    specular: Option<[f32; 3]>,
-    shininess: Option<f32>,
-    transparency: Option<f32>,
-    illumination: Option<i32>,
-    texture_map: Option<String>,
+pub(super) struct Material {
+    pub(super) name: String,
+    pub(super) ambient: Option<[f32; 3]>,
+    pub(super) diffuse: Option<[f32; 3]>,
+    pub(super) specular: Option<[f32; 3]>,
+    pub(super) shininess: Option<f32>,
+    pub(super) transparency: Option<f32>,
+    pub(super) illumination: Option<i32>,
+    pub(super) texture_map: Option<String>,
 }
 
 fn safe_f64_to_number(value: f64) -> serde_json::Number {
@@ -544,7 +561,7 @@ async fn read_obj(
     Ok(())
 }
 
-fn parse_obj_content(content: &Bytes) -> Result<ObjData, SourceError> {
+pub(super) fn parse_obj_content(content: &Bytes) -> Result<ObjData, SourceError> {
     let reader = BufReader::new(&content[..]);
     let mut obj_data = ObjData::default();
 
@@ -743,7 +760,7 @@ fn parse_face_vertex(vertex_str: &str) -> Result<FaceVertex, String> {
     })
 }
 
-async fn resolve_material_path(
+pub(super) async fn resolve_material_path(
     _ctx: &NodeContext,
     storage_resolver: Arc<reearth_flow_storage::resolve::StorageResolver>,
     obj_uri: &Uri,
@@ -781,7 +798,7 @@ async fn resolve_material_path(
     Ok(None)
 }
 
-async fn parse_mtl(
+pub(super) async fn parse_mtl(
     _ctx: &NodeContext,
     storage_resolver: Arc<reearth_flow_storage::resolve::StorageResolver>,
     mtl_uri: &Uri,

--- a/engine/runtime/action-source/src/file/obj.rs
+++ b/engine/runtime/action-source/src/file/obj.rs
@@ -247,6 +247,10 @@ pub(super) struct Material {
     pub(super) transparency: Option<f32>,
     pub(super) illumination: Option<i32>,
     pub(super) texture_map: Option<String>,
+    // Resolved absolute Uri of `map_Kd`, relative to the MTL file's directory.
+    // Populated by `parse_mtl`; used by the new-geometry appearance path.
+    #[cfg_attr(not(feature = "new-geometry"), allow(dead_code))]
+    pub(super) texture_uri: Option<Uri>,
 }
 
 fn safe_f64_to_number(value: f64) -> serde_json::Number {
@@ -798,6 +802,21 @@ pub(super) async fn resolve_material_path(
     Ok(None)
 }
 
+/// Resolves a `map_Kd` texture path to an absolute [`Uri`], relative to the
+/// MTL file's directory. Pure string join, no I/O.
+pub(super) fn join_texture_uri(mtl_uri: &Uri, tex: &str) -> Option<Uri> {
+    // Already absolute (has a scheme), e.g. `gs://bucket/tex.png`.
+    // Checked on the raw string: `Uri::from_str` always succeeds for
+    // relative paths too (it resolves them against CWD into a `file://`
+    // URI), so testing the parsed Uri's string would defeat this check.
+    if tex.contains("://") {
+        return Uri::from_str(tex).ok();
+    }
+    let base = mtl_uri.to_string();
+    let dir = base.rfind('/').map(|i| &base[..i]).unwrap_or(&base);
+    Uri::from_str(&format!("{dir}/{tex}")).ok()
+}
+
 pub(super) async fn parse_mtl(
     _ctx: &NodeContext,
     storage_resolver: Arc<reearth_flow_storage::resolve::StorageResolver>,
@@ -902,7 +921,9 @@ pub(super) async fn parse_mtl(
             }
             "map_Kd" if parts.len() >= 2 => {
                 if let Some(ref mut mat) = current_material {
-                    mat.texture_map = Some(parts[1..].join(" "));
+                    let tex = parts[1..].join(" ");
+                    mat.texture_uri = join_texture_uri(mtl_uri, &tex);
+                    mat.texture_map = Some(tex);
                 }
             }
             _ => {}
@@ -1170,6 +1191,14 @@ f 4 5 6
             safe_f64_to_number(f64::NEG_INFINITY),
             serde_json::Number::from(0)
         );
+    }
+
+    #[test]
+    fn map_kd_resolves_relative_to_mtl_dir() {
+        // join_texture_uri is the pure resolver extracted in Step 3.
+        let mtl = Uri::from_str("file:///data/models/scene.mtl").unwrap();
+        let uri = join_texture_uri(&mtl, "textures/brick.png").unwrap();
+        assert_eq!(uri.to_string(), "file:///data/models/textures/brick.png");
     }
 
     #[test]

--- a/engine/runtime/action-source/src/file/obj.rs
+++ b/engine/runtime/action-source/src/file/obj.rs
@@ -833,15 +833,19 @@ pub(super) async fn parse_mtl(
         .bytes()
         .await
         .map_err(|e| SourceError::ObjReader(format!("Failed to read MTL file content: {e}")))?;
-    let content = content.to_vec();
-    let reader = BufReader::new(&content[..]);
+    let content = String::from_utf8(content.to_vec())
+        .map_err(|e| SourceError::ObjReader(format!("Error reading MTL file: {e}")))?;
+    Ok(parse_mtl_str(&content, mtl_uri))
+}
+
+/// The sync line-parsing core of [`parse_mtl`], split out so the MTL-to-material
+/// mapping is unit-testable without a storage resolver (no I/O here; `parse_mtl`
+/// reads the MTL bytes and hands the decoded string to this function).
+pub(super) fn parse_mtl_str(content: &str, mtl_uri: &Uri) -> HashMap<String, Material> {
     let mut materials = HashMap::new();
     let mut current_material: Option<Material> = None;
 
-    for line in reader.lines() {
-        let line =
-            line.map_err(|e| SourceError::ObjReader(format!("Error reading MTL file: {e}")))?;
-
+    for line in content.lines() {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
             continue;
@@ -934,7 +938,7 @@ pub(super) async fn parse_mtl(
         materials.insert(mat.name.clone(), mat);
     }
 
-    Ok(materials)
+    materials
 }
 
 fn create_geometry_from_faces(

--- a/engine/runtime/action-source/src/file/obj.rs
+++ b/engine/runtime/action-source/src/file/obj.rs
@@ -812,9 +812,10 @@ pub(super) fn join_texture_uri(mtl_uri: &Uri, tex: &str) -> Option<Uri> {
     if tex.contains("://") {
         return Uri::from_str(tex).ok();
     }
-    let base = mtl_uri.to_string();
-    let dir = base.rfind('/').map(|i| &base[..i]).unwrap_or(&base);
-    Uri::from_str(&format!("{dir}/{tex}")).ok()
+    // Resolve relative to the MTL file's directory using the path-aware
+    // `parent` + `join` (separator-safe), rather than string-splitting on '/'
+    // which breaks on Windows where `Uri` normalizes to the OS separator.
+    mtl_uri.parent()?.join(tex).ok()
 }
 
 pub(super) async fn parse_mtl(

--- a/engine/runtime/action-source/src/file/obj_next.rs
+++ b/engine/runtime/action-source/src/file/obj_next.rs
@@ -412,6 +412,55 @@ mod tests {
     }
 
     #[test]
+    fn textured_face_with_uvs_gets_diffuse_map_and_flipped_v() {
+        use reearth_flow_geometry::appearance::{Material, UvSource};
+
+        // Third corner's vt (0.25, 0.75) should end up as [0.25, 1.0 - 0.75] = [0.25, 0.25].
+        let data = parse(
+            "v 0 0 0\nv 1 0 0\nv 0 1 0\nvt 0.1 0.2\nvt 0.9 0.3\nvt 0.25 0.75\nusemtl tex\nf 1/1 2/2 3/3\n",
+        );
+        let mut materials = std::collections::HashMap::new();
+        materials.insert(
+            "tex".to_string(),
+            super::super::Material {
+                name: "tex".to_string(),
+                diffuse: Some([1.0, 1.0, 1.0]),
+                texture_uri: Some(
+                    reearth_flow_common::uri::Uri::from_str("file:///t.png").unwrap(),
+                ),
+                ..Default::default()
+            },
+        );
+        let params = test_params();
+        let mesh = mesh_of(build_geometry(&data, &data.faces, &materials, &params));
+        let app = mesh.appearance().as_ref().expect("appearance attached");
+
+        match &app.materials()[0] {
+            Material::Phong(m) => {
+                assert!(
+                    m.diffuse_map.is_some(),
+                    "complete UVs -> textured diffuse_map"
+                )
+            }
+            other => panic!("expected Phong, got {other:?}"),
+        }
+
+        let uv_set = app.themes()[0]
+            .uv_sets
+            .iter()
+            .find_map(|set| match &set.uv {
+                UvSource::Explicit(coords) => Some(coords.clone()),
+                UvSource::WorldToTexture(_) => None,
+            })
+            .expect("an explicit UV set is present");
+        assert_eq!(
+            uv_set[2],
+            [0.25, 0.25],
+            "v flipped to 1 - v (top-left canonical origin)"
+        );
+    }
+
+    #[test]
     fn textured_face_without_uvs_falls_back_to_colour_only() {
         use reearth_flow_geometry::appearance::Material;
 

--- a/engine/runtime/action-source/src/file/obj_next.rs
+++ b/engine/runtime/action-source/src/file/obj_next.rs
@@ -1,13 +1,24 @@
 //! New-geometry path for the OBJ Reader. Reads OBJ faces into a single
-//! `PolygonMesh3D` per feature (Euclidean frame; OBJ is model-space). Appearance
-//! is added in a later step. Reuses `super`'s OBJ/MTL parser.
+//! `PolygonMesh3D` per feature (Euclidean frame; OBJ is model-space), attaching
+//! any `usemtl` material as a per-face `Material::Phong` appearance (with a
+//! `diffuse_map` texture and per-corner UVs when the face supplies them).
+//! Reuses `super`'s OBJ/MTL parser.
 
+use std::collections::HashMap;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use bytes::Bytes;
 use indexmap::IndexMap;
+use reearth_flow_common::uri::Uri;
 use reearth_flow_geometry::{
-    coordinate::CoordinateFrame, polygon::Polygon3D, polygon_mesh::PolygonMesh3D,
+    appearance::{
+        ChannelId, Material as GeoMaterial, PhongMaterial, Raster, Sampler, Texture, ThemeId,
+        UvSource,
+    },
+    coordinate::CoordinateFrame,
+    polygon::Polygon3D,
+    polygon_mesh::PolygonMesh3D,
     Euclidean3DGeometry, Geometry,
 };
 use reearth_flow_runtime::{
@@ -18,34 +29,103 @@ use reearth_flow_types::{Attribute, AttributeValue, Feature};
 use tokio::sync::mpsc::Sender;
 
 use crate::errors::SourceError;
+use crate::file::reader::runner::get_input_path;
 
 use super::{Face, ObjData, ObjReaderCompiledParam};
 
 pub(super) async fn read(
-    _ctx: &NodeContext,
-    _storage_resolver: Arc<reearth_flow_storage::resolve::StorageResolver>,
+    ctx: &NodeContext,
+    storage_resolver: Arc<reearth_flow_storage::resolve::StorageResolver>,
     content: &Bytes,
     params: &ObjReaderCompiledParam,
     sender: &Sender<(Port, IngestionMessage)>,
 ) -> Result<(), SourceError> {
     let obj_data = super::parse_obj_content(content)?;
+    let materials = load_materials(ctx, storage_resolver, &obj_data, params).await?;
 
     if params.merge_groups {
         let feature = build_feature(
             &obj_data,
             &obj_data.faces,
             group_attrs_merged(&obj_data),
+            &materials,
             params,
         );
         send_feature(sender, feature).await?;
     } else {
         for (name, faces) in group_faces(&obj_data) {
-            let feature =
-                build_feature(&obj_data, &faces, group_attrs_one(&obj_data, &name), params);
+            let feature = build_feature(
+                &obj_data,
+                &faces,
+                group_attrs_one(&obj_data, &name),
+                &materials,
+                params,
+            );
             send_feature(sender, feature).await?;
         }
     }
     Ok(())
+}
+
+/// Load the OBJ's materials, mirroring old-world `read_obj`'s material-loading
+/// block: an explicit `material_file` param overrides any `mtllib` directives in
+/// the OBJ itself; otherwise every referenced `mtllib` is parsed and merged.
+/// Returns an empty map when `parse_materials` is off, or if resolution fails
+/// (a warning is logged; a missing/bad MTL never fails the read).
+async fn load_materials(
+    ctx: &NodeContext,
+    storage_resolver: Arc<reearth_flow_storage::resolve::StorageResolver>,
+    obj_data: &ObjData,
+    params: &ObjReaderCompiledParam,
+) -> Result<HashMap<String, super::Material>, SourceError> {
+    if !params.parse_materials {
+        return Ok(HashMap::new());
+    }
+
+    let obj_uri = get_input_path(&params.common)
+        .map_err(SourceError::ObjReader)?
+        .unwrap_or_else(|| Uri::from_str("file://./unknown.obj").unwrap());
+
+    let mut all_materials = HashMap::new();
+
+    if let Some(ref material_file) = params.material_file {
+        let external_mtl = material_file
+            .eval_string_env_only(ctx.env_vars.clone())
+            .map_err(|e| {
+                SourceError::ObjReader(format!("Failed to evaluate material_file: {e:?}"))
+            })?;
+        let mtl_uri =
+            super::resolve_material_path(ctx, storage_resolver.clone(), &obj_uri, &external_mtl)
+                .await?;
+        if let Some(mtl_uri) = mtl_uri {
+            match super::parse_mtl(ctx, storage_resolver.clone(), &mtl_uri).await {
+                Ok(mats) => all_materials.extend(mats),
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to parse external material file {}: {}",
+                        external_mtl,
+                        e
+                    );
+                }
+            }
+        }
+    } else if !obj_data.material_libs.is_empty() {
+        for mtl_lib in &obj_data.material_libs {
+            let mtl_uri =
+                super::resolve_material_path(ctx, storage_resolver.clone(), &obj_uri, mtl_lib)
+                    .await?;
+            if let Some(mtl_uri) = mtl_uri {
+                match super::parse_mtl(ctx, storage_resolver.clone(), &mtl_uri).await {
+                    Ok(mats) => all_materials.extend(mats),
+                    Err(e) => {
+                        tracing::warn!("Failed to parse material file {}: {}", mtl_lib, e);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(all_materials)
 }
 
 /// Group faces by object (fallback group, then "default"), preserving the old
@@ -63,22 +143,37 @@ fn group_faces(obj_data: &ObjData) -> Vec<(String, Vec<Face>)> {
     groups.into_iter().collect()
 }
 
-/// Convert a set of OBJ faces into one `PolygonMesh3D` geometry (bare in this task).
-fn faces_to_geometry(
+/// Convert a set of OBJ faces into one `PolygonMesh3D` geometry, attaching each
+/// face's `usemtl` material (if any) as a `Material::Phong` appearance before
+/// the faces are merged into the mesh.
+fn build_geometry(
     obj_data: &ObjData,
     faces: &[Face],
-    _params: &ObjReaderCompiledParam,
+    materials: &HashMap<String, super::Material>,
+    params: &ObjReaderCompiledParam,
 ) -> Geometry {
+    let theme = ThemeId(Arc::from("default"));
     let mut polygons: Vec<Polygon3D> = Vec::new();
     for face in faces {
         let Some(ring) = face_ring(obj_data, face) else {
             continue;
         };
-        polygons.push(Polygon3D::from_rings(
+        let mut polygon = Polygon3D::from_rings(
             CoordinateFrame::Euclidean,
             ring,
             std::iter::empty::<Vec<[f64; 3]>>(),
-        ));
+        );
+
+        if let Some(mat) = face.material.as_ref().and_then(|n| materials.get(n)) {
+            let uv = face_uv(obj_data, face, params);
+            let material = to_phong(mat, uv.is_some());
+            if let Err(e) =
+                polygon.set_appearance(theme.clone(), material, uv.map(UvSource::Explicit))
+            {
+                tracing::warn!("OBJ: skipping face appearance: {e:?}");
+            }
+        }
+        polygons.push(polygon);
     }
     if polygons.is_empty() {
         return Geometry::None;
@@ -90,6 +185,68 @@ fn faces_to_geometry(
             Geometry::None
         }
     }
+}
+
+/// Per-corner UVs for a face (`v` flipped to `1 - v`, top-left canonical
+/// origin), or `None` if texcoords are disabled or any corner lacks a valid
+/// `vt` index.
+fn face_uv(
+    obj_data: &ObjData,
+    face: &Face,
+    params: &ObjReaderCompiledParam,
+) -> Option<Box<[[f64; 2]]>> {
+    if !params._include_texcoords {
+        return None;
+    }
+    let mut uv = Vec::with_capacity(face.vertices.len());
+    for v in &face.vertices {
+        let ti = v.texture_index?;
+        let idx = if ti > 0 {
+            (ti - 1) as usize
+        } else {
+            (obj_data.texcoords.len() as i32 + ti) as usize
+        };
+        let t = obj_data.texcoords.get(idx)?;
+        uv.push([t[0], 1.0 - t[1]]);
+    }
+    Some(uv.into_boxed_slice())
+}
+
+/// Map an OBJ/MTL `Material` to a `Material::Phong`. `with_texture` gates the
+/// `diffuse_map` (only attach when the face supplies UVs); a textured Phong
+/// without a UV set is rejected by `Polygon3D::set_appearance`, so a face
+/// lacking UVs always gets a colour-only material.
+///
+/// `transparency`: OBJ `d`/`Tr` is opacity (1 = opaque) but the model's
+/// `transparency` is 0 = opaque, so this stores `1 - d`. The current MTL parser
+/// stores whatever value follows `d` *or* `Tr` into the same field without
+/// inverting for `Tr` (whose direction is already opposite `d`), so this is a
+/// known approximation inherited from the existing parser, not new here.
+fn to_phong(mat: &super::Material, with_texture: bool) -> GeoMaterial {
+    let diffuse_map = if with_texture {
+        mat.texture_uri.as_ref().map(|uri| Texture {
+            raster: Arc::new(Raster::Uri(uri.clone())),
+            sampler: Sampler::default(),
+            transform: None,
+            uv_channel: ChannelId(0),
+        })
+    } else {
+        None
+    };
+    GeoMaterial::Phong(PhongMaterial {
+        diffuse: mat.diffuse.unwrap_or([1.0, 1.0, 1.0]),
+        specular: mat.specular.unwrap_or([0.0, 0.0, 0.0]),
+        emissive: [0.0, 0.0, 0.0],
+        ambient_intensity: mat
+            .ambient
+            .map(|a| (a[0] + a[1] + a[2]) / 3.0)
+            .unwrap_or(0.0),
+        shininess: mat.shininess.unwrap_or(0.0),
+        transparency: mat.transparency.map(|d| 1.0 - d).unwrap_or(0.0),
+        diffuse_map,
+        emissive_map: None,
+        normal_map: None,
+    })
 }
 
 /// Resolve a face's vertex ring to `[f64;3]` coordinates (OBJ 1-based / negative
@@ -111,6 +268,7 @@ fn build_feature(
     obj_data: &ObjData,
     faces: &[Face],
     mut attributes: IndexMap<Attribute, AttributeValue>,
+    materials: &HashMap<String, super::Material>,
     params: &ObjReaderCompiledParam,
 ) -> Feature {
     attributes.insert(
@@ -119,7 +277,7 @@ fn build_feature(
     );
     Feature::new_with_attributes_and_geometry(
         attributes,
-        faces_to_geometry(obj_data, faces, params),
+        build_geometry(obj_data, faces, materials, params),
     )
 }
 
@@ -211,13 +369,71 @@ mod tests {
     fn quad_face_becomes_one_polygon_mesh_face_euclidean() {
         let data = parse("v 0 0 0\nv 1 0 0\nv 1 1 0\nv 0 1 0\nf 1 2 3 4\n");
         let params = test_params();
-        let mesh = mesh_of(faces_to_geometry(&data, &data.faces, &params));
+        let mesh = mesh_of(build_geometry(
+            &data,
+            &data.faces,
+            &std::collections::HashMap::new(),
+            &params,
+        ));
         assert_eq!(*mesh.frame(), CoordinateFrame::Euclidean);
         assert_eq!(
             mesh.num_faces(),
             1,
             "one quad face preserved as one n-gon face"
         );
-        assert!(mesh.appearance().is_none(), "no materials yet in Task 1");
+        assert!(
+            mesh.appearance().is_none(),
+            "no materials used by this face"
+        );
+    }
+
+    #[test]
+    fn face_with_material_gets_phong_appearance() {
+        use reearth_flow_geometry::appearance::Material;
+
+        let data = parse("v 0 0 0\nv 1 0 0\nv 0 1 0\nusemtl red\nf 1 2 3\n");
+        let mut materials = std::collections::HashMap::new();
+        materials.insert(
+            "red".to_string(),
+            super::super::Material {
+                name: "red".to_string(),
+                diffuse: Some([0.8, 0.1, 0.1]),
+                ..Default::default()
+            },
+        );
+        let params = test_params();
+        let mesh = mesh_of(build_geometry(&data, &data.faces, &materials, &params));
+        let app = mesh.appearance().as_ref().expect("appearance attached");
+        assert_eq!(app.materials().len(), 1);
+        match &app.materials()[0] {
+            Material::Phong(m) => assert_eq!(m.diffuse, [0.8, 0.1, 0.1]),
+            other => panic!("expected Phong, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn textured_face_without_uvs_falls_back_to_colour_only() {
+        use reearth_flow_geometry::appearance::Material;
+
+        // Material has a texture Uri but the face has no vt indices.
+        let data = parse("v 0 0 0\nv 1 0 0\nv 0 1 0\nusemtl tex\nf 1 2 3\n");
+        let mut materials = std::collections::HashMap::new();
+        materials.insert(
+            "tex".to_string(),
+            super::super::Material {
+                name: "tex".to_string(),
+                diffuse: Some([1.0, 1.0, 1.0]),
+                texture_uri: Some(
+                    reearth_flow_common::uri::Uri::from_str("file:///t.png").unwrap(),
+                ),
+                ..Default::default()
+            },
+        );
+        let params = test_params();
+        let mesh = mesh_of(build_geometry(&data, &data.faces, &materials, &params));
+        match &mesh.appearance().as_ref().unwrap().materials()[0] {
+            Material::Phong(m) => assert!(m.diffuse_map.is_none(), "no UVs -> colour-only"),
+            other => panic!("expected Phong, got {other:?}"),
+        }
     }
 }

--- a/engine/runtime/action-source/src/file/obj_next.rs
+++ b/engine/runtime/action-source/src/file/obj_next.rs
@@ -460,8 +460,17 @@ mod tests {
         );
     }
 
+    // detailed.obj's faces with `vt` indices use materials without `map_Kd`, and
+    // its one `map_Kd` material (green_material) is applied to a face lacking
+    // `vt`, so `to_phong`'s `with_texture` gating never attaches a `diffuse_map`
+    // here. This test therefore verifies a real OBJ+MTL pair reads into a
+    // PolygonMesh carrying a colour-only Phong appearance, not a textured one;
+    // the genuinely-textured (diffuse_map + UV-flip) path is covered by the
+    // synthetic `textured_face_with_uvs_gets_diffuse_map_and_flipped_v` test above.
     #[test]
-    fn real_detailed_obj_reads_as_textured_polygon_mesh() {
+    fn real_detailed_obj_reads_as_polygon_mesh_with_material() {
+        use reearth_flow_geometry::appearance::Material;
+
         let bytes = include_bytes!("../../../tests/fixture/testdata/obj/detailed.obj");
         let data = super::super::parse_obj_content(&bytes::Bytes::from_static(bytes)).unwrap();
         // Materials from the sibling materials.mtl, resolved relative to the mtl dir.
@@ -472,7 +481,17 @@ mod tests {
         let params = test_params();
         let mesh = mesh_of(build_geometry(&data, &data.faces, &materials, &params));
         assert!(mesh.num_faces() > 0);
-        assert!(mesh.appearance().is_some(), "detailed.obj uses materials");
+        let appearance = mesh
+            .appearance()
+            .as_ref()
+            .expect("detailed.obj uses materials");
+        assert!(
+            appearance
+                .materials()
+                .iter()
+                .any(|m| matches!(m, Material::Phong(_))),
+            "detailed.obj's usemtl materials should map to at least one Phong appearance"
+        );
     }
 
     #[test]

--- a/engine/runtime/action-source/src/file/obj_next.rs
+++ b/engine/runtime/action-source/src/file/obj_next.rs
@@ -1,0 +1,223 @@
+//! New-geometry path for the OBJ Reader. Reads OBJ faces into a single
+//! `PolygonMesh3D` per feature (Euclidean frame; OBJ is model-space). Appearance
+//! is added in a later step. Reuses `super`'s OBJ/MTL parser.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use indexmap::IndexMap;
+use reearth_flow_geometry::{
+    coordinate::CoordinateFrame, polygon::Polygon3D, polygon_mesh::PolygonMesh3D,
+    Euclidean3DGeometry, Geometry,
+};
+use reearth_flow_runtime::{
+    executor_operation::NodeContext,
+    node::{IngestionMessage, Port, FEATURES_PORT},
+};
+use reearth_flow_types::{Attribute, AttributeValue, Feature};
+use tokio::sync::mpsc::Sender;
+
+use crate::errors::SourceError;
+
+use super::{Face, ObjData, ObjReaderCompiledParam};
+
+pub(super) async fn read(
+    _ctx: &NodeContext,
+    _storage_resolver: Arc<reearth_flow_storage::resolve::StorageResolver>,
+    content: &Bytes,
+    params: &ObjReaderCompiledParam,
+    sender: &Sender<(Port, IngestionMessage)>,
+) -> Result<(), SourceError> {
+    let obj_data = super::parse_obj_content(content)?;
+
+    if params.merge_groups {
+        let feature = build_feature(
+            &obj_data,
+            &obj_data.faces,
+            group_attrs_merged(&obj_data),
+            params,
+        );
+        send_feature(sender, feature).await?;
+    } else {
+        for (name, faces) in group_faces(&obj_data) {
+            let feature =
+                build_feature(&obj_data, &faces, group_attrs_one(&obj_data, &name), params);
+            send_feature(sender, feature).await?;
+        }
+    }
+    Ok(())
+}
+
+/// Group faces by object (fallback group, then "default"), preserving the old
+/// reader's grouping.
+fn group_faces(obj_data: &ObjData) -> Vec<(String, Vec<Face>)> {
+    let mut groups: IndexMap<String, Vec<Face>> = IndexMap::new();
+    for face in &obj_data.faces {
+        let key = face
+            .object
+            .clone()
+            .or_else(|| face.group.clone())
+            .unwrap_or_else(|| "default".to_string());
+        groups.entry(key).or_default().push(face.clone());
+    }
+    groups.into_iter().collect()
+}
+
+/// Convert a set of OBJ faces into one `PolygonMesh3D` geometry (bare in this task).
+fn faces_to_geometry(
+    obj_data: &ObjData,
+    faces: &[Face],
+    _params: &ObjReaderCompiledParam,
+) -> Geometry {
+    let mut polygons: Vec<Polygon3D> = Vec::new();
+    for face in faces {
+        let Some(ring) = face_ring(obj_data, face) else {
+            continue;
+        };
+        polygons.push(Polygon3D::from_rings(
+            CoordinateFrame::Euclidean,
+            ring,
+            std::iter::empty::<Vec<[f64; 3]>>(),
+        ));
+    }
+    if polygons.is_empty() {
+        return Geometry::None;
+    }
+    match PolygonMesh3D::from_polygons(CoordinateFrame::Euclidean, &polygons) {
+        Ok(mesh) => Geometry::Euclidean3D(Euclidean3DGeometry::PolygonMesh(Box::new(mesh))),
+        Err(e) => {
+            tracing::warn!("OBJ: failed to build PolygonMesh, dropping feature: {e:?}");
+            Geometry::None
+        }
+    }
+}
+
+/// Resolve a face's vertex ring to `[f64;3]` coordinates (OBJ 1-based / negative
+/// indices), or `None` if any index is out of bounds or the ring has < 3 vertices.
+fn face_ring(obj_data: &ObjData, face: &Face) -> Option<Vec<[f64; 3]>> {
+    let mut ring = Vec::with_capacity(face.vertices.len());
+    for v in &face.vertices {
+        let idx = if v.vertex_index > 0 {
+            (v.vertex_index - 1) as usize
+        } else {
+            (obj_data.vertices.len() as i32 + v.vertex_index) as usize
+        };
+        ring.push(*obj_data.vertices.get(idx)?);
+    }
+    (ring.len() >= 3).then_some(ring)
+}
+
+fn build_feature(
+    obj_data: &ObjData,
+    faces: &[Face],
+    mut attributes: IndexMap<Attribute, AttributeValue>,
+    params: &ObjReaderCompiledParam,
+) -> Feature {
+    attributes.insert(
+        Attribute::new("faceCount"),
+        AttributeValue::Number(serde_json::Number::from(faces.len())),
+    );
+    Feature::new_with_attributes_and_geometry(
+        attributes,
+        faces_to_geometry(obj_data, faces, params),
+    )
+}
+
+fn base_attrs() -> IndexMap<Attribute, AttributeValue> {
+    let mut a = IndexMap::new();
+    a.insert(
+        Attribute::new("source"),
+        AttributeValue::String("OBJ".to_string()),
+    );
+    a
+}
+
+fn group_attrs_one(obj_data: &ObjData, name: &str) -> IndexMap<Attribute, AttributeValue> {
+    let mut a = base_attrs();
+    let key = if obj_data.objects.iter().any(|o| o == name) {
+        "object"
+    } else {
+        "group"
+    };
+    a.insert(
+        Attribute::new(key),
+        AttributeValue::String(name.to_string()),
+    );
+    a
+}
+
+fn group_attrs_merged(obj_data: &ObjData) -> IndexMap<Attribute, AttributeValue> {
+    let mut a = base_attrs();
+    let arr = |v: &[String]| {
+        AttributeValue::Array(v.iter().cloned().map(AttributeValue::String).collect())
+    };
+    if !obj_data.objects.is_empty() {
+        a.insert(Attribute::new("objects"), arr(&obj_data.objects));
+    }
+    if !obj_data.groups.is_empty() {
+        a.insert(Attribute::new("groups"), arr(&obj_data.groups));
+    }
+    a
+}
+
+async fn send_feature(
+    sender: &Sender<(Port, IngestionMessage)>,
+    feature: Feature,
+) -> Result<(), SourceError> {
+    sender
+        .send((
+            FEATURES_PORT.clone(),
+            IngestionMessage::OperationEvent { feature },
+        ))
+        .await
+        .map_err(|e| SourceError::ObjReader(format!("Failed to send feature: {e}")))
+}
+
+#[cfg(test)]
+fn test_params() -> ObjReaderCompiledParam {
+    use crate::file::reader::runner::FileReaderCompiledParam;
+
+    ObjReaderCompiledParam {
+        parse_materials: false,
+        material_file: None,
+        triangulate: false,
+        merge_groups: false,
+        _include_normals: true,
+        _include_texcoords: true,
+        common: FileReaderCompiledParam {
+            dataset: None,
+            inline: None,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Build ObjData directly via the shared parser.
+    fn parse(obj: &str) -> super::super::ObjData {
+        super::super::parse_obj_content(&bytes::Bytes::copy_from_slice(obj.as_bytes())).unwrap()
+    }
+
+    fn mesh_of(geom: Geometry) -> reearth_flow_geometry::polygon_mesh::PolygonMesh3D {
+        match geom {
+            Geometry::Euclidean3D(Euclidean3DGeometry::PolygonMesh(m)) => *m,
+            other => panic!("expected Euclidean3D PolygonMesh, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn quad_face_becomes_one_polygon_mesh_face_euclidean() {
+        let data = parse("v 0 0 0\nv 1 0 0\nv 1 1 0\nv 0 1 0\nf 1 2 3 4\n");
+        let params = test_params();
+        let mesh = mesh_of(faces_to_geometry(&data, &data.faces, &params));
+        assert_eq!(*mesh.frame(), CoordinateFrame::Euclidean);
+        assert_eq!(
+            mesh.num_faces(),
+            1,
+            "one quad face preserved as one n-gon face"
+        );
+        assert!(mesh.appearance().is_none(), "no materials yet in Task 1");
+    }
+}

--- a/engine/runtime/action-source/src/file/obj_next.rs
+++ b/engine/runtime/action-source/src/file/obj_next.rs
@@ -461,6 +461,21 @@ mod tests {
     }
 
     #[test]
+    fn real_detailed_obj_reads_as_textured_polygon_mesh() {
+        let bytes = include_bytes!("../../../tests/fixture/testdata/obj/detailed.obj");
+        let data = super::super::parse_obj_content(&bytes::Bytes::from_static(bytes)).unwrap();
+        // Materials from the sibling materials.mtl, resolved relative to the mtl dir.
+        let mtl = include_str!("../../../tests/fixture/testdata/obj/materials.mtl");
+        let mtl_uri =
+            reearth_flow_common::uri::Uri::from_str("file:///fixture/obj/materials.mtl").unwrap();
+        let materials = super::super::parse_mtl_str(mtl, &mtl_uri);
+        let params = test_params();
+        let mesh = mesh_of(build_geometry(&data, &data.faces, &materials, &params));
+        assert!(mesh.num_faces() > 0);
+        assert!(mesh.appearance().is_some(), "detailed.obj uses materials");
+    }
+
+    #[test]
     fn textured_face_without_uvs_falls_back_to_colour_only() {
         use reearth_flow_geometry::appearance::Material;
 

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.92"
+version = "0.2.93"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.95"
+version = "0.2.96"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.89"
+version = "0.2.90"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.94"
+version = "0.2.95"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.282"
+version = "0.1.283"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.285"
+version = "0.1.286"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.284"
+version = "0.1.285"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.279"
+version = "0.1.280"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
## What

Ports the **OBJ Reader** to the `new-geometry` feature flag (next after GeoJSON #2254, GeoPackage #2255, and glTF #2287). Previously the reader had no `#[cfg(feature = "new-geometry")]` `start`, so under the flag it hit the "not yet ported" default.

It reads OBJ mesh geometry **and** MTL appearances into the new model, and needs **no Cesium writer changes** — OBJ's shape is exactly what the writer already consumes from CityGML.

## Design decisions & mappings

### Geometry: `PolygonMesh3D`
OBJ faces are arbitrary polygons (n-gons/quads), so the idiomatic target is `PolygonMesh3D` (faces preserved), not `TriangularMesh3D`. Each OBJ face becomes one `Polygon3D`; a feature's faces merge into one `PolygonMesh3D::from_polygons` (shared vertex pool). This mirrors the CityGML parser's `PolygonMesh3D` path — the established new-geometry convention for arbitrary polygon surfaces. Frame is always `CoordinateFrame::Euclidean` (OBJ is model-space, no CRS).

### Appearance: `Material::Phong` + file textures
MTL materials map to `Material::Phong` (Kd→diffuse, Ks→specular, Ka→ambient_intensity, Ns→shininess, `d`/`Tr`→transparency, `map_Kd`→`diffuse_map`). The `map_Kd` path is resolved (relative to the MTL directory) to a `Raster::Uri` file texture. Per-corner UVs come from `vt` indices with **`v` flipped to `1 - v`** (top-left canonical origin, matching CityGML). Each face's appearance is set before `from_polygons` merges them into a `PerFace`-bound mesh appearance. A textured material on a face lacking UVs (or with `includeTexcoords=false`) falls back to colour-only. This is the same Phong + `Raster::Uri` shape the CityGML path already produces, so the Cesium 3D Tiles writer consumes it unchanged (verified by a round-trip test).

### Per-feature semantics
One feature per **object** (fallback group, then `default`), or one merged feature with `mergeGroups`. Attributes: `source="OBJ"`, `object`/`objects` or `group`/`groups`, `faceCount`. Material info now lives on the geometry appearance; the old `materialProperties`/`materials` attribute dump is dropped in the new path.

### Params
`parseMaterials`, `materialFile`, `mergeGroups` unchanged. `includeTexcoords` gates UV/texture attachment. `includeNormals` is a no-op (mesh carries no normals; the writer computes flat normals) and `triangulate` no longer changes the output type (the writer triangulates n-gons) — both kept for schema stability.

## Limitations (documented, out of scope)
- **Georeferencing**: OBJ is model-space (Euclidean); the Cesium writer skips non-CRS meshes, so OBJ → 3D Tiles yields an empty tileset until a placement step exists (same class as glTF #2293). Correctness is verified at the reader level.
- Textures render only for **local** OBJ inputs (`Raster::Uri{File}`).
- Vertex normals (`vn`) / smoothing groups (`s`) dropped; non-planar n-gons triangulate approximately; `map_Kd` option flags unsupported (pre-existing parser limitation).

## Tests
Reader (`obj_next`): n-gon face → `PolygonMesh3D` (faces preserved, Euclidean); per-face Phong appearance from MTL; textured happy path (`diffuse_map` + `1-v` flip value); textured-without-UV → colour-only fallback; real `detailed.obj`/`materials.mtl` read. Writer: a round-trip test proving an OBJ-shaped `PolygonMesh3D` + Phong + `Raster::Uri` texture flows through `extract` unchanged (no writer code changed). `parse_mtl` refactored to a testable sync `parse_mtl_str` core (old-world behavior preserved).

Per the migration's CI model these compile/lint under `new-geometry` but aren't run by the suite; run locally with `cargo test -p reearth-flow-action-source -p reearth-flow-action-sink --features new-geometry`.

## Verification
- new world: `reearth-flow-action-source` 45/45 + `reearth-flow-action-sink` 92/92 pass
- clippy clean under `--features new-geometry` and old-world (`-D warnings`); old-world OBJ tests unchanged/green; `cargo fmt` applied; engine version bumped to 0.0.455.
