### PR TITLE
fix(api): preserve parameter order in Action by using json.RawMessage

### DIFF
--- a/server/api/internal/app/actions.go
+++ b/server/api/internal/app/actions.go
@@ -24,11 +24,10 @@ const (
 )
 
 type Action struct {
-	// Parameter is passed through as raw bytes rather than decoded into a map.
-	// Property order in a JSON Schema drives the field order the UI renders, and
-	// encoding/json sorts map keys alphabetically on marshal — decoding it would
-	// silently reorder every action's parameters.
-	Parameter   json.RawMessage `json:"parameter"`
+	// Parameter is the action's JSON Schema, forwarded verbatim to preserve
+	// property order — encoding/json sorts map keys, which would reorder the
+	// fields the UI renders. Guarded by TestGetActionDetailsPreservesParameterOrder.
+	Parameter   json.RawMessage `json:"parameter" swaggertype:"object"`
 	Name        string          `json:"name"`
 	Type        ActionType      `json:"type"`
 	Description string          `json:"description"`

--- a/server/api/internal/app/actions.go
+++ b/server/api/internal/app/actions.go
@@ -24,15 +24,19 @@ const (
 )
 
 type Action struct {
-	Parameter   map[string]interface{} `json:"parameter"`
-	Name        string                 `json:"name"`
-	Type        ActionType             `json:"type"`
-	Description string                 `json:"description"`
-	InputPorts  []string               `json:"inputPorts"`
-	OutputPorts []string               `json:"outputPorts"`
-	Categories  []string               `json:"categories"`
-	Tags        []string               `json:"tags"`
-	Builtin     bool                   `json:"builtin"`
+	// Parameter is passed through as raw bytes rather than decoded into a map.
+	// Property order in a JSON Schema drives the field order the UI renders, and
+	// encoding/json sorts map keys alphabetically on marshal — decoding it would
+	// silently reorder every action's parameters.
+	Parameter   json.RawMessage `json:"parameter"`
+	Name        string          `json:"name"`
+	Type        ActionType      `json:"type"`
+	Description string          `json:"description"`
+	InputPorts  []string        `json:"inputPorts"`
+	OutputPorts []string        `json:"outputPorts"`
+	Categories  []string        `json:"categories"`
+	Tags        []string        `json:"tags"`
+	Builtin     bool            `json:"builtin"`
 }
 
 func (a *Action) Validate() error {

--- a/server/api/internal/app/actions_test.go
+++ b/server/api/internal/app/actions_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -273,6 +274,86 @@ func TestGetActionDetails(t *testing.T) {
 			}
 		})
 	}
+}
+
+// jsonKeyOrder returns the keys of a JSON object in the order they appear in raw.
+func jsonKeyOrder(t *testing.T, raw json.RawMessage) []string {
+	t.Helper()
+
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	tok, err := dec.Token()
+	assert.NoError(t, err)
+	assert.Equal(t, json.Delim('{'), tok)
+
+	var keys []string
+	for dec.More() {
+		key, err := dec.Token()
+		if !assert.NoError(t, err) {
+			break
+		}
+		keys = append(keys, key.(string))
+
+		var skip json.RawMessage
+		if !assert.NoError(t, dec.Decode(&skip)) {
+			break
+		}
+	}
+	return keys
+}
+
+// Property order in a JSON Schema is meaningful — it drives the field order the
+// UI renders. Decoding Action.Parameter into a map would let encoding/json sort
+// the keys alphabetically on the way out, so it is kept as raw bytes.
+func TestGetActionDetailsPreservesParameterOrder(t *testing.T) {
+	// Deliberately not in alphabetical order, at both the top level and nested.
+	const parameter = `{` +
+		`"type":"object",` +
+		`"properties":{` +
+		`"method":{"type":"string"},` +
+		`"aggregateAttributes":{"type":"object","properties":{"newAttribute":{"type":"string"},"attribute":{"type":"string"}}},` +
+		`"calculationValue":{"type":"integer"},` +
+		`"calculation":{"type":"string"}` +
+		`}}`
+
+	resetTestData()
+	actionsDataMap[""] = ActionsData{Actions: []Action{{
+		Name:      "CSV Reader",
+		Type:      ActionTypeSource,
+		Parameter: json.RawMessage(parameter),
+	}}}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/actions/:id")
+	c.SetParamNames("id")
+	c.SetParamValues("CSV Reader")
+
+	assert.NoError(t, getActionDetails(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response Action
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+
+	var served map[string]json.RawMessage
+	assert.NoError(t, json.Unmarshal(response.Parameter, &served))
+
+	assert.Equal(t,
+		[]string{"method", "aggregateAttributes", "calculationValue", "calculation"},
+		jsonKeyOrder(t, served["properties"]),
+		"top-level property order must survive the round trip")
+
+	var props map[string]json.RawMessage
+	assert.NoError(t, json.Unmarshal(served["properties"], &props))
+
+	var nested map[string]json.RawMessage
+	assert.NoError(t, json.Unmarshal(props["aggregateAttributes"], &nested))
+
+	assert.Equal(t,
+		[]string{"newAttribute", "attribute"},
+		jsonKeyOrder(t, nested["properties"]),
+		"nested property order must survive the round trip")
 }
 
 func TestGetActionDetailsNotFound(t *testing.T) {


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
