### PR TITLE
fix(engine): new-geom single elevation

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.89"
+version = "0.2.90"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "futures",
  "once_cell",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "approx",
  "async-trait",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "Inflector",
  "approx",
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "bytes",
  "clap",
@@ -5058,7 +5058,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5101,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5129,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5142,7 +5142,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "approx",
  "bvh",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5287,7 +5287,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "bytes",
  "futures",
@@ -5335,7 +5335,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "bytes",
  "futures",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "ahash",
  "bytes",
@@ -5438,7 +5438,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.457"
+version = "0.0.458"
 dependencies = [
  "async-trait",
  "axum",
@@ -8204,7 +8204,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.279"
+version = "0.1.280"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.457"
+version = "0.0.458"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/action-processor/src/geometry/bounds_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/bounds_extractor.rs
@@ -225,8 +225,7 @@ impl BoundsExtractor {
     }
 
     /// Write the box onto the feature as one attribute per bound. A 2D box
-    /// writes no z attributes: the optional elevation a 2D-embedded geometry
-    /// lies at is not part of its box.
+    /// writes no z attributes.
     #[cfg(feature = "new-geometry")]
     fn insert_bounds(&self, feature: &mut Feature, aabb: Aabb) {
         let (min, max, z) = match aabb {

--- a/engine/runtime/action-processor/src/geometry/bounds_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/bounds_extractor.rs
@@ -225,8 +225,8 @@ impl BoundsExtractor {
     }
 
     /// Write the box onto the feature as one attribute per bound. A 2D box
-    /// writes no z attributes: the optional per-vertex elevation of a
-    /// 2D-embedded geometry is not part of its box.
+    /// writes no z attributes: the optional elevation a 2D-embedded geometry
+    /// lies at is not part of its box.
     #[cfg(feature = "new-geometry")]
     fn insert_bounds(&self, feature: &mut Feature, aabb: Aabb) {
         let (min, max, z) = match aabb {

--- a/engine/runtime/action-processor/src/geometry/bounds_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/bounds_extractor.rs
@@ -478,9 +478,10 @@ mod tests {
 
     #[test]
     fn elevation_of_a_two_dimensional_geometry_is_not_folded_in() {
-        let line = LineString2D::from_coords_with_elevation(
+        let line = LineString2D::from_coords_at_elevation(
             CoordinateFrame::Euclidean,
-            [[1.0, 2.0, 10.0], [3.0, 4.0, 20.0]],
+            [[1.0, 2.0], [3.0, 4.0]],
+            10.0,
         );
         let feature = extract(Geometry::Euclidean2D(Euclidean2DGeometry::LineString(line)));
         assert!(feature.attributes.get(&Attribute::new("zmin")).is_none());

--- a/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
+++ b/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
@@ -79,6 +79,10 @@ enum BasePoint {
 /// CRS and a Euclidean frame. Converting across the Euclidean/CRS boundary
 /// reinterprets coordinates as-is: values and ring winding are left unchanged,
 /// so orientation follows the destination frame's axis order.
+///
+/// Reprojecting across coordinate reference systems takes 2D geometry lying at a
+/// single elevation into 3D, because the vertical result varies with position and
+/// one elevation cannot describe it.
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CoordinateFrameReprojectorParam {

--- a/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
+++ b/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
@@ -81,8 +81,7 @@ enum BasePoint {
 /// so orientation follows the destination frame's axis order.
 ///
 /// Reprojecting across coordinate reference systems takes 2D geometry lying at a
-/// single elevation into 3D, because the vertical result varies with position and
-/// one elevation cannot describe it.
+/// single elevation into 3D.
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CoordinateFrameReprojectorParam {

--- a/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
+++ b/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
@@ -230,7 +230,7 @@ impl CoordinateFrameReprojector {
         base_point: Option<[f64; 3]>,
     ) -> Result<Feature, BoxedError> {
         let mut feature = feature.clone();
-        REPROJECTION_CACHE
+        let converted = REPROJECTION_CACHE
             .with(|cache| {
                 feature.geometry_mut().convert_frame(
                     &self.target,
@@ -243,6 +243,7 @@ impl CoordinateFrameReprojector {
                     e.to_string(),
                 )) as BoxedError
             })?;
+        *feature.geometry_mut() = converted;
         Ok(feature)
     }
 
@@ -251,10 +252,10 @@ impl CoordinateFrameReprojector {
     /// point or cannot be converted.
     fn base_point_in_target(&self, geometry: &Geometry) -> Option<[f64; 3]> {
         let mut geometry = geometry.clone();
-        REPROJECTION_CACHE
+        let converted = REPROJECTION_CACHE
             .with(|cache| geometry.convert_frame(&self.target, None, &mut cache.borrow_mut()))
             .ok()?;
-        representative_point(&geometry)
+        representative_point(&converted)
     }
 
     /// Convert `feature` and forward it to the features port, or forward the

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/mesh.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/mesh.rs
@@ -217,10 +217,19 @@ fn extract_one(mut mesh: PolygonMesh3D, caches: &mut ExtractCaches) -> Option<Ex
         return None;
     }
 
-    if let Err(e) = mesh.reproject(WGS84_GEOCENTRIC, &mut caches.geocentric) {
-        tracing::warn!("Cesium3DTilesWriter: failed to reproject to ECEF: {e:?}");
-        return None;
-    }
+    let mut mesh = match mesh.reproject(WGS84_GEOCENTRIC, &mut caches.geocentric) {
+        Ok(Geometry::Euclidean3D(Euclidean3DGeometry::PolygonMesh(mesh))) => *mesh,
+        Ok(other) => {
+            tracing::warn!(
+                "Cesium3DTilesWriter: ECEF reprojection did not yield a 3D polygon mesh: {other:?}"
+            );
+            return None;
+        }
+        Err(e) => {
+            tracing::warn!("Cesium3DTilesWriter: failed to reproject to ECEF: {e:?}");
+            return None;
+        }
+    };
 
     let result = match mesh.triangulate_with_normals(&mut caches.triangulation) {
         Ok(result) => result,
@@ -269,10 +278,19 @@ fn extract_triangular(
         return None;
     }
 
-    if let Err(e) = mesh.reproject(WGS84_GEOCENTRIC, &mut caches.geocentric) {
-        tracing::warn!("Cesium3DTilesWriter: failed to reproject to ECEF: {e:?}");
-        return None;
-    }
+    let mesh = match mesh.reproject(WGS84_GEOCENTRIC, &mut caches.geocentric) {
+        Ok(Geometry::Euclidean3D(Euclidean3DGeometry::TriangularMesh(mesh))) => *mesh,
+        Ok(other) => {
+            tracing::warn!(
+                "Cesium3DTilesWriter: ECEF reprojection did not yield a 3D triangle mesh: {other:?}"
+            );
+            return None;
+        }
+        Err(e) => {
+            tracing::warn!("Cesium3DTilesWriter: failed to reproject to ECEF: {e:?}");
+            return None;
+        }
+    };
 
     // Same convention as the polygon path: the flat normal is the triangle's
     // right-hand-rule normal in the (now ECEF) coordinates, times the frame's

--- a/engine/runtime/geometry/src/collection.rs
+++ b/engine/runtime/geometry/src/collection.rs
@@ -19,7 +19,7 @@ use crate::ops::{
 };
 #[cfg(feature = "new-geometry")]
 use crate::validation_next::Validate;
-use crate::{Euclidean2DGeometry, Euclidean3DGeometry};
+use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
 
 /// A `Multi*` collection of 2D geometries; members may differ in coordinate frame.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
@@ -165,16 +165,52 @@ impl Collection2D {
     }
 }
 
+impl Collection2D {
+    /// Whether any member lies at an elevation.
+    fn carries_elevation(&self) -> bool {
+        self.members
+            .iter()
+            .any(Euclidean2DGeometry::carries_elevation)
+    }
+}
+
+/// Unwrap a member's converted result back to a 2D geometry. Errors if it is
+/// not 2D, which only a collection carrying no elevation is asked for.
+fn expect_2d(g: Geometry) -> Result<Euclidean2DGeometry, Error> {
+    match g {
+        Geometry::Euclidean2D(g) => Ok(g),
+        other => Err(Error::projection(format!(
+            "a member of a pure 2D collection did not stay 2D: {other:?}"
+        ))),
+    }
+}
+
+/// Unwrap a member's converted result back to a 3D geometry. Errors if it is
+/// not 3D.
+fn expect_3d(g: Geometry) -> Result<Euclidean3DGeometry, Error> {
+    match g {
+        Geometry::Euclidean3D(g) => Ok(g),
+        other => Err(Error::projection(format!(
+            "a member of a 3D collection did not stay 3D: {other:?}"
+        ))),
+    }
+}
+
 impl Reproject for Collection2D {
     fn reproject(
         &mut self,
         target: EpsgCode,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
-        for member in self.members_mut() {
-            member.reproject(target, cache)?;
+    ) -> crate::error::Result<Geometry> {
+        // One embedding for the collection: one 2.5D member takes all of it to 3D.
+        if self.carries_elevation() {
+            return std::mem::take(self).into_3d().reproject(target, cache);
         }
-        Ok(())
+        let mut out = std::mem::take(self);
+        for member in out.members.iter_mut() {
+            *member = expect_2d(member.reproject(target, cache)?)?;
+        }
+        Ok(Geometry::Euclidean2D(Euclidean2DGeometry::Collection(out)))
     }
 }
 
@@ -183,11 +219,12 @@ impl Reproject for Collection3D {
         &mut self,
         target: EpsgCode,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
-        for member in self.members_mut() {
-            member.reproject(target, cache)?;
+    ) -> crate::error::Result<Geometry> {
+        let mut out = std::mem::take(self);
+        for member in out.members.iter_mut() {
+            *member = expect_3d(member.reproject(target, cache)?)?;
         }
-        Ok(())
+        Ok(Geometry::Euclidean3D(Euclidean3DGeometry::Collection(out)))
     }
 }
 
@@ -201,11 +238,23 @@ impl crate::ops::ConvertFrame for Collection2D {
         target: &crate::coordinate::CoordinateFrame,
         base_point: Option<[f64; 3]>,
         cache: &mut crate::ops::ReprojectionCache,
-    ) -> crate::error::Result<()> {
-        for member in self.members_mut() {
-            member.convert_frame(target, base_point, cache)?;
+    ) -> crate::error::Result<Geometry> {
+        // Members need not share a frame, so any one of them reprojecting
+        // decides the embedding for the whole collection.
+        let mut reprojects = false;
+        for member in self.members.iter() {
+            reprojects |= member.reprojects_to(target, base_point)?;
         }
-        Ok(())
+        if reprojects && self.carries_elevation() {
+            return std::mem::take(self)
+                .into_3d()
+                .convert_frame(target, base_point, cache);
+        }
+        let mut out = std::mem::take(self);
+        for member in out.members.iter_mut() {
+            *member = expect_2d(member.convert_frame(target, base_point, cache)?)?;
+        }
+        Ok(Geometry::Euclidean2D(Euclidean2DGeometry::Collection(out)))
     }
 }
 
@@ -215,11 +264,12 @@ impl crate::ops::ConvertFrame for Collection3D {
         target: &crate::coordinate::CoordinateFrame,
         base_point: Option<[f64; 3]>,
         cache: &mut crate::ops::ReprojectionCache,
-    ) -> crate::error::Result<()> {
-        for member in self.members_mut() {
-            member.convert_frame(target, base_point, cache)?;
+    ) -> crate::error::Result<Geometry> {
+        let mut out = std::mem::take(self);
+        for member in out.members.iter_mut() {
+            *member = expect_3d(member.convert_frame(target, base_point, cache)?)?;
         }
-        Ok(())
+        Ok(Geometry::Euclidean3D(Euclidean3DGeometry::Collection(out)))
     }
 }
 

--- a/engine/runtime/geometry/src/collection.rs
+++ b/engine/runtime/geometry/src/collection.rs
@@ -151,6 +151,20 @@ impl BoundingBox for Collection3D {
     }
 }
 
+impl Collection2D {
+    /// The 3D counterpart of this collection.
+    ///
+    /// A collection holds one embedding, so it converts as a unit: members that
+    /// carry no elevation are placed at `0.0` alongside those that do. Per-child
+    /// attributes stay parallel, since the member count is unchanged.
+    pub(crate) fn into_3d(self) -> Collection3D {
+        Collection3D {
+            members: self.members.into_iter().map(|m| m.into_3d()).collect(),
+            attrs: self.attrs,
+        }
+    }
+}
+
 impl Reproject for Collection2D {
     fn reproject(
         &mut self,

--- a/engine/runtime/geometry/src/collection.rs
+++ b/engine/runtime/geometry/src/collection.rs
@@ -152,11 +152,8 @@ impl BoundingBox for Collection3D {
 }
 
 impl Collection2D {
-    /// The 3D counterpart of this collection.
-    ///
-    /// A collection holds one embedding, so it converts as a unit: members that
-    /// carry no elevation are placed at `0.0` alongside those that do. Per-child
-    /// attributes stay parallel, since the member count is unchanged.
+    /// The 3D counterpart of this collection: members carrying no elevation are
+    /// placed at `0.0`.
     pub(crate) fn into_3d(self) -> Collection3D {
         Collection3D {
             members: self.members.into_iter().map(|m| m.into_3d()).collect(),
@@ -174,8 +171,7 @@ impl Collection2D {
     }
 }
 
-/// Unwrap a member's converted result back to a 2D geometry. Errors if it is
-/// not 2D, which only a collection carrying no elevation is asked for.
+/// Unwrap a member's converted result back to a 2D geometry.
 fn expect_2d(g: Geometry) -> Result<Euclidean2DGeometry, Error> {
     match g {
         Geometry::Euclidean2D(g) => Ok(g),
@@ -185,8 +181,7 @@ fn expect_2d(g: Geometry) -> Result<Euclidean2DGeometry, Error> {
     }
 }
 
-/// Unwrap a member's converted result back to a 3D geometry. Errors if it is
-/// not 3D.
+/// Unwrap a member's converted result back to a 3D geometry.
 fn expect_3d(g: Geometry) -> Result<Euclidean3DGeometry, Error> {
     match g {
         Geometry::Euclidean3D(g) => Ok(g),
@@ -202,7 +197,6 @@ impl Reproject for Collection2D {
         target: EpsgCode,
         cache: &mut ReprojectionCache,
     ) -> crate::error::Result<Geometry> {
-        // One embedding for the collection: one 2.5D member takes all of it to 3D.
         if self.carries_elevation() {
             return std::mem::take(self).into_3d().reproject(target, cache);
         }
@@ -239,8 +233,6 @@ impl crate::ops::ConvertFrame for Collection2D {
         base_point: Option<[f64; 3]>,
         cache: &mut crate::ops::ReprojectionCache,
     ) -> crate::error::Result<Geometry> {
-        // Members need not share a frame, so any one of them reprojecting
-        // decides the embedding for the whole collection.
         let mut reprojects = false;
         for member in self.members.iter() {
             reprojects |= member.reprojects_to(target, base_point)?;

--- a/engine/runtime/geometry/src/index.rs
+++ b/engine/runtime/geometry/src/index.rs
@@ -25,6 +25,13 @@ pub(crate) enum IndexBuffer<const N: usize> {
     U32(Vec<[u32; N]>),
 }
 
+/// An empty buffer at the narrowest width.
+impl<const N: usize> Default for IndexBuffer<N> {
+    fn default() -> Self {
+        IndexBuffer::U8(Vec::new())
+    }
+}
+
 /// Monomorphize a body over the concrete index width of an [`IndexBuffer`].
 ///
 /// The body must be a thin call into a generic function, never an inlined

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -150,8 +150,8 @@ impl GeometryCollection {
     }
 }
 
-/// 2D-embedded geometry. All coordinates are 2D `(x, y)`; some leaves carry an
-/// optional per-vertex elevation (2.5D).
+/// 2D-embedded geometry. All coordinates are 2D `(x, y)`; some leaves carry a
+/// single optional elevation the whole leaf lies at (2.5D).
 ///
 /// The heavy aggregate leaves (`Polygon`, the meshes) are boxed so the small,
 /// common variants don't inflate the enum — and `Geometry` with them — to the
@@ -531,15 +531,11 @@ mod triangulate_tests {
 
         let poly2d = Polygon2D::from_rings(e.clone(), square, Vec::<Vec<[f64; 2]>>::new());
         let poly2d_hole = Polygon2D::from_rings(e.clone(), square, vec![hole]);
-        let poly2d_elev = Polygon2D::from_rings_with_elevation(
+        let poly2d_elev = Polygon2D::from_rings_at_elevation(
             e.clone(),
-            [
-                [0.0, 0.0, 1.0],
-                [4.0, 0.0, 2.0],
-                [4.0, 4.0, 3.0],
-                [0.0, 0.0, 1.0],
-            ],
-            Vec::<Vec<[f64; 3]>>::new(),
+            [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 0.0]],
+            Vec::<Vec<[f64; 2]>>::new(),
+            1.0,
         );
         let poly3d = Polygon3D::from_rings(
             e.clone(),

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -833,7 +833,7 @@ mod force_2d_tests {
         // A 2.5D input loses its elevation and its frame's vertical axis, giving
         // exactly what a natively 2D line string in the demoted frame would.
         let mut g = Geometry::Euclidean2D(Euclidean2DGeometry::LineString(
-            LineString2D::from_coords_with_elevation(crs(), [[0.0, 0.0, 5.0], [2.0, 1.0, 9.0]]),
+            LineString2D::from_coords_at_elevation(crs(), [[0.0, 0.0], [2.0, 1.0]], 5.0),
         ));
         let forced = g.force_2d().unwrap();
         let expected = Geometry::Euclidean2D(Euclidean2DGeometry::LineString(

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -297,9 +297,7 @@ impl Triangulate for GeometryCollection {
 }
 
 impl Euclidean2DGeometry {
-    /// Whether any part of this geometry lies at an elevation, making it 2.5D
-    /// rather than pure 2D. A `Collection` answers for its members: they share
-    /// one embedding, so one member with an elevation makes the whole 2.5D.
+    /// Whether any part of this geometry lies at an elevation (2.5D).
     pub(crate) fn carries_elevation(&self) -> bool {
         match self {
             Self::Point(_) => false,
@@ -311,9 +309,7 @@ impl Euclidean2DGeometry {
         }
     }
 
-    /// Whether converting to `target` reprojects this geometry across CRSs, the
-    /// one frame step whose vertical result varies with position. A `Collection`
-    /// answers for its members, whose frames need not agree.
+    /// Whether converting to `target` reprojects this geometry across CRSs.
     pub(crate) fn reprojects_to(
         &self,
         target: &CoordinateFrame,
@@ -375,7 +371,6 @@ impl Reproject for GeometryCollection {
         target: EpsgCode,
         cache: &mut ReprojectionCache,
     ) -> crate::error::Result<Geometry> {
-        // Cross-dimensional by definition: members convert independently.
         let mut out = std::mem::take(self);
         for member in out.members.iter_mut() {
             *member = member.reproject(target, cache)?;

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -63,7 +63,7 @@ use ops::Split;
 #[cfg(feature = "new-geometry")]
 use validation_next::{Validate, ValidationParams, ValidationReport, ValidationType};
 
-use coordinate::EpsgCode;
+use coordinate::{CoordinateFrame, EpsgCode};
 
 use collection::{Collection2D, Collection3D};
 use csg::Csg;
@@ -296,12 +296,97 @@ impl Triangulate for GeometryCollection {
     }
 }
 
+impl Euclidean2DGeometry {
+    /// Whether any part of this geometry lies at an elevation, making it 2.5D
+    /// rather than pure 2D. A `Collection` answers for its members: they share
+    /// one embedding, so one member with an elevation makes the whole 2.5D.
+    pub(crate) fn carries_elevation(&self) -> bool {
+        match self {
+            Self::Point(_) => false,
+            Self::LineString(g) => g.elevation().is_some(),
+            Self::Polygon(g) => g.elevation().is_some(),
+            Self::PolygonMesh(g) => g.elevation().is_some(),
+            Self::TriangularMesh(g) => g.elevation().is_some(),
+            Self::Collection(c) => c.members().iter().any(Self::carries_elevation),
+        }
+    }
+
+    /// Whether converting to `target` reprojects this geometry across CRSs, the
+    /// one frame step whose vertical result varies with position. A `Collection`
+    /// answers for its members, whose frames need not agree.
+    pub(crate) fn reprojects_to(
+        &self,
+        target: &CoordinateFrame,
+        base_point: Option<[f64; 3]>,
+    ) -> crate::error::Result<bool> {
+        let frame = match self {
+            Self::Point(g) => g.frame(),
+            Self::LineString(g) => g.frame(),
+            Self::Polygon(g) => g.frame(),
+            Self::PolygonMesh(g) => g.frame(),
+            Self::TriangularMesh(g) => g.frame(),
+            Self::Collection(c) => {
+                for member in c.members() {
+                    if member.reprojects_to(target, base_point)? {
+                        return Ok(true);
+                    }
+                }
+                return Ok(false);
+            }
+        };
+        Ok(matches!(
+            ops::plan_frame_step(frame, target, base_point)?,
+            ops::FrameStep::Reproject(_)
+        ))
+    }
+
+    /// The 3D counterpart of this geometry, with every coordinate placed at the
+    /// elevation its leaf lies at, or at `0.0` where there is none.
+    pub(crate) fn into_3d(self) -> Euclidean3DGeometry {
+        match self {
+            Self::Point(g) => Euclidean3DGeometry::Point(g.into_3d()),
+            Self::LineString(g) => Euclidean3DGeometry::LineString(g.into_3d()),
+            Self::Polygon(g) => Euclidean3DGeometry::Polygon(Box::new(g.into_3d())),
+            Self::PolygonMesh(g) => Euclidean3DGeometry::PolygonMesh(Box::new(g.into_3d())),
+            Self::TriangularMesh(g) => Euclidean3DGeometry::TriangularMesh(Box::new(g.into_3d())),
+            Self::Collection(c) => Euclidean3DGeometry::Collection(c.into_3d()),
+        }
+    }
+}
+
+impl Geometry {
+    /// Give up the 2D embedding when a 2.5D geometry is about to be reprojected
+    /// across CRSs, replacing it with its 3D counterpart.
+    ///
+    /// A leaf holds one elevation for all of its coordinates, and a reprojection
+    /// is the one frame step whose vertical result varies with position, so the
+    /// single elevation cannot describe the result. The rigid steps can: a
+    /// translation shifts that one elevation along with the coordinates, so a
+    /// 2.5D geometry stays 2.5D across the Euclidean/CRS boundary.
+    fn make_3d_for_reprojection(&mut self, step_reprojects: bool) {
+        if !step_reprojects {
+            return;
+        }
+        let Self::Euclidean2D(g) = self else { return };
+        if !g.carries_elevation() {
+            return;
+        }
+        let Self::Euclidean2D(g) = std::mem::take(self) else {
+            unreachable!("just matched as 2D")
+        };
+        *self = Self::Euclidean3D(g.into_3d());
+    }
+}
+
 impl Reproject for Geometry {
     fn reproject(
         &mut self,
         target: EpsgCode,
         cache: &mut ReprojectionCache,
     ) -> crate::error::Result<()> {
+        // Reprojecting is always a CRS-to-CRS step, so a 2.5D geometry gives up
+        // its single elevation here and comes out 3D.
+        self.make_3d_for_reprojection(true);
         match self {
             Geometry::None => Ok(()),
             Geometry::Euclidean2D(g) => g.reproject(target, cache),
@@ -333,7 +418,17 @@ impl ConvertFrame for Geometry {
     ) -> crate::error::Result<()> {
         match self {
             Geometry::None => Ok(()),
-            Geometry::Euclidean2D(g) => g.convert_frame(target, base_point, cache),
+            Geometry::Euclidean2D(g) => {
+                // Only a CRS-to-CRS step reprojects; the rigid steps keep a 2.5D
+                // geometry 2.5D, so the embedding turns on the planned step.
+                let reprojects = g.reprojects_to(target, base_point)?;
+                self.make_3d_for_reprojection(reprojects);
+                match self {
+                    Geometry::Euclidean2D(g) => g.convert_frame(target, base_point, cache),
+                    Geometry::Euclidean3D(g) => g.convert_frame(target, base_point, cache),
+                    _ => unreachable!("stayed 2D or became 3D"),
+                }
+            }
             Geometry::Euclidean3D(g) => g.convert_frame(target, base_point, cache),
             Geometry::GeometryCollection(c) => c.convert_frame(target, base_point, cache),
         }

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -354,41 +354,14 @@ impl Euclidean2DGeometry {
     }
 }
 
-impl Geometry {
-    /// Give up the 2D embedding when a 2.5D geometry is about to be reprojected
-    /// across CRSs, replacing it with its 3D counterpart.
-    ///
-    /// A leaf holds one elevation for all of its coordinates, and a reprojection
-    /// is the one frame step whose vertical result varies with position, so the
-    /// single elevation cannot describe the result. The rigid steps can: a
-    /// translation shifts that one elevation along with the coordinates, so a
-    /// 2.5D geometry stays 2.5D across the Euclidean/CRS boundary.
-    fn make_3d_for_reprojection(&mut self, step_reprojects: bool) {
-        if !step_reprojects {
-            return;
-        }
-        let Self::Euclidean2D(g) = self else { return };
-        if !g.carries_elevation() {
-            return;
-        }
-        let Self::Euclidean2D(g) = std::mem::take(self) else {
-            unreachable!("just matched as 2D")
-        };
-        *self = Self::Euclidean3D(g.into_3d());
-    }
-}
-
 impl Reproject for Geometry {
     fn reproject(
         &mut self,
         target: EpsgCode,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
-        // Reprojecting is always a CRS-to-CRS step, so a 2.5D geometry gives up
-        // its single elevation here and comes out 3D.
-        self.make_3d_for_reprojection(true);
+    ) -> crate::error::Result<Geometry> {
         match self {
-            Geometry::None => Ok(()),
+            Geometry::None => Ok(Geometry::None),
             Geometry::Euclidean2D(g) => g.reproject(target, cache),
             Geometry::Euclidean3D(g) => g.reproject(target, cache),
             Geometry::GeometryCollection(c) => c.reproject(target, cache),
@@ -401,11 +374,13 @@ impl Reproject for GeometryCollection {
         &mut self,
         target: EpsgCode,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
-        for member in self.members_mut() {
-            member.reproject(target, cache)?;
+    ) -> crate::error::Result<Geometry> {
+        // Cross-dimensional by definition: members convert independently.
+        let mut out = std::mem::take(self);
+        for member in out.members.iter_mut() {
+            *member = member.reproject(target, cache)?;
         }
-        Ok(())
+        Ok(Geometry::GeometryCollection(out))
     }
 }
 
@@ -415,20 +390,10 @@ impl ConvertFrame for Geometry {
         target: &coordinate::CoordinateFrame,
         base_point: Option<[f64; 3]>,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         match self {
-            Geometry::None => Ok(()),
-            Geometry::Euclidean2D(g) => {
-                // Only a CRS-to-CRS step reprojects; the rigid steps keep a 2.5D
-                // geometry 2.5D, so the embedding turns on the planned step.
-                let reprojects = g.reprojects_to(target, base_point)?;
-                self.make_3d_for_reprojection(reprojects);
-                match self {
-                    Geometry::Euclidean2D(g) => g.convert_frame(target, base_point, cache),
-                    Geometry::Euclidean3D(g) => g.convert_frame(target, base_point, cache),
-                    _ => unreachable!("stayed 2D or became 3D"),
-                }
-            }
+            Geometry::None => Ok(Geometry::None),
+            Geometry::Euclidean2D(g) => g.convert_frame(target, base_point, cache),
             Geometry::Euclidean3D(g) => g.convert_frame(target, base_point, cache),
             Geometry::GeometryCollection(c) => c.convert_frame(target, base_point, cache),
         }
@@ -441,11 +406,12 @@ impl ConvertFrame for GeometryCollection {
         target: &coordinate::CoordinateFrame,
         base_point: Option<[f64; 3]>,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
-        for member in self.members_mut() {
-            member.convert_frame(target, base_point, cache)?;
+    ) -> crate::error::Result<Geometry> {
+        let mut out = std::mem::take(self);
+        for member in out.members.iter_mut() {
+            *member = member.convert_frame(target, base_point, cache)?;
         }
-        Ok(())
+        Ok(Geometry::GeometryCollection(out))
     }
 }
 

--- a/engine/runtime/geometry/src/line_string/constructor.rs
+++ b/engine/runtime/geometry/src/line_string/constructor.rs
@@ -23,9 +23,7 @@ impl LineString2D {
         }
     }
 
-    /// Build a 2.5D polyline: an `[x, y]` chain lying wholly at `elevation`. A
-    /// chain whose vertices sit at differing heights is not representable here —
-    /// that is a [`LineString3D`].
+    /// Build a 2.5D polyline: an `[x, y]` chain lying wholly at `elevation`.
     pub fn from_coords_at_elevation(
         frame: CoordinateFrame,
         coords: impl IntoIterator<Item = [f64; 2]>,
@@ -85,7 +83,6 @@ mod tests {
             10.0,
         );
         assert_eq!(l.coords, vec![[0.0, 0.0], [1.0, 0.0]].into_boxed_slice());
-        // One elevation for the chain, not one per vertex.
         assert_eq!(l.elevation(), Some(10.0));
     }
 

--- a/engine/runtime/geometry/src/line_string/constructor.rs
+++ b/engine/runtime/geometry/src/line_string/constructor.rs
@@ -3,19 +3,18 @@
 //! A `LineString` is a flat coordinate chain: every reader (CityGML `gml:Curve`,
 //! shapefile polylines, GeoJSON, WKT, GeoPackage WKB) hands one over as a plain
 //! sequence of points — no shared pool, no indices, no rings. So construction is
-//! just wrapping that buffer; the 2D form optionally carries per-vertex elevation
-//! (2.5D), split out of `[x, y, z]` input. Lines are stored as given (not closed)
-//! and carry no appearance.
+//! just wrapping that buffer; the 2D form optionally carries the one elevation the
+//! whole chain lies at (2.5D). Lines are stored as given (not closed) and carry no
+//! appearance.
 
 use crate::coordinate::CoordinateFrame;
-use crate::error::Error;
 
 use super::{LineString2D, LineString3D};
 
 impl LineString2D {
     /// Build a 2D polyline from `[x, y]` coordinates. The result is pure 2D (no
-    /// elevation); for per-vertex elevation use
-    /// [`LineString2D::from_coords_with_elevation`].
+    /// elevation); to place the chain at a height use
+    /// [`LineString2D::from_coords_at_elevation`].
     pub fn from_coords(frame: CoordinateFrame, coords: impl IntoIterator<Item = [f64; 2]>) -> Self {
         Self {
             frame,
@@ -24,44 +23,25 @@ impl LineString2D {
         }
     }
 
-    /// Build a 2.5D polyline from `[x, y, z]` coordinates: the `(x, y)` populate
-    /// `coords` and the `z` the parallel elevation buffer.
-    pub fn from_coords_with_elevation(
+    /// Build a 2.5D polyline: an `[x, y]` chain lying wholly at `elevation`. A
+    /// chain whose vertices sit at differing heights is not representable here —
+    /// that is a [`LineString3D`].
+    pub fn from_coords_at_elevation(
         frame: CoordinateFrame,
-        coords: impl IntoIterator<Item = [f64; 3]>,
+        coords: impl IntoIterator<Item = [f64; 2]>,
+        elevation: f64,
     ) -> Self {
-        let coords = coords.into_iter();
-        let cap = coords.size_hint().0;
-        let mut xy = Vec::with_capacity(cap);
-        let mut z = Vec::with_capacity(cap);
-        for [x, y, elevation] in coords {
-            xy.push([x, y]);
-            z.push(elevation);
-        }
         Self {
             frame,
-            coords: xy.into_boxed_slice(),
-            z: Some(z.into_boxed_slice()),
+            coords: coords.into_iter().collect(),
+            z: Some(elevation),
         }
     }
 
-    /// Build from an already-built coordinate buffer and optional parallel
-    /// elevation. Errors if `z` is present and not the same length as `coords`.
-    pub fn from_raw_parts(
-        frame: CoordinateFrame,
-        coords: Box<[[f64; 2]]>,
-        z: Option<Box<[f64]>>,
-    ) -> Result<Self, Error> {
-        if let Some(z) = z.as_ref() {
-            if z.len() != coords.len() {
-                return Err(Error::invalid_geometry(format!(
-                    "elevation buffer length {} does not match coordinate count {}",
-                    z.len(),
-                    coords.len()
-                )));
-            }
-        }
-        Ok(Self { frame, coords, z })
+    /// Build from an already-built coordinate buffer and the chain's optional
+    /// elevation.
+    pub fn from_raw_parts(frame: CoordinateFrame, coords: Box<[[f64; 2]]>, z: Option<f64>) -> Self {
+        Self { frame, coords, z }
     }
 }
 
@@ -98,37 +78,22 @@ mod tests {
     }
 
     #[test]
-    fn from_coords_with_elevation_splits_z() {
-        let l = LineString2D::from_coords_with_elevation(
+    fn from_coords_at_elevation_keeps_one_height() {
+        let l = LineString2D::from_coords_at_elevation(
             CoordinateFrame::Euclidean,
-            [[0.0, 0.0, 10.0], [1.0, 0.0, 11.0]],
+            [[0.0, 0.0], [1.0, 0.0]],
+            10.0,
         );
         assert_eq!(l.coords, vec![[0.0, 0.0], [1.0, 0.0]].into_boxed_slice());
-        assert_eq!(l.z.as_deref(), Some(&[10.0, 11.0][..]));
+        // One elevation for the chain, not one per vertex.
+        assert_eq!(l.elevation(), Some(10.0));
     }
 
     #[test]
-    fn from_raw_parts_2d_rejects_unparallel_z() {
+    fn from_raw_parts_2d_carries_elevation() {
         let coords: Box<[[f64; 2]]> = vec![[0.0, 0.0], [1.0, 0.0]].into_boxed_slice();
-        let err = LineString2D::from_raw_parts(
-            CoordinateFrame::Euclidean,
-            coords,
-            Some(vec![0.0].into_boxed_slice()),
-        )
-        .unwrap_err();
-        assert!(matches!(err, Error::InvalidGeometry(_)));
-    }
-
-    #[test]
-    fn from_raw_parts_2d_accepts_parallel_z() {
-        let coords: Box<[[f64; 2]]> = vec![[0.0, 0.0], [1.0, 0.0]].into_boxed_slice();
-        let l = LineString2D::from_raw_parts(
-            CoordinateFrame::Euclidean,
-            coords,
-            Some(vec![3.0, 4.0].into_boxed_slice()),
-        )
-        .unwrap();
-        assert_eq!(l.z.as_deref(), Some(&[3.0, 4.0][..]));
+        let l = LineString2D::from_raw_parts(CoordinateFrame::Euclidean, coords, Some(3.0));
+        assert_eq!(l.elevation(), Some(3.0));
     }
 
     #[test]

--- a/engine/runtime/geometry/src/line_string/mod.rs
+++ b/engine/runtime/geometry/src/line_string/mod.rs
@@ -3,8 +3,8 @@
 //! A `LineString` is a polyline: an ordered chain of coordinates, a variant in
 //! both embeddings. It follows the `Polygon` flat-buffer convention: a single
 //! closed/open chain of coordinates in one `Box<[_]>` allocation, with the 2D
-//! form carrying optional per-vertex elevation parallel to `coords`. Lines carry
-//! no appearance.
+//! form carrying one optional elevation for the whole chain. Lines carry no
+//! appearance.
 
 use serde::{Deserialize, Serialize};
 
@@ -15,15 +15,15 @@ mod ops;
 #[cfg(feature = "new-geometry")]
 mod validation;
 
-/// A polyline in 2D space, with optional per-vertex elevation (2.5D).
+/// A polyline in 2D space, lying at a single optional elevation (2.5D).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct LineString2D {
     /// Coordinate frame these coords are expressed in.
     frame: CoordinateFrame,
     coords: Box<[[f64; 2]]>,
-    /// Optional per-vertex elevation, parallel to `coords`.
-    /// INVARIANT: when `Some`, `z.len() == coords.len()`. `None` = pure 2D.
-    z: Option<Box<[f64]>>,
+    /// The one elevation the whole chain lies at; `None` = pure 2D. A chain whose
+    /// vertices sit at differing heights is a [`LineString3D`], not this.
+    z: Option<f64>,
 }
 
 /// A polyline in 3D space.
@@ -45,6 +45,12 @@ impl LineString2D {
     #[inline]
     pub fn coords(&self) -> &[[f64; 2]] {
         &self.coords
+    }
+
+    /// The elevation the chain lies at, or `None` when it is pure 2D.
+    #[inline]
+    pub fn elevation(&self) -> Option<f64> {
+        self.z
     }
 }
 

--- a/engine/runtime/geometry/src/line_string/mod.rs
+++ b/engine/runtime/geometry/src/line_string/mod.rs
@@ -21,8 +21,7 @@ pub struct LineString2D {
     /// Coordinate frame these coords are expressed in.
     frame: CoordinateFrame,
     coords: Box<[[f64; 2]]>,
-    /// The one elevation the whole chain lies at; `None` = pure 2D. A chain whose
-    /// vertices sit at differing heights is a [`LineString3D`], not this.
+    /// The one elevation the whole chain lies at. `None` = pure 2D.
     z: Option<f64>,
 }
 

--- a/engine/runtime/geometry/src/line_string/ops.rs
+++ b/engine/runtime/geometry/src/line_string/ops.rs
@@ -1,7 +1,9 @@
 use super::{LineString2D, LineString3D};
 use crate::coordinate::{CoordinateFrame, EpsgCode};
 use crate::ops::reproject::{transform_coords_2d, transform_coords_3d};
-use crate::ops::{Aabb, BoundingBox, Reproject, ReprojectionCache, UnsupportedOperation};
+use crate::ops::{
+    lift_coords, Aabb, BoundingBox, Reproject, ReprojectionCache, UnsupportedOperation,
+};
 
 impl BoundingBox for LineString2D {
     fn bounding_box(&self) -> Result<Aabb, UnsupportedOperation> {
@@ -56,7 +58,7 @@ use crate::ops::{plan_frame_step, translate_2d, translate_3d, ConvertFrame, Fram
 
 impl Translate for LineString2D {
     fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
-        translate_2d(&mut self.coords, self.z.as_deref_mut(), delta);
+        translate_2d(&mut self.coords, &mut self.z, delta);
         Ok(())
     }
 }
@@ -133,6 +135,17 @@ impl ForceTwoDimension for LineString3D {
             coords,
             z: None,
         }))
+    }
+}
+
+impl LineString2D {
+    /// The 3D counterpart of this leaf, with every coordinate placed at the
+    /// elevation the leaf lies at, or at `0.0` when it carries none.
+    pub(crate) fn into_3d(self) -> LineString3D {
+        LineString3D {
+            frame: self.frame,
+            coords: lift_coords(self.coords.iter(), self.z).into_boxed_slice(),
+        }
     }
 }
 

--- a/engine/runtime/geometry/src/line_string/ops.rs
+++ b/engine/runtime/geometry/src/line_string/ops.rs
@@ -66,7 +66,6 @@ impl Reproject for LineString2D {
         if from == target {
             return Ok(self.take_geometry());
         }
-        // One elevation cannot describe a position-varying vertical result.
         if self.z.is_some() {
             return self.take().into_3d().reproject(target, cache);
         }

--- a/engine/runtime/geometry/src/line_string/ops.rs
+++ b/engine/runtime/geometry/src/line_string/ops.rs
@@ -147,7 +147,6 @@ impl ConvertFrame for LineString3D {
 }
 
 use crate::ops::{ForceTwoDimension, ForceTwoDimensionError};
-use crate::Euclidean2DGeometry;
 
 impl ForceTwoDimension for LineString2D {
     fn force_2d(&mut self) -> Result<Euclidean2DGeometry, ForceTwoDimensionError> {

--- a/engine/runtime/geometry/src/line_string/ops.rs
+++ b/engine/runtime/geometry/src/line_string/ops.rs
@@ -5,7 +5,7 @@ use crate::ops::{Aabb, BoundingBox, Reproject, ReprojectionCache, UnsupportedOpe
 
 impl BoundingBox for LineString2D {
     fn bounding_box(&self) -> Result<Aabb, UnsupportedOperation> {
-        // 2D embedding: the optional per-vertex elevation is not folded in.
+        // 2D embedding: the optional elevation is not folded in.
         Aabb::from_points_2d(self.coords.iter().copied()).ok_or(UnsupportedOperation {
             geometry: "LineString2D",
             operation: "bounding_box",
@@ -30,7 +30,7 @@ impl Reproject for LineString2D {
     ) -> crate::error::Result<()> {
         let from = self.frame.require_crs()?;
         if from != target {
-            transform_coords_2d(cache, from, target, &mut self.coords, self.z.as_deref_mut())?;
+            transform_coords_2d(cache, from, target, &mut self.coords, self.z.as_mut())?;
             self.frame = CoordinateFrame::Crs(target);
         }
         Ok(())
@@ -158,9 +158,10 @@ mod tests {
 
     #[test]
     fn linestring2d_box_ignores_elevation() {
-        let ls = LineString2D::from_coords_with_elevation(
+        let ls = LineString2D::from_coords_at_elevation(
             CoordinateFrame::Euclidean,
-            [[0.0, 0.0, 99.0], [2.0, 1.0, -99.0]],
+            [[0.0, 0.0], [2.0, 1.0]],
+            99.0,
         );
         // 2.5D elevation does not widen the 2D box.
         assert_eq!(

--- a/engine/runtime/geometry/src/line_string/ops.rs
+++ b/engine/runtime/geometry/src/line_string/ops.rs
@@ -30,7 +30,7 @@ impl Reproject for LineString2D {
     ) -> crate::error::Result<()> {
         let from = self.frame.require_crs()?;
         if from != target {
-            transform_coords_2d(cache, from, target, &mut self.coords, self.z.as_mut())?;
+            transform_coords_2d(cache, from, target, &mut self.coords, &mut self.z)?;
             self.frame = CoordinateFrame::Crs(target);
         }
         Ok(())

--- a/engine/runtime/geometry/src/line_string/ops.rs
+++ b/engine/runtime/geometry/src/line_string/ops.rs
@@ -4,6 +4,7 @@ use crate::ops::reproject::{transform_coords_2d, transform_coords_3d};
 use crate::ops::{
     lift_coords, Aabb, BoundingBox, Reproject, ReprojectionCache, UnsupportedOperation,
 };
+use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
 
 impl BoundingBox for LineString2D {
     fn bounding_box(&self) -> Result<Aabb, UnsupportedOperation> {
@@ -24,18 +25,55 @@ impl BoundingBox for LineString3D {
     }
 }
 
+impl LineString2D {
+    /// Move the chain out, leaving an empty husk.
+    fn take(&mut self) -> Self {
+        Self {
+            frame: std::mem::take(&mut self.frame),
+            coords: std::mem::take(&mut self.coords),
+            z: self.z.take(),
+        }
+    }
+
+    /// The leaf moved out and wrapped as a [`Geometry`].
+    fn take_geometry(&mut self) -> Geometry {
+        Geometry::Euclidean2D(Euclidean2DGeometry::LineString(self.take()))
+    }
+}
+
+impl LineString3D {
+    /// Move the chain out, leaving an empty husk.
+    fn take(&mut self) -> Self {
+        Self {
+            frame: std::mem::take(&mut self.frame),
+            coords: std::mem::take(&mut self.coords),
+        }
+    }
+
+    /// The leaf moved out and wrapped as a [`Geometry`].
+    fn take_geometry(&mut self) -> Geometry {
+        Geometry::Euclidean3D(Euclidean3DGeometry::LineString(self.take()))
+    }
+}
+
 impl Reproject for LineString2D {
     fn reproject(
         &mut self,
         target: EpsgCode,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         let from = self.frame.require_crs()?;
-        if from != target {
-            transform_coords_2d(cache, from, target, &mut self.coords, &mut self.z)?;
-            self.frame = CoordinateFrame::Crs(target);
+        if from == target {
+            return Ok(self.take_geometry());
         }
-        Ok(())
+        // One elevation cannot describe a position-varying vertical result.
+        if self.z.is_some() {
+            return self.take().into_3d().reproject(target, cache);
+        }
+        let mut ls = self.take();
+        transform_coords_2d(cache, from, target, &mut ls.coords)?;
+        ls.frame = CoordinateFrame::Crs(target);
+        Ok(Geometry::Euclidean2D(Euclidean2DGeometry::LineString(ls)))
     }
 }
 
@@ -44,13 +82,14 @@ impl Reproject for LineString3D {
         &mut self,
         target: EpsgCode,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         let from = self.frame.require_crs()?;
+        let mut ls = self.take();
         if from != target {
-            transform_coords_3d(cache, from, target, &mut self.coords)?;
-            self.frame = CoordinateFrame::Crs(target);
+            transform_coords_3d(cache, from, target, &mut ls.coords)?;
+            ls.frame = CoordinateFrame::Crs(target);
         }
-        Ok(())
+        Ok(Geometry::Euclidean3D(Euclidean3DGeometry::LineString(ls)))
     }
 }
 
@@ -76,14 +115,14 @@ impl ConvertFrame for LineString2D {
         target: &CoordinateFrame,
         base_point: Option<[f64; 3]>,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         match plan_frame_step(&self.frame, target, base_point)? {
-            FrameStep::Noop => Ok(()),
+            FrameStep::Noop => Ok(self.take_geometry()),
             FrameStep::Reproject(to) => self.reproject(to, cache),
             FrameStep::Translate(offset, frame) => {
                 self.translate(offset)?;
                 self.frame = frame;
-                Ok(())
+                Ok(self.take_geometry())
             }
         }
     }
@@ -95,14 +134,14 @@ impl ConvertFrame for LineString3D {
         target: &CoordinateFrame,
         base_point: Option<[f64; 3]>,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         match plan_frame_step(&self.frame, target, base_point)? {
-            FrameStep::Noop => Ok(()),
+            FrameStep::Noop => Ok(self.take_geometry()),
             FrameStep::Reproject(to) => self.reproject(to, cache),
             FrameStep::Translate(offset, frame) => {
                 self.translate(offset)?;
                 self.frame = frame;
-                Ok(())
+                Ok(self.take_geometry())
             }
         }
     }

--- a/engine/runtime/geometry/src/line_string/validation.rs
+++ b/engine/runtime/geometry/src/line_string/validation.rs
@@ -2,9 +2,10 @@ use super::{LineString2D, LineString3D};
 use crate::validation_next::{
     check_chain_simple_2d, check_chain_simple_3d, check_degenerate_chain_2d,
     check_degenerate_chain_3d, check_duplicate_points, check_finite_2d, check_finite_3d,
-    check_too_few_points_2d, check_too_few_points_3d, Validate, ValidationParams, ValidationReport,
-    ValidationType,
+    check_finite_elevation, check_too_few_points_2d, check_too_few_points_3d, Validate,
+    ValidationParams, ValidationReport, ValidationType,
 };
+use crate::{Euclidean2DGeometry, Geometry};
 
 /// The checks that apply to a line string; 2D and 3D share the table row.
 const LINE_STRING_CHECKS: [ValidationType; 5] = [
@@ -21,7 +22,14 @@ impl Validate for LineString2D {
     }
 
     fn check_finite(&self, _params: &ValidationParams) -> ValidationReport {
-        ValidationReport::ran(|r| check_finite_2d(&self.frame, &self.coords, self.z, r))
+        ValidationReport::ran(|r| {
+            check_finite_elevation(
+                self.z,
+                || Geometry::Euclidean2D(Euclidean2DGeometry::LineString(self.clone())),
+                r,
+            );
+            check_finite_2d(&self.frame, &self.coords, r);
+        })
     }
 
     fn check_too_few_points(&self, _params: &ValidationParams) -> ValidationReport {

--- a/engine/runtime/geometry/src/line_string/validation.rs
+++ b/engine/runtime/geometry/src/line_string/validation.rs
@@ -21,7 +21,7 @@ impl Validate for LineString2D {
     }
 
     fn check_finite(&self, _params: &ValidationParams) -> ValidationReport {
-        ValidationReport::ran(|r| check_finite_2d(&self.frame, &self.coords, self.z.as_deref(), r))
+        ValidationReport::ran(|r| check_finite_2d(&self.frame, &self.coords, self.z, r))
     }
 
     fn check_too_few_points(&self, _params: &ValidationParams) -> ValidationReport {

--- a/engine/runtime/geometry/src/ops/mod.rs
+++ b/engine/runtime/geometry/src/ops/mod.rs
@@ -330,8 +330,8 @@ impl<T: ForceTwoDimension + ?Sized> ForceTwoDimension for Box<T> {
 #[enum_dispatch::enum_dispatch]
 pub trait Translate {
     /// Add `delta` to every coordinate. For a 2D-embedded geometry, `delta`'s
-    /// `z` applies to the optional per-vertex elevation. The default body reports
-    /// the type as unsupported; a leaf opts in by overriding it.
+    /// `z` shifts the one elevation the leaf lies at, when it carries one. The
+    /// default body reports the type as unsupported; a leaf opts in by overriding it.
     fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
         let _ = delta;
         Err(Error::projection(format!(
@@ -386,16 +386,22 @@ pub(crate) fn translate_3d(coords: &mut [[f64; 3]], delta: [f64; 3]) {
 /// bridge is a positional reinterpretation: coordinate values and ring winding
 /// are left unchanged, so a ring's orientation follows the axis order of the
 /// frame it is retagged into. A `Tangent` frame on either side is rejected.
+///
+/// Like [`Reproject`], a conversion consumes its input and returns a
+/// [`Geometry`](crate::Geometry): only the reprojecting step changes a
+/// geometry's embedding, so a 2.5D geometry stays 2.5D across the
+/// Euclidean/CRS boundary.
 #[enum_dispatch::enum_dispatch]
 pub trait ConvertFrame {
-    /// Convert every coordinate to `target`. The default body reports the type
-    /// as unsupported; a leaf opts in by overriding it.
+    /// Convert every coordinate to `target`, consuming `self` into the result.
+    /// The default body reports the type as unsupported; a leaf opts in by
+    /// overriding it.
     fn convert_frame(
         &mut self,
         target: &crate::coordinate::CoordinateFrame,
         base_point: Option<[f64; 3]>,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<crate::Geometry> {
         let _ = (target, base_point, cache);
         Err(Error::projection(format!(
             "convert_frame is not supported by `{}`",
@@ -410,7 +416,7 @@ impl<T: ConvertFrame + ?Sized> ConvertFrame for Box<T> {
         target: &crate::coordinate::CoordinateFrame,
         base_point: Option<[f64; 3]>,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<crate::Geometry> {
         (**self).convert_frame(target, base_point, cache)
     }
 }
@@ -497,17 +503,28 @@ mod convert_frame_tests {
     use super::{ConvertFrame, ReprojectionCache};
     use crate::coordinate::{BaseFrame, CoordinateFrame, EpsgCode, TangentPlane};
     use crate::point::Point3D;
+    use crate::{Euclidean3DGeometry, Geometry};
+
+    /// Unwrap a converted result back to the single 3D point these cases build.
+    fn point(g: Geometry) -> Point3D {
+        match g {
+            Geometry::Euclidean3D(Euclidean3DGeometry::Point(p)) => p,
+            other => panic!("expected a 3D point, got {other:?}"),
+        }
+    }
 
     #[test]
     fn euclidean_to_crs_adds_base_point() {
         let mut cache = ReprojectionCache::new();
-        let mut p = Point3D::new(CoordinateFrame::Euclidean, [1.0, 2.0, 3.0]);
-        p.convert_frame(
-            &CoordinateFrame::Crs(EpsgCode::new(6697)),
-            Some([10.0, 20.0, 30.0]),
-            &mut cache,
-        )
-        .unwrap();
+        let p = point(
+            Point3D::new(CoordinateFrame::Euclidean, [1.0, 2.0, 3.0])
+                .convert_frame(
+                    &CoordinateFrame::Crs(EpsgCode::new(6697)),
+                    Some([10.0, 20.0, 30.0]),
+                    &mut cache,
+                )
+                .unwrap(),
+        );
         assert_eq!(p.position(), [11.0, 22.0, 33.0]);
         assert_eq!(p.frame(), &CoordinateFrame::Crs(EpsgCode::new(6697)));
     }
@@ -515,16 +532,18 @@ mod convert_frame_tests {
     #[test]
     fn crs_to_euclidean_subtracts_base_point() {
         let mut cache = ReprojectionCache::new();
-        let mut p = Point3D::new(
-            CoordinateFrame::Crs(EpsgCode::new(6697)),
-            [11.0, 22.0, 33.0],
+        let p = point(
+            Point3D::new(
+                CoordinateFrame::Crs(EpsgCode::new(6697)),
+                [11.0, 22.0, 33.0],
+            )
+            .convert_frame(
+                &CoordinateFrame::Euclidean,
+                Some([10.0, 20.0, 30.0]),
+                &mut cache,
+            )
+            .unwrap(),
         );
-        p.convert_frame(
-            &CoordinateFrame::Euclidean,
-            Some([10.0, 20.0, 30.0]),
-            &mut cache,
-        )
-        .unwrap();
         assert_eq!(p.position(), [1.0, 2.0, 3.0]);
         assert_eq!(p.frame(), &CoordinateFrame::Euclidean);
     }
@@ -532,9 +551,11 @@ mod convert_frame_tests {
     #[test]
     fn as_is_bridge_only_retags() {
         let mut cache = ReprojectionCache::new();
-        let mut p = Point3D::new(CoordinateFrame::Euclidean, [1.0, 2.0, 3.0]);
-        p.convert_frame(&CoordinateFrame::Crs(EpsgCode::new(4979)), None, &mut cache)
-            .unwrap();
+        let p = point(
+            Point3D::new(CoordinateFrame::Euclidean, [1.0, 2.0, 3.0])
+                .convert_frame(&CoordinateFrame::Crs(EpsgCode::new(4979)), None, &mut cache)
+                .unwrap(),
+        );
         assert_eq!(p.position(), [1.0, 2.0, 3.0]);
         assert_eq!(p.frame(), &CoordinateFrame::Crs(EpsgCode::new(4979)));
     }
@@ -542,9 +563,11 @@ mod convert_frame_tests {
     #[test]
     fn same_crs_is_noop() {
         let mut cache = ReprojectionCache::new();
-        let mut p = Point3D::new(CoordinateFrame::Crs(EpsgCode::new(4979)), [1.0, 2.0, 3.0]);
-        p.convert_frame(&CoordinateFrame::Crs(EpsgCode::new(4979)), None, &mut cache)
-            .unwrap();
+        let p = point(
+            Point3D::new(CoordinateFrame::Crs(EpsgCode::new(4979)), [1.0, 2.0, 3.0])
+                .convert_frame(&CoordinateFrame::Crs(EpsgCode::new(4979)), None, &mut cache)
+                .unwrap(),
+        );
         assert_eq!(p.position(), [1.0, 2.0, 3.0]);
     }
 
@@ -552,12 +575,14 @@ mod convert_frame_tests {
     fn crs_to_crs_reprojects_without_a_base_point() {
         let mut cache = ReprojectionCache::new();
         // 4979 (geographic 3D) -> 4978 (ECEF) is a grid-free datum-identity transform.
-        let mut p = Point3D::new(
-            CoordinateFrame::Crs(EpsgCode::new(4979)),
-            [35.0, 139.0, 0.0],
+        let p = point(
+            Point3D::new(
+                CoordinateFrame::Crs(EpsgCode::new(4979)),
+                [35.0, 139.0, 0.0],
+            )
+            .convert_frame(&CoordinateFrame::Crs(EpsgCode::new(4978)), None, &mut cache)
+            .unwrap(),
         );
-        p.convert_frame(&CoordinateFrame::Crs(EpsgCode::new(4978)), None, &mut cache)
-            .unwrap();
         assert_eq!(p.frame(), &CoordinateFrame::Crs(EpsgCode::new(4978)));
         // ECEF magnitude is ~ Earth radius.
         let [x, y, z] = p.position();

--- a/engine/runtime/geometry/src/ops/mod.rs
+++ b/engine/runtime/geometry/src/ops/mod.rs
@@ -12,7 +12,9 @@ pub mod reproject;
 pub mod split;
 pub mod triangulation;
 
-pub(crate) use reproject::{axis_order_sign, crs_demote_to_2d, crs_is_linear, TwoDimensionalCrs, lift_coords};
+pub(crate) use reproject::{
+    axis_order_sign, crs_demote_to_2d, crs_is_linear, lift_coords, TwoDimensionalCrs,
+};
 pub use reproject::{Reproject, ReprojectionCache};
 pub use split::Split;
 

--- a/engine/runtime/geometry/src/ops/mod.rs
+++ b/engine/runtime/geometry/src/ops/mod.rs
@@ -329,9 +329,9 @@ impl<T: ForceTwoDimension + ?Sized> ForceTwoDimension for Box<T> {
 /// job of [`Reproject`] and [`ConvertFrame`].
 #[enum_dispatch::enum_dispatch]
 pub trait Translate {
-    /// Add `delta` to every coordinate. For a 2D-embedded geometry, `delta`'s
-    /// `z` shifts the one elevation the leaf lies at, when it carries one. The
-    /// default body reports the type as unsupported; a leaf opts in by overriding it.
+    /// Add `delta` to every coordinate. For a 2D-embedded geometry, `delta`'s `z`
+    /// shifts the leaf's elevation when it carries one. The default body reports
+    /// the type as unsupported.
     fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
         let _ = delta;
         Err(Error::projection(format!(
@@ -350,12 +350,7 @@ impl<T: Translate + ?Sized> Translate for Box<T> {
 }
 
 /// Add `delta`'s `(x, y)` to a 2D coordinate buffer, and its `z` to the leaf's
-/// elevation when present.
-///
-/// A translation is rigid, so it shifts the one elevation the whole leaf lies at
-/// and the leaf stays planar. A leaf with no elevation does not acquire one, even
-/// from a delta with a non-zero `z`: it is pure 2D, and lifting it is a change of
-/// embedding rather than a translation.
+/// elevation when present. A leaf with no elevation does not acquire one.
 pub(crate) fn translate_2d(coords: &mut [[f64; 2]], z: &mut Option<f64>, delta: [f64; 3]) {
     for c in coords.iter_mut() {
         c[0] += delta[0];
@@ -387,15 +382,12 @@ pub(crate) fn translate_3d(coords: &mut [[f64; 3]], delta: [f64; 3]) {
 /// are left unchanged, so a ring's orientation follows the axis order of the
 /// frame it is retagged into. A `Tangent` frame on either side is rejected.
 ///
-/// Like [`Reproject`], a conversion consumes its input and returns a
-/// [`Geometry`](crate::Geometry): only the reprojecting step changes a
-/// geometry's embedding, so a 2.5D geometry stays 2.5D across the
-/// Euclidean/CRS boundary.
+/// Consumes its input and returns a [`Geometry`](crate::Geometry); only the
+/// reprojecting step changes a geometry's embedding.
 #[enum_dispatch::enum_dispatch]
 pub trait ConvertFrame {
     /// Convert every coordinate to `target`, consuming `self` into the result.
-    /// The default body reports the type as unsupported; a leaf opts in by
-    /// overriding it.
+    /// The default body reports the type as unsupported.
     fn convert_frame(
         &mut self,
         target: &crate::coordinate::CoordinateFrame,

--- a/engine/runtime/geometry/src/ops/mod.rs
+++ b/engine/runtime/geometry/src/ops/mod.rs
@@ -12,7 +12,7 @@ pub mod reproject;
 pub mod split;
 pub mod triangulation;
 
-pub(crate) use reproject::{axis_order_sign, crs_demote_to_2d, crs_is_linear, TwoDimensionalCrs};
+pub(crate) use reproject::{axis_order_sign, crs_demote_to_2d, crs_is_linear, TwoDimensionalCrs, lift_coords};
 pub use reproject::{Reproject, ReprojectionCache};
 pub use split::Split;
 
@@ -349,17 +349,20 @@ impl<T: Translate + ?Sized> Translate for Box<T> {
     }
 }
 
-/// Add `delta`'s `(x, y)` to a 2D coordinate buffer, and its `z` to a parallel
-/// elevation buffer when present.
-pub(crate) fn translate_2d(coords: &mut [[f64; 2]], z: Option<&mut [f64]>, delta: [f64; 3]) {
+/// Add `delta`'s `(x, y)` to a 2D coordinate buffer, and its `z` to the leaf's
+/// elevation when present.
+///
+/// A translation is rigid, so it shifts the one elevation the whole leaf lies at
+/// and the leaf stays planar. A leaf with no elevation does not acquire one, even
+/// from a delta with a non-zero `z`: it is pure 2D, and lifting it is a change of
+/// embedding rather than a translation.
+pub(crate) fn translate_2d(coords: &mut [[f64; 2]], z: &mut Option<f64>, delta: [f64; 3]) {
     for c in coords.iter_mut() {
         c[0] += delta[0];
         c[1] += delta[1];
     }
-    if let Some(z) = z {
-        for elevation in z.iter_mut() {
-            *elevation += delta[2];
-        }
+    if let Some(elevation) = z {
+        *elevation += delta[2];
     }
 }
 

--- a/engine/runtime/geometry/src/ops/reproject/mod.rs
+++ b/engine/runtime/geometry/src/ops/reproject/mod.rs
@@ -52,26 +52,32 @@ pub fn transform_coords_3d(
 ///
 /// The elevation feeds the vertical component of every coordinate's transform, so
 /// the horizontal result is correct everywhere. The output elevation is then read
-/// off the **first** coordinate: a datum shift varies with position, so the
-/// transformed heights are not all equal, and a 2.5D leaf has exactly one to keep.
-/// Anything that needs the per-vertex vertical result is a 3D leaf, which
-/// [`transform_coords_3d`] handles exactly.
+/// off the **first** coordinate: the vertical result of a transform can vary with
+/// position, and a 2.5D leaf has exactly one height to keep. Anything that needs
+/// the per-vertex vertical result is a 3D leaf, which [`transform_coords_3d`]
+/// handles exactly.
+///
+/// A leaf with no coordinates offers no position at which to evaluate the vertical
+/// transform, so it comes out pure 2D rather than keeping a height that belongs to
+/// `from` while the leaf now declares `target`.
 pub(crate) fn transform_coords_2d(
     cache: &mut ReprojectionCache,
     from: EpsgCode,
     target: EpsgCode,
     coords: &mut [[f64; 2]],
-    z: Option<&mut f64>,
+    z: &mut Option<f64>,
 ) -> Result<()> {
-    let elevation = z.as_deref().copied().unwrap_or(0.0);
+    let elevation = z.unwrap_or(0.0);
     let mut first_out_z = None;
     for c in coords.iter_mut() {
         let [x, y, new_z] = cache.transform(from, target, [c[0], c[1], elevation])?;
         *c = [x, y];
-        first_out_z.get_or_insert(new_z);
+        if first_out_z.is_none() {
+            first_out_z = Some(new_z);
+        }
     }
-    if let (Some(z), Some(new_z)) = (z, first_out_z) {
-        *z = new_z;
+    if z.is_some() {
+        *z = first_out_z;
     }
     Ok(())
 }
@@ -235,6 +241,22 @@ mod tests {
         );
         ls.reproject(EpsgCode::new(3857), &mut cache).unwrap();
         // A leaf with no elevation does not acquire one from the transform.
+        assert_eq!(ls.elevation(), None);
+    }
+
+    #[test]
+    fn coordinateless_leaf_does_not_keep_a_source_frame_elevation() {
+        let mut cache = ReprojectionCache::new();
+        let mut ls = LineString2D::from_coords_at_elevation(
+            CoordinateFrame::Crs(EpsgCode::new(4326)),
+            Vec::<[f64; 2]>::new(),
+            10.0,
+        );
+        ls.reproject(EpsgCode::new(3857), &mut cache).unwrap();
+        // The frame moved, so an untransformed height would now be stated in a
+        // frame it was never expressed in. With no coordinate to evaluate the
+        // vertical transform at, the leaf comes out pure 2D instead.
+        assert_eq!(ls.frame(), &CoordinateFrame::Crs(EpsgCode::new(3857)));
         assert_eq!(ls.elevation(), None);
     }
 

--- a/engine/runtime/geometry/src/ops/reproject/mod.rs
+++ b/engine/runtime/geometry/src/ops/reproject/mod.rs
@@ -11,16 +11,12 @@ pub(crate) use ffi::{axis_order_sign, crs_demote_to_2d, crs_is_linear, TwoDimens
 
 /// Reproject a geometry's coordinates to a target CRS.
 ///
-/// Reprojection consumes its input. An implementor takes `&mut self`,
-/// deconstructs it, and returns a [`Geometry`] owning the reprojected buffers.
-///
-/// The result is a `Geometry` rather than `()` because reprojecting can change a
-/// geometry's embedding; a 2D leaf lying at a single elevation comes out 3D.
+/// Consumes its input: the implementor deconstructs `&mut self` into the
+/// returned [`Geometry`]. A 2D leaf lying at a single elevation comes out 3D.
 #[enum_dispatch::enum_dispatch]
 pub trait Reproject {
     /// Reproject every coordinate to `target` (an EPSG code), consuming `self`
-    /// into the result. The default body reports the type as unsupported; a leaf
-    /// opts in by overriding it.
+    /// into the result. The default body reports the type as unsupported.
     fn reproject(
         &mut self,
         target: EpsgCode,
@@ -34,8 +30,7 @@ pub trait Reproject {
     }
 }
 
-/// Pair a 2D coordinate buffer with the leaf's elevation, the shared body of
-/// every 2D leaf's `into_3d`.
+/// Pair a 2D coordinate buffer with the leaf's elevation.
 pub(crate) fn lift_coords<'a>(
     coords: impl IntoIterator<Item = &'a [f64; 2]>,
     z: Option<f64>,
@@ -163,7 +158,6 @@ mod tests {
 
         let mut p = Point2D::new(CoordinateFrame::Crs(EpsgCode::new(4326)), [35.681, 139.767]);
         let out = p.reproject(EpsgCode::new(3857), &mut cache).unwrap();
-        // A point carries no elevation, so it stays 2D.
         assert_eq!(
             out,
             Geometry::Euclidean2D(Euclidean2DGeometry::Point(Point2D::new(
@@ -185,7 +179,6 @@ mod tests {
                     .unwrap()
             })
             .collect();
-        // One shared elevation in, two different heights out.
         assert_ne!(expected[0][2], expected[1][2]);
 
         let mut ls = LineString2D::from_coords_at_elevation(
@@ -201,7 +194,6 @@ mod tests {
                 expected,
             )))
         );
-        // Deconstructed, not copied: the input is left empty.
         assert!(ls.coords().is_empty());
     }
 
@@ -235,7 +227,6 @@ mod tests {
             .clone()
             .reproject(EpsgCode::new(4979), &mut cache)
             .unwrap();
-        // Nothing reprojected, so the chain keeps its one elevation.
         assert_eq!(
             out,
             Geometry::Euclidean2D(Euclidean2DGeometry::LineString(before))
@@ -277,7 +268,6 @@ mod tests {
     #[test]
     fn a_2_5d_collection_gives_up_its_embedding_as_a_unit() {
         let mut cache = ReprojectionCache::new();
-        // One 2.5D member and one pure-2D member: all of it comes back 3D.
         let mut col = Collection2D::new([
             Euclidean2DGeometry::LineString(LineString2D::from_coords_at_elevation(
                 CoordinateFrame::Crs(EpsgCode::new(4979)),
@@ -305,7 +295,6 @@ mod tests {
             [[35.6, 139.7], [35.7, 139.8]],
         );
         let out = ls.reproject(EpsgCode::new(3857), &mut cache).unwrap();
-        // No elevation in, none acquired from the transform.
         let Geometry::Euclidean2D(Euclidean2DGeometry::LineString(ls)) = &out else {
             panic!("expected a 2D line string, got {out:?}");
         };
@@ -321,8 +310,6 @@ mod tests {
             10.0,
         );
         let out = ls.reproject(EpsgCode::new(4978), &mut cache).unwrap();
-        // No coordinate to evaluate the vertical transform at, so the height
-        // cannot be restated in the target frame.
         let Geometry::Euclidean3D(Euclidean3DGeometry::LineString(ls)) = &out else {
             panic!("expected a promoted 3D line string, got {out:?}");
         };

--- a/engine/runtime/geometry/src/ops/reproject/mod.rs
+++ b/engine/runtime/geometry/src/ops/reproject/mod.rs
@@ -2,6 +2,7 @@
 
 use crate::coordinate::EpsgCode;
 use crate::error::{Error, Result};
+use crate::Geometry;
 
 mod ffi;
 
@@ -9,15 +10,22 @@ pub use ffi::ReprojectionCache;
 pub(crate) use ffi::{axis_order_sign, crs_demote_to_2d, crs_is_linear, TwoDimensionalCrs};
 
 /// Reproject a geometry's coordinates to a target CRS.
+///
+/// Reprojection consumes its input. An implementor takes `&mut self`,
+/// deconstructs it, and returns a [`Geometry`] owning the reprojected buffers.
+///
+/// The result is a `Geometry` rather than `()` because reprojecting can change a
+/// geometry's embedding; a 2D leaf lying at a single elevation comes out 3D.
 #[enum_dispatch::enum_dispatch]
 pub trait Reproject {
-    /// Reproject every coordinate to `target` (an EPSG code). The default body
-    /// reports the type as unsupported; a leaf opts in by overriding it.
+    /// Reproject every coordinate to `target` (an EPSG code), consuming `self`
+    /// into the result. The default body reports the type as unsupported; a leaf
+    /// opts in by overriding it.
     fn reproject(
         &mut self,
         target: EpsgCode,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         let _ = (target, cache);
         Err(Error::projection(format!(
             "reproject is not supported by `{}`",
@@ -39,7 +47,7 @@ pub(crate) fn lift_coords<'a>(
 // The boxed enum variants (`Box<Polygon2D>`, `Box<Solid>`, …) need the trait on
 // the `Box` itself: `enum_dispatch` forwards by UFCS, not auto-deref.
 impl<T: Reproject + ?Sized> Reproject for Box<T> {
-    fn reproject(&mut self, target: EpsgCode, cache: &mut ReprojectionCache) -> Result<()> {
+    fn reproject(&mut self, target: EpsgCode, cache: &mut ReprojectionCache) -> Result<Geometry> {
         (**self).reproject(target, cache)
     }
 }
@@ -57,37 +65,16 @@ pub fn transform_coords_3d(
     Ok(())
 }
 
-/// Reproject a 2D coordinate buffer in place from `from` to `target` (EPSG),
-/// carrying the leaf's single elevation through the transform when present.
-///
-/// The elevation feeds the vertical component of every coordinate's transform, so
-/// the horizontal result is correct everywhere. The output elevation is then read
-/// off the **first** coordinate: the vertical result of a transform can vary with
-/// position, and a 2.5D leaf has exactly one height to keep. Anything that needs
-/// the per-vertex vertical result is a 3D leaf, which [`transform_coords_3d`]
-/// handles exactly.
-///
-/// A leaf with no coordinates offers no position at which to evaluate the vertical
-/// transform, so it comes out pure 2D rather than keeping a height that belongs to
-/// `from` while the leaf now declares `target`.
+/// Reproject a 2D coordinate buffer in place from `from` to `target` (EPSG).
 pub(crate) fn transform_coords_2d(
     cache: &mut ReprojectionCache,
     from: EpsgCode,
     target: EpsgCode,
     coords: &mut [[f64; 2]],
-    z: &mut Option<f64>,
 ) -> Result<()> {
-    let elevation = z.unwrap_or(0.0);
-    let mut first_out_z = None;
     for c in coords.iter_mut() {
-        let [x, y, new_z] = cache.transform(from, target, [c[0], c[1], elevation])?;
+        let [x, y, _] = cache.transform(from, target, [c[0], c[1], 0.0])?;
         *c = [x, y];
-        if first_out_z.is_none() {
-            first_out_z = Some(new_z);
-        }
-    }
-    if z.is_some() {
-        *z = first_out_z;
     }
     Ok(())
 }
@@ -97,12 +84,12 @@ mod tests {
     use approx::assert_relative_eq;
 
     use super::*;
-    use crate::collection::Collection3D;
+    use crate::collection::{Collection2D, Collection3D};
     use crate::coordinate::CoordinateFrame;
-    use crate::line_string::LineString2D;
+    use crate::line_string::{LineString2D, LineString3D};
     use crate::point::{Point2D, Point3D};
     use crate::point_cloud::PointCloud;
-    use crate::Euclidean3DGeometry;
+    use crate::{Euclidean2DGeometry, Euclidean3DGeometry};
 
     #[test]
     fn transform_round_trip_3d() {
@@ -153,10 +140,13 @@ mod tests {
             .unwrap();
 
         let mut p = Point3D::new(CoordinateFrame::Crs(EpsgCode::new(4979)), start);
-        p.reproject(EpsgCode::new(4978), &mut cache).unwrap();
+        let out = p.reproject(EpsgCode::new(4978), &mut cache).unwrap();
         assert_eq!(
-            p,
-            Point3D::new(CoordinateFrame::Crs(EpsgCode::new(4978)), expected)
+            out,
+            Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
+                CoordinateFrame::Crs(EpsgCode::new(4978)),
+                expected
+            )))
         );
     }
 
@@ -172,89 +162,83 @@ mod tests {
             .unwrap();
 
         let mut p = Point2D::new(CoordinateFrame::Crs(EpsgCode::new(4326)), [35.681, 139.767]);
-        p.reproject(EpsgCode::new(3857), &mut cache).unwrap();
+        let out = p.reproject(EpsgCode::new(3857), &mut cache).unwrap();
+        // A point carries no elevation, so it stays 2D.
         assert_eq!(
-            p,
-            Point2D::new(CoordinateFrame::Crs(EpsgCode::new(3857)), [x, y])
+            out,
+            Geometry::Euclidean2D(Euclidean2DGeometry::Point(Point2D::new(
+                CoordinateFrame::Crs(EpsgCode::new(3857)),
+                [x, y]
+            )))
         );
     }
 
     #[test]
-    fn scratch_euclid_crs_roundtrip() {
-        use crate::line_string::LineString2D;
-        use crate::ops::ConvertFrame;
-        use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry as G};
+    fn a_2_5d_leaf_reprojects_to_3d_keeping_every_vertical_result() {
         let mut cache = ReprojectionCache::new();
-        let pts = [[35.680, 139.760], [35.685, 139.765]];
-        let wgs = CoordinateFrame::Crs(EpsgCode::new(4326));
-        let euc = CoordinateFrame::Euclidean;
-        let bp = Some([1.0, 2.0, 3.0]);
-
-        let mk = |f: &CoordinateFrame| {
-            G::Euclidean2D(Euclidean2DGeometry::LineString(
-                LineString2D::from_coords_at_elevation(f.clone(), pts, 10.0),
-            ))
-        };
-        let label = |g: &G| match g {
-            G::Euclidean2D(Euclidean2DGeometry::LineString(l)) => format!(
-                "2.5D kept, elevation {:?}, frame {:?}",
-                l.elevation(),
-                l.frame()
-            ),
-            G::Euclidean3D(Euclidean3DGeometry::LineString(_)) => "PROMOTED TO 3D".to_string(),
-            _ => "other".into(),
-        };
-
-        for (name, src, dst, base) in [
-            ("euclid -> crs  (base point)", &euc, &wgs, bp),
-            ("crs    -> euclid (base point)", &wgs, &euc, bp),
-            ("euclid -> crs  (as-is)", &euc, &wgs, None),
-            ("crs    -> euclid (as-is)", &wgs, &euc, None),
-            ("euclid -> euclid (base point)", &euc, &euc, bp),
-            ("euclid -> euclid (as-is)", &euc, &euc, None),
-        ] {
-            let mut g = mk(src);
-            match g.convert_frame(dst, base, &mut cache) {
-                Ok(()) => println!("SCRATCH {name:<30} => {}", label(&g)),
-                Err(e) => println!("SCRATCH {name:<30} => ERR {e}"),
-            }
-        }
-
-        // And a full round trip: crs -> euclid -> crs.
-        let mut g = mk(&wgs);
-        g.convert_frame(&euc, bp, &mut cache).unwrap();
-        g.convert_frame(&wgs, bp, &mut cache).unwrap();
-        println!("SCRATCH {:<30} => {}", "crs -> euclid -> crs", label(&g));
-    }
-
-    #[test]
-    fn linestring2d_reproject_carries_elevation() {
-        let mut cache = ReprojectionCache::new();
-        let raw = [[35.6, 139.7], [35.7, 139.8]];
+        let raw = [[35.6, 139.7], [35.9, 140.0]];
         let expected: Vec<[f64; 3]> = raw
             .iter()
             .map(|&[x, y]| {
                 cache
-                    .transform(EpsgCode::new(4326), EpsgCode::new(3857), [x, y, 10.0])
+                    .transform(EpsgCode::new(4979), EpsgCode::new(4978), [x, y, 10.0])
                     .unwrap()
             })
             .collect();
+        // One shared elevation in, two different heights out.
+        assert_ne!(expected[0][2], expected[1][2]);
 
         let mut ls = LineString2D::from_coords_at_elevation(
-            CoordinateFrame::Crs(EpsgCode::new(4326)),
+            CoordinateFrame::Crs(EpsgCode::new(4979)),
             raw,
             10.0,
         );
-        ls.reproject(EpsgCode::new(3857), &mut cache).unwrap();
-        // The horizontal result comes from transforming each coordinate at the
-        // chain's elevation; the one elevation kept is the first coordinate's.
+        let out = ls.reproject(EpsgCode::new(4978), &mut cache).unwrap();
         assert_eq!(
-            ls,
+            out,
+            Geometry::Euclidean3D(Euclidean3DGeometry::LineString(LineString3D::from_coords(
+                CoordinateFrame::Crs(EpsgCode::new(4978)),
+                expected,
+            )))
+        );
+        // Deconstructed, not copied: the input is left empty.
+        assert!(ls.coords().is_empty());
+    }
+
+    #[test]
+    fn the_same_promotion_happens_through_geometry() {
+        let mut cache = ReprojectionCache::new();
+        let raw = [[35.6, 139.7], [35.9, 140.0]];
+        let mk = || {
             LineString2D::from_coords_at_elevation(
-                CoordinateFrame::Crs(EpsgCode::new(3857)),
-                expected.iter().map(|&[x, y, _]| [x, y]),
-                expected[0][2],
+                CoordinateFrame::Crs(EpsgCode::new(4979)),
+                raw,
+                10.0,
             )
+        };
+        let direct = mk().reproject(EpsgCode::new(4978), &mut cache).unwrap();
+        let via_geometry = Geometry::Euclidean2D(Euclidean2DGeometry::LineString(mk()))
+            .reproject(EpsgCode::new(4978), &mut cache)
+            .unwrap();
+        assert_eq!(direct, via_geometry);
+    }
+
+    #[test]
+    fn same_crs_reprojection_of_a_2_5d_leaf_keeps_it_2_5d() {
+        let mut cache = ReprojectionCache::new();
+        let before = LineString2D::from_coords_at_elevation(
+            CoordinateFrame::Crs(EpsgCode::new(4979)),
+            [[35.6, 139.7], [35.7, 139.8]],
+            10.0,
+        );
+        let out = before
+            .clone()
+            .reproject(EpsgCode::new(4979), &mut cache)
+            .unwrap();
+        // Nothing reprojected, so the chain keeps its one elevation.
+        assert_eq!(
+            out,
+            Geometry::Euclidean2D(Euclidean2DGeometry::LineString(before))
         );
     }
 
@@ -274,10 +258,10 @@ mod tests {
             Euclidean3DGeometry::Point(Point3D::new(CoordinateFrame::Crs(EpsgCode::new(4979)), a)),
             Euclidean3DGeometry::Point(Point3D::new(CoordinateFrame::Crs(EpsgCode::new(4979)), b)),
         ]);
-        col.reproject(EpsgCode::new(4978), &mut cache).unwrap();
+        let out = col.reproject(EpsgCode::new(4978), &mut cache).unwrap();
         assert_eq!(
-            col,
-            Collection3D::new([
+            out,
+            Geometry::Euclidean3D(Euclidean3DGeometry::Collection(Collection3D::new([
                 Euclidean3DGeometry::Point(Point3D::new(
                     CoordinateFrame::Crs(EpsgCode::new(4978)),
                     ea
@@ -286,8 +270,31 @@ mod tests {
                     CoordinateFrame::Crs(EpsgCode::new(4978)),
                     eb
                 )),
-            ])
+            ])))
         );
+    }
+
+    #[test]
+    fn a_2_5d_collection_gives_up_its_embedding_as_a_unit() {
+        let mut cache = ReprojectionCache::new();
+        // One 2.5D member and one pure-2D member: all of it comes back 3D.
+        let mut col = Collection2D::new([
+            Euclidean2DGeometry::LineString(LineString2D::from_coords_at_elevation(
+                CoordinateFrame::Crs(EpsgCode::new(4979)),
+                [[35.6, 139.7]],
+                10.0,
+            )),
+            Euclidean2DGeometry::Point(Point2D::new(
+                CoordinateFrame::Crs(EpsgCode::new(4979)),
+                [35.9, 140.0],
+            )),
+        ]);
+        let out = col.reproject(EpsgCode::new(4978), &mut cache).unwrap();
+        let Geometry::Euclidean3D(Euclidean3DGeometry::Collection(c)) = &out else {
+            panic!("expected a promoted 3D collection, got {out:?}");
+        };
+        assert_eq!(c.members().len(), 2);
+        assert!(matches!(c.members()[1], Euclidean3DGeometry::Point(_),));
     }
 
     #[test]
@@ -297,25 +304,30 @@ mod tests {
             CoordinateFrame::Crs(EpsgCode::new(4326)),
             [[35.6, 139.7], [35.7, 139.8]],
         );
-        ls.reproject(EpsgCode::new(3857), &mut cache).unwrap();
-        // A leaf with no elevation does not acquire one from the transform.
+        let out = ls.reproject(EpsgCode::new(3857), &mut cache).unwrap();
+        // No elevation in, none acquired from the transform.
+        let Geometry::Euclidean2D(Euclidean2DGeometry::LineString(ls)) = &out else {
+            panic!("expected a 2D line string, got {out:?}");
+        };
         assert_eq!(ls.elevation(), None);
     }
 
     #[test]
-    fn coordinateless_leaf_does_not_keep_a_source_frame_elevation() {
+    fn a_coordinateless_2_5d_leaf_promotes_rather_than_keeping_a_stale_height() {
         let mut cache = ReprojectionCache::new();
         let mut ls = LineString2D::from_coords_at_elevation(
-            CoordinateFrame::Crs(EpsgCode::new(4326)),
+            CoordinateFrame::Crs(EpsgCode::new(4979)),
             Vec::<[f64; 2]>::new(),
             10.0,
         );
-        ls.reproject(EpsgCode::new(3857), &mut cache).unwrap();
-        // The frame moved, so an untransformed height would now be stated in a
-        // frame it was never expressed in. With no coordinate to evaluate the
-        // vertical transform at, the leaf comes out pure 2D instead.
-        assert_eq!(ls.frame(), &CoordinateFrame::Crs(EpsgCode::new(3857)));
-        assert_eq!(ls.elevation(), None);
+        let out = ls.reproject(EpsgCode::new(4978), &mut cache).unwrap();
+        // No coordinate to evaluate the vertical transform at, so the height
+        // cannot be restated in the target frame.
+        let Geometry::Euclidean3D(Euclidean3DGeometry::LineString(ls)) = &out else {
+            panic!("expected a promoted 3D line string, got {out:?}");
+        };
+        assert_eq!(ls.frame(), &CoordinateFrame::Crs(EpsgCode::new(4978)));
+        assert!(ls.coords().is_empty());
     }
 
     #[test]
@@ -325,13 +337,13 @@ mod tests {
             CoordinateFrame::Crs(EpsgCode::new(4979)),
             [139.7, 35.6, 50.0],
         );
-        p.reproject(EpsgCode::new(4979), &mut cache).unwrap();
+        let out = p.reproject(EpsgCode::new(4979), &mut cache).unwrap();
         assert_eq!(
-            p,
-            Point3D::new(
+            out,
+            Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
                 CoordinateFrame::Crs(EpsgCode::new(4979)),
                 [139.7, 35.6, 50.0]
-            )
+            )))
         );
     }
 

--- a/engine/runtime/geometry/src/ops/reproject/mod.rs
+++ b/engine/runtime/geometry/src/ops/reproject/mod.rs
@@ -48,32 +48,30 @@ pub fn transform_coords_3d(
 }
 
 /// Reproject a 2D coordinate buffer in place from `from` to `target` (EPSG),
-/// transforming the parallel elevation buffer too when present.
+/// carrying the leaf's single elevation through the transform when present.
+///
+/// The elevation feeds the vertical component of every coordinate's transform, so
+/// the horizontal result is correct everywhere. The output elevation is then read
+/// off the **first** coordinate: a datum shift varies with position, so the
+/// transformed heights are not all equal, and a 2.5D leaf has exactly one to keep.
+/// Anything that needs the per-vertex vertical result is a 3D leaf, which
+/// [`transform_coords_3d`] handles exactly.
 pub(crate) fn transform_coords_2d(
     cache: &mut ReprojectionCache,
     from: EpsgCode,
     target: EpsgCode,
     coords: &mut [[f64; 2]],
-    z: Option<&mut [f64]>,
+    z: Option<&mut f64>,
 ) -> Result<()> {
-    if let Some(elevations) = z {
-        if elevations.len() != coords.len() {
-            return Err(Error::projection(format!(
-                "elevation buffer length {} does not match coordinate count {}",
-                elevations.len(),
-                coords.len()
-            )));
-        }
-        for (c, elevation) in coords.iter_mut().zip(elevations.iter_mut()) {
-            let [x, y, new_z] = cache.transform(from, target, [c[0], c[1], *elevation])?;
-            *c = [x, y];
-            *elevation = new_z;
-        }
-    } else {
-        for c in coords.iter_mut() {
-            let [x, y, _] = cache.transform(from, target, [c[0], c[1], 0.0])?;
-            *c = [x, y];
-        }
+    let elevation = z.as_deref().copied().unwrap_or(0.0);
+    let mut first_out_z = None;
+    for c in coords.iter_mut() {
+        let [x, y, new_z] = cache.transform(from, target, [c[0], c[1], elevation])?;
+        *c = [x, y];
+        first_out_z.get_or_insert(new_z);
+    }
+    if let (Some(z), Some(new_z)) = (z, first_out_z) {
+        *z = new_z;
     }
     Ok(())
 }
@@ -168,26 +166,30 @@ mod tests {
     #[test]
     fn linestring2d_reproject_carries_elevation() {
         let mut cache = ReprojectionCache::new();
-        let raw = [[35.6, 139.7, 10.0], [35.7, 139.8, 20.0]];
+        let raw = [[35.6, 139.7], [35.7, 139.8]];
         let expected: Vec<[f64; 3]> = raw
             .iter()
-            .map(|&[x, y, z]| {
+            .map(|&[x, y]| {
                 cache
-                    .transform(EpsgCode::new(4326), EpsgCode::new(3857), [x, y, z])
+                    .transform(EpsgCode::new(4326), EpsgCode::new(3857), [x, y, 10.0])
                     .unwrap()
             })
             .collect();
 
-        let mut ls = LineString2D::from_coords_with_elevation(
+        let mut ls = LineString2D::from_coords_at_elevation(
             CoordinateFrame::Crs(EpsgCode::new(4326)),
             raw,
+            10.0,
         );
         ls.reproject(EpsgCode::new(3857), &mut cache).unwrap();
+        // The horizontal result comes from transforming each coordinate at the
+        // chain's elevation; the one elevation kept is the first coordinate's.
         assert_eq!(
             ls,
-            LineString2D::from_coords_with_elevation(
+            LineString2D::from_coords_at_elevation(
                 CoordinateFrame::Crs(EpsgCode::new(3857)),
-                expected
+                expected.iter().map(|&[x, y, _]| [x, y]),
+                expected[0][2],
             )
         );
     }
@@ -225,20 +227,15 @@ mod tests {
     }
 
     #[test]
-    fn mismatched_elevation_buffer_is_error() {
+    fn pure_2d_leaf_stays_pure_2d() {
         let mut cache = ReprojectionCache::new();
-        let mut coords = [[139.7, 35.6], [139.8, 35.7]];
-        let mut z = [10.0]; // one short of `coords`
-        assert!(matches!(
-            transform_coords_2d(
-                &mut cache,
-                EpsgCode::new(4326),
-                EpsgCode::new(3857),
-                &mut coords,
-                Some(&mut z)
-            ),
-            Err(Error::Projection(_))
-        ));
+        let mut ls = LineString2D::from_coords(
+            CoordinateFrame::Crs(EpsgCode::new(4326)),
+            [[35.6, 139.7], [35.7, 139.8]],
+        );
+        ls.reproject(EpsgCode::new(3857), &mut cache).unwrap();
+        // A leaf with no elevation does not acquire one from the transform.
+        assert_eq!(ls.elevation(), None);
     }
 
     #[test]

--- a/engine/runtime/geometry/src/ops/reproject/mod.rs
+++ b/engine/runtime/geometry/src/ops/reproject/mod.rs
@@ -26,6 +26,16 @@ pub trait Reproject {
     }
 }
 
+/// Pair a 2D coordinate buffer with the leaf's elevation, the shared body of
+/// every 2D leaf's `into_3d`.
+pub(crate) fn lift_coords<'a>(
+    coords: impl IntoIterator<Item = &'a [f64; 2]>,
+    z: Option<f64>,
+) -> Vec<[f64; 3]> {
+    let z = z.unwrap_or(0.0);
+    coords.into_iter().map(|&[x, y]| [x, y, z]).collect()
+}
+
 // The boxed enum variants (`Box<Polygon2D>`, `Box<Solid>`, …) need the trait on
 // the `Box` itself: `enum_dispatch` forwards by UFCS, not auto-deref.
 impl<T: Reproject + ?Sized> Reproject for Box<T> {
@@ -167,6 +177,54 @@ mod tests {
             p,
             Point2D::new(CoordinateFrame::Crs(EpsgCode::new(3857)), [x, y])
         );
+    }
+
+    #[test]
+    fn scratch_euclid_crs_roundtrip() {
+        use crate::line_string::LineString2D;
+        use crate::ops::ConvertFrame;
+        use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry as G};
+        let mut cache = ReprojectionCache::new();
+        let pts = [[35.680, 139.760], [35.685, 139.765]];
+        let wgs = CoordinateFrame::Crs(EpsgCode::new(4326));
+        let euc = CoordinateFrame::Euclidean;
+        let bp = Some([1.0, 2.0, 3.0]);
+
+        let mk = |f: &CoordinateFrame| {
+            G::Euclidean2D(Euclidean2DGeometry::LineString(
+                LineString2D::from_coords_at_elevation(f.clone(), pts, 10.0),
+            ))
+        };
+        let label = |g: &G| match g {
+            G::Euclidean2D(Euclidean2DGeometry::LineString(l)) => format!(
+                "2.5D kept, elevation {:?}, frame {:?}",
+                l.elevation(),
+                l.frame()
+            ),
+            G::Euclidean3D(Euclidean3DGeometry::LineString(_)) => "PROMOTED TO 3D".to_string(),
+            _ => "other".into(),
+        };
+
+        for (name, src, dst, base) in [
+            ("euclid -> crs  (base point)", &euc, &wgs, bp),
+            ("crs    -> euclid (base point)", &wgs, &euc, bp),
+            ("euclid -> crs  (as-is)", &euc, &wgs, None),
+            ("crs    -> euclid (as-is)", &wgs, &euc, None),
+            ("euclid -> euclid (base point)", &euc, &euc, bp),
+            ("euclid -> euclid (as-is)", &euc, &euc, None),
+        ] {
+            let mut g = mk(src);
+            match g.convert_frame(dst, base, &mut cache) {
+                Ok(()) => println!("SCRATCH {name:<30} => {}", label(&g)),
+                Err(e) => println!("SCRATCH {name:<30} => ERR {e}"),
+            }
+        }
+
+        // And a full round trip: crs -> euclid -> crs.
+        let mut g = mk(&wgs);
+        g.convert_frame(&euc, bp, &mut cache).unwrap();
+        g.convert_frame(&wgs, bp, &mut cache).unwrap();
+        println!("SCRATCH {:<30} => {}", "crs -> euclid -> crs", label(&g));
     }
 
     #[test]

--- a/engine/runtime/geometry/src/overlay/mod.rs
+++ b/engine/runtime/geometry/src/overlay/mod.rs
@@ -48,8 +48,8 @@
 //!   relationship that alone determines the result (disjoint, boundary-only
 //!   touch, containment, equality) bypasses the backend instead of trusting
 //!   its snapped output near zero-area configurations.
-//! - Output is pure 2D: any per-vertex elevation on the inputs is ignored and
-//!   dropped, and appearance does not propagate.
+//! - Output is pure 2D: any elevation on the inputs is ignored and dropped, and
+//!   appearance does not propagate.
 
 mod segments;
 mod shapes;

--- a/engine/runtime/geometry/src/point/ops.rs
+++ b/engine/runtime/geometry/src/point/ops.rs
@@ -1,6 +1,7 @@
 use super::{Point2D, Point3D};
 use crate::coordinate::{CoordinateFrame, EpsgCode};
 use crate::ops::{Aabb, BoundingBox, Reproject, ReprojectionCache, UnsupportedOperation};
+use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
 
 impl BoundingBox for Point2D {
     fn bounding_box(&self) -> Result<Aabb, UnsupportedOperation> {
@@ -14,20 +15,51 @@ impl BoundingBox for Point3D {
     }
 }
 
+impl Point2D {
+    /// Move the point out, leaving an empty husk.
+    fn take(&mut self) -> Self {
+        Self {
+            frame: std::mem::take(&mut self.frame),
+            position: std::mem::take(&mut self.position),
+        }
+    }
+
+    /// The leaf moved out and wrapped as a [`Geometry`].
+    fn take_geometry(&mut self) -> Geometry {
+        Geometry::Euclidean2D(Euclidean2DGeometry::Point(self.take()))
+    }
+}
+
+impl Point3D {
+    /// Move the point out, leaving an empty husk.
+    fn take(&mut self) -> Self {
+        Self {
+            frame: std::mem::take(&mut self.frame),
+            position: std::mem::take(&mut self.position),
+        }
+    }
+
+    /// The leaf moved out and wrapped as a [`Geometry`].
+    fn take_geometry(&mut self) -> Geometry {
+        Geometry::Euclidean3D(Euclidean3DGeometry::Point(self.take()))
+    }
+}
+
 impl Reproject for Point2D {
     fn reproject(
         &mut self,
         target: EpsgCode,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         let from = self.frame.require_crs()?;
+        let mut p = self.take();
         if from != target {
-            let [x, y] = self.position;
+            let [x, y] = p.position;
             let [nx, ny, _] = cache.transform(from, target, [x, y, 0.0])?;
-            self.position = [nx, ny];
-            self.frame = CoordinateFrame::Crs(target);
+            p.position = [nx, ny];
+            p.frame = CoordinateFrame::Crs(target);
         }
-        Ok(())
+        Ok(Geometry::Euclidean2D(Euclidean2DGeometry::Point(p)))
     }
 }
 
@@ -36,13 +68,14 @@ impl Reproject for Point3D {
         &mut self,
         target: EpsgCode,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         let from = self.frame.require_crs()?;
+        let mut p = self.take();
         if from != target {
-            self.position = cache.transform(from, target, self.position)?;
-            self.frame = CoordinateFrame::Crs(target);
+            p.position = cache.transform(from, target, p.position)?;
+            p.frame = CoordinateFrame::Crs(target);
         }
-        Ok(())
+        Ok(Geometry::Euclidean3D(Euclidean3DGeometry::Point(p)))
     }
 }
 
@@ -71,14 +104,14 @@ impl ConvertFrame for Point2D {
         target: &CoordinateFrame,
         base_point: Option<[f64; 3]>,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         match plan_frame_step(&self.frame, target, base_point)? {
-            FrameStep::Noop => Ok(()),
+            FrameStep::Noop => Ok(self.take_geometry()),
             FrameStep::Reproject(to) => self.reproject(to, cache),
             FrameStep::Translate(offset, frame) => {
                 self.translate(offset)?;
                 self.frame = frame;
-                Ok(())
+                Ok(self.take_geometry())
             }
         }
     }
@@ -90,14 +123,14 @@ impl ConvertFrame for Point3D {
         target: &CoordinateFrame,
         base_point: Option<[f64; 3]>,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         match plan_frame_step(&self.frame, target, base_point)? {
-            FrameStep::Noop => Ok(()),
+            FrameStep::Noop => Ok(self.take_geometry()),
             FrameStep::Reproject(to) => self.reproject(to, cache),
             FrameStep::Translate(offset, frame) => {
                 self.translate(offset)?;
                 self.frame = frame;
-                Ok(())
+                Ok(self.take_geometry())
             }
         }
     }

--- a/engine/runtime/geometry/src/point/ops.rs
+++ b/engine/runtime/geometry/src/point/ops.rs
@@ -164,7 +164,6 @@ impl Point2D {
     /// The 3D counterpart of this leaf, with every coordinate placed at the
     /// elevation the leaf lies at, or at `0.0` when it carries none.
     pub(crate) fn into_3d(self) -> Point3D {
-        // A point carries no elevation, so it lands at zero.
         let [x, y] = self.position;
         Point3D::new(self.frame, [x, y, 0.0])
     }

--- a/engine/runtime/geometry/src/point/ops.rs
+++ b/engine/runtime/geometry/src/point/ops.rs
@@ -127,6 +127,16 @@ impl ForceTwoDimension for Point3D {
     }
 }
 
+impl Point2D {
+    /// The 3D counterpart of this leaf, with every coordinate placed at the
+    /// elevation the leaf lies at, or at `0.0` when it carries none.
+    pub(crate) fn into_3d(self) -> Point3D {
+        // A point carries no elevation, so it lands at zero.
+        let [x, y] = self.position;
+        Point3D::new(self.frame, [x, y, 0.0])
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/point/ops.rs
+++ b/engine/runtime/geometry/src/point/ops.rs
@@ -137,7 +137,6 @@ impl ConvertFrame for Point3D {
 }
 
 use crate::ops::{ForceTwoDimension, ForceTwoDimensionError};
-use crate::Euclidean2DGeometry;
 
 impl ForceTwoDimension for Point2D {
     fn force_2d(&mut self) -> Result<Euclidean2DGeometry, ForceTwoDimensionError> {

--- a/engine/runtime/geometry/src/point/validation.rs
+++ b/engine/runtime/geometry/src/point/validation.rs
@@ -11,7 +11,7 @@ impl Validate for Point2D {
 
     fn check_finite(&self, _params: &ValidationParams) -> ValidationReport {
         ValidationReport::ran(|r| {
-            check_finite_2d(&self.frame, std::slice::from_ref(&self.position), None, r)
+            check_finite_2d(&self.frame, std::slice::from_ref(&self.position), r)
         })
     }
 }

--- a/engine/runtime/geometry/src/polygon/constructor.rs
+++ b/engine/runtime/geometry/src/polygon/constructor.rs
@@ -82,8 +82,8 @@ use state::{Empty, HasExterior};
 
 impl Polygon2D {
     /// Build a 2D polygon from an exterior ring and interior holes, each a
-    /// sequence of `[x, y]`. The result is pure 2D (no elevation, no allocation
-    /// for `z`); for per-vertex elevation use [`Polygon2D::from_rings_with_elevation`].
+    /// sequence of `[x, y]`. The result is pure 2D (no elevation); to place the
+    /// face at a height use [`Polygon2D::from_rings_at_elevation`].
     ///
     /// Rings are concatenated exterior-first and stored verbatim — *not* closed, so
     /// an open ring (first != last) is left as-is for later validation; empty
@@ -104,32 +104,28 @@ impl Polygon2D {
         }
     }
 
-    /// Build a 2.5D polygon from rings of `[x, y, z]`: the `(x, y)` populate
-    /// `coords` and the `z` the parallel elevation buffer. Use this for sources
-    /// that carry elevation on an otherwise 2D footprint (e.g. a height-tagged
-    /// shapefile or GeoPackage layer).
-    pub fn from_rings_with_elevation<E, I, R>(
+    /// Build a 2.5D polygon: an `[x, y]` footprint lying wholly at `elevation`.
+    /// Use this for sources that carry one height for an otherwise 2D footprint
+    /// (e.g. a height-tagged shapefile or GeoPackage layer). A boundary whose
+    /// vertices sit at differing heights is not representable here — that is a
+    /// [`Polygon3D`].
+    pub fn from_rings_at_elevation<E, I, R>(
         frame: CoordinateFrame,
         exterior: E,
         interiors: I,
+        elevation: f64,
     ) -> Self
     where
-        E: IntoIterator<Item = [f64; 3]>,
+        E: IntoIterator<Item = [f64; 2]>,
         I: IntoIterator<Item = R>,
-        R: IntoIterator<Item = [f64; 3]>,
+        R: IntoIterator<Item = [f64; 2]>,
     {
-        let (xyz, interior_offsets) = flatten_rings::<3, _, _, _>(exterior, interiors);
-        let mut coords = Vec::with_capacity(xyz.len());
-        let mut z = Vec::with_capacity(xyz.len());
-        for [x, y, zz] in xyz {
-            coords.push([x, y]);
-            z.push(zz);
-        }
+        let (coords, interior_offsets) = flatten_rings::<2, _, _, _>(exterior, interiors);
         Self {
             frame,
             coords: coords.into_boxed_slice(),
             interior_offsets: interior_offsets.into_boxed_slice(),
-            z: Some(z.into_boxed_slice()),
+            z: Some(elevation),
             appearance: None,
         }
     }
@@ -137,25 +133,15 @@ impl Polygon2D {
     /// Build directly from already-flattened CSR buffers, for callers that hold
     /// the leaf's exact layout (deserialization, slicing, geometry algorithms).
     ///
-    /// The layout invariants are validated: `z`, when present, must be parallel to
-    /// `coords`, and `interior_offsets` must be strictly increasing with each
-    /// offset in `1..coords.len()` (every ring non-empty, exterior included).
-    /// Violations return [`Error::InvalidGeometry`].
+    /// The layout invariant is validated: `interior_offsets` must be strictly
+    /// increasing with each offset in `1..coords.len()` (every ring non-empty,
+    /// exterior included). Violations return [`Error::InvalidGeometry`].
     pub fn from_raw_parts(
         frame: CoordinateFrame,
         coords: Box<[[f64; 2]]>,
         interior_offsets: Box<[u32]>,
-        z: Option<Box<[f64]>>,
+        z: Option<f64>,
     ) -> Result<Self, Error> {
-        if let Some(z) = z.as_ref() {
-            if z.len() != coords.len() {
-                return Err(Error::invalid_geometry(format!(
-                    "elevation buffer length {} does not match coordinate count {}",
-                    z.len(),
-                    coords.len()
-                )));
-            }
-        }
         check_offsets(&interior_offsets, coords.len())?;
         Ok(Self {
             frame,
@@ -654,17 +640,17 @@ mod tests {
     }
 
     #[test]
-    fn from_rings_with_elevation_splits_z() {
-        let p = Polygon2D::from_rings_with_elevation(
+    fn from_rings_at_elevation_keeps_one_height() {
+        let p = Polygon2D::from_rings_at_elevation(
             CoordinateFrame::Euclidean,
-            [[0.0, 0.0, 10.0], [1.0, 0.0, 11.0], [0.0, 1.0, 12.0]],
-            Vec::<Vec<[f64; 3]>>::new(),
+            [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
+            Vec::<Vec<[f64; 2]>>::new(),
+            10.0,
         );
-        let z = p.z.as_ref().expect("elevation present");
         assert_eq!(p.coords.len(), 3);
-        assert_eq!(z.len(), p.coords.len());
         assert_eq!(p.coords[1], [1.0, 0.0]);
-        assert_eq!(z[1], 11.0);
+        // One elevation for the face, not one per vertex.
+        assert_eq!(p.elevation(), Some(10.0));
     }
 
     #[test]
@@ -697,16 +683,12 @@ mod tests {
     }
 
     #[test]
-    fn from_raw_parts_rejects_unparallel_z() {
+    fn from_raw_parts_carries_elevation() {
         let coords: Box<[[f64; 2]]> = vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]].into_boxed_slice();
-        let err = Polygon2D::from_raw_parts(
-            CoordinateFrame::Euclidean,
-            coords,
-            Box::new([]),
-            Some(vec![0.0, 0.0].into_boxed_slice()),
-        )
-        .unwrap_err();
-        assert!(matches!(err, Error::InvalidGeometry(_)));
+        let p =
+            Polygon2D::from_raw_parts(CoordinateFrame::Euclidean, coords, Box::new([]), Some(7.5))
+                .expect("valid layout");
+        assert_eq!(p.elevation(), Some(7.5));
     }
 
     #[test]

--- a/engine/runtime/geometry/src/polygon/constructor.rs
+++ b/engine/runtime/geometry/src/polygon/constructor.rs
@@ -105,10 +105,6 @@ impl Polygon2D {
     }
 
     /// Build a 2.5D polygon: an `[x, y]` footprint lying wholly at `elevation`.
-    /// Use this for sources that carry one height for an otherwise 2D footprint
-    /// (e.g. a height-tagged shapefile or GeoPackage layer). A boundary whose
-    /// vertices sit at differing heights is not representable here — that is a
-    /// [`Polygon3D`].
     pub fn from_rings_at_elevation<E, I, R>(
         frame: CoordinateFrame,
         exterior: E,
@@ -649,7 +645,6 @@ mod tests {
         );
         assert_eq!(p.coords.len(), 3);
         assert_eq!(p.coords[1], [1.0, 0.0]);
-        // One elevation for the face, not one per vertex.
         assert_eq!(p.elevation(), Some(10.0));
     }
 

--- a/engine/runtime/geometry/src/polygon/mod.rs
+++ b/engine/runtime/geometry/src/polygon/mod.rs
@@ -36,9 +36,7 @@ pub struct Polygon2D {
     /// holes. exterior = `coords[0 .. first interior start (or end)]`;
     /// interior j = `coords[interior_offsets[j] .. interior_offsets[j+1] (or end)]`.
     interior_offsets: Box<[u32]>,
-    /// The one elevation the whole face lies at; `None` = pure 2D. Keeping this a
-    /// scalar is what makes the face genuinely planar: a boundary whose vertices
-    /// sit at differing heights is a [`Polygon3D`], not a lifted 2D face.
+    /// The elevation the whole face lies at. `None` = pure 2D.
     z: Option<f64>,
     /// Materials / themes / single-face binding, incl. per-theme UV parallel to
     /// `coords`; `None` = bare geometry.

--- a/engine/runtime/geometry/src/polygon/mod.rs
+++ b/engine/runtime/geometry/src/polygon/mod.rs
@@ -21,7 +21,7 @@ mod validation;
 
 pub use constructor::{state, PolygonBuilder2D, PolygonBuilder3D, PolygonFace};
 
-/// A planar polygon face in 2D space, with optional per-vertex elevation.
+/// A planar polygon face in 2D space, lying at a single optional elevation.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Polygon2D {
     /// Coordinate frame these coords are expressed in.
@@ -36,10 +36,10 @@ pub struct Polygon2D {
     /// holes. exterior = `coords[0 .. first interior start (or end)]`;
     /// interior j = `coords[interior_offsets[j] .. interior_offsets[j+1] (or end)]`.
     interior_offsets: Box<[u32]>,
-    /// Optional per-vertex elevation, parallel to `coords` (same ring
-    /// concatenation). INVARIANT: when `Some`, `z.len() == coords.len()`.
-    /// `None` = pure 2D (no allocation).
-    z: Option<Box<[f64]>>,
+    /// The one elevation the whole face lies at; `None` = pure 2D. Keeping this a
+    /// scalar is what makes the face genuinely planar: a boundary whose vertices
+    /// sit at differing heights is a [`Polygon3D`], not a lifted 2D face.
+    z: Option<f64>,
     /// Materials / themes / single-face binding, incl. per-theme UV parallel to
     /// `coords`; `None` = bare geometry.
     appearance: Option<Appearance>,
@@ -90,6 +90,12 @@ impl Polygon2D {
             let end = offsets.get(j + 1).map_or(coords.len(), |&o| o as usize);
             &coords[start..end]
         })
+    }
+
+    /// The elevation the face lies at, or `None` when it is pure 2D.
+    #[inline]
+    pub fn elevation(&self) -> Option<f64> {
+        self.z
     }
 
     /// Borrow the appearance, if any.

--- a/engine/runtime/geometry/src/polygon/ops.rs
+++ b/engine/runtime/geometry/src/polygon/ops.rs
@@ -29,18 +29,61 @@ impl BoundingBox for Polygon3D {
     }
 }
 
+impl Polygon2D {
+    /// Move the face out, leaving an empty husk.
+    fn take(&mut self) -> Self {
+        Self {
+            frame: std::mem::take(&mut self.frame),
+            coords: std::mem::take(&mut self.coords),
+            interior_offsets: std::mem::take(&mut self.interior_offsets),
+            z: self.z.take(),
+            appearance: self.appearance.take(),
+        }
+    }
+
+    /// The leaf moved out and wrapped as a [`Geometry`].
+    fn take_geometry(&mut self) -> Geometry {
+        Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(Box::new(self.take())))
+    }
+}
+
+impl Polygon3D {
+    /// Move the face out, leaving an empty husk.
+    fn take(&mut self) -> Self {
+        Self {
+            frame: std::mem::take(&mut self.frame),
+            coords: std::mem::take(&mut self.coords),
+            interior_offsets: std::mem::take(&mut self.interior_offsets),
+            appearance: self.appearance.take(),
+        }
+    }
+
+    /// The leaf moved out and wrapped as a [`Geometry`].
+    fn take_geometry(&mut self) -> Geometry {
+        Geometry::Euclidean3D(Euclidean3DGeometry::Polygon(Box::new(self.take())))
+    }
+}
+
 impl Reproject for Polygon2D {
     fn reproject(
         &mut self,
         target: EpsgCode,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         let from = self.frame.require_crs()?;
-        if from != target {
-            transform_coords_2d(cache, from, target, &mut self.coords, &mut self.z)?;
-            self.frame = CoordinateFrame::Crs(target);
+        if from == target {
+            return Ok(self.take_geometry());
         }
-        Ok(())
+        // One elevation cannot describe a position-varying vertical result.
+        if self.z.is_some() {
+            return self.take().into_3d().reproject(target, cache);
+        }
+        let mut p = self.take();
+        transform_coords_2d(cache, from, target, &mut p.coords)?;
+        p.frame = CoordinateFrame::Crs(target);
+        Ok(Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(
+            Box::new(p),
+        )))
     }
 }
 
@@ -49,13 +92,16 @@ impl Reproject for Polygon3D {
         &mut self,
         target: EpsgCode,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         let from = self.frame.require_crs()?;
+        let mut p = self.take();
         if from != target {
-            transform_coords_3d(cache, from, target, &mut self.coords)?;
-            self.frame = CoordinateFrame::Crs(target);
+            transform_coords_3d(cache, from, target, &mut p.coords)?;
+            p.frame = CoordinateFrame::Crs(target);
         }
-        Ok(())
+        Ok(Geometry::Euclidean3D(Euclidean3DGeometry::Polygon(
+            Box::new(p),
+        )))
     }
 }
 
@@ -81,14 +127,14 @@ impl ConvertFrame for Polygon2D {
         target: &CoordinateFrame,
         base_point: Option<[f64; 3]>,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         match plan_frame_step(&self.frame, target, base_point)? {
-            FrameStep::Noop => Ok(()),
+            FrameStep::Noop => Ok(self.take_geometry()),
             FrameStep::Reproject(to) => self.reproject(to, cache),
             FrameStep::Translate(offset, frame) => {
                 self.translate(offset)?;
                 self.frame = frame;
-                Ok(())
+                Ok(self.take_geometry())
             }
         }
     }
@@ -100,14 +146,14 @@ impl ConvertFrame for Polygon3D {
         target: &CoordinateFrame,
         base_point: Option<[f64; 3]>,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         match plan_frame_step(&self.frame, target, base_point)? {
-            FrameStep::Noop => Ok(()),
+            FrameStep::Noop => Ok(self.take_geometry()),
             FrameStep::Reproject(to) => self.reproject(to, cache),
             FrameStep::Translate(offset, frame) => {
                 self.translate(offset)?;
                 self.frame = frame;
-                Ok(())
+                Ok(self.take_geometry())
             }
         }
     }

--- a/engine/runtime/geometry/src/polygon/ops.rs
+++ b/engine/runtime/geometry/src/polygon/ops.rs
@@ -37,7 +37,7 @@ impl Reproject for Polygon2D {
     ) -> crate::error::Result<()> {
         let from = self.frame.require_crs()?;
         if from != target {
-            transform_coords_2d(cache, from, target, &mut self.coords, self.z.as_mut())?;
+            transform_coords_2d(cache, from, target, &mut self.coords, &mut self.z)?;
             self.frame = CoordinateFrame::Crs(target);
         }
         Ok(())

--- a/engine/runtime/geometry/src/polygon/ops.rs
+++ b/engine/runtime/geometry/src/polygon/ops.rs
@@ -74,7 +74,6 @@ impl Reproject for Polygon2D {
         if from == target {
             return Ok(self.take_geometry());
         }
-        // One elevation cannot describe a position-varying vertical result.
         if self.z.is_some() {
             return self.take().into_3d().reproject(target, cache);
         }
@@ -184,8 +183,6 @@ impl Triangulate for Polygon2D {
                 .map(|&i| unsafe { *self.coords.get_unchecked(i as usize) }),
         );
         triangulate_2d(earcut, &verts, &buffers.holes, &mut buffers.out);
-        // The face lies at one elevation, so the tessellation of its footprint
-        // lies at that same elevation: carry it across unchanged.
         // SAFETY: every earcut index is `< verts.len()`; count is a multiple of 3.
         let mut mesh = unsafe {
             match self.z {
@@ -349,9 +346,6 @@ impl ForceTwoDimension for Polygon3D {
 impl Polygon2D {
     /// The 3D counterpart of this leaf, with every coordinate placed at the
     /// elevation the leaf lies at, or at `0.0` when it carries none.
-    /// The rings, their CSR offsets and the appearance are all indexed by
-    /// corner, and lifting neither adds nor drops a corner, so they carry over
-    /// verbatim.
     pub(crate) fn into_3d(self) -> Polygon3D {
         Polygon3D {
             frame: self.frame,

--- a/engine/runtime/geometry/src/polygon/ops.rs
+++ b/engine/runtime/geometry/src/polygon/ops.rs
@@ -3,7 +3,7 @@ use crate::coordinate::{CoordinateFrame, EpsgCode};
 use crate::ops::reproject::{transform_coords_2d, transform_coords_3d};
 use crate::ops::triangulation::{expand_appearance, triangulate_2d, triangulate_3d, Cache};
 use crate::ops::{
-    Aabb, BoundingBox, Reproject, ReprojectionCache, Triangulate, UnsupportedOperation,
+    lift_coords, Aabb, BoundingBox, Reproject, ReprojectionCache, Triangulate, UnsupportedOperation,
 };
 use crate::triangular_mesh::{TriangularMesh2D, TriangularMesh3D};
 use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
@@ -63,7 +63,7 @@ use crate::ops::{plan_frame_step, translate_2d, translate_3d, ConvertFrame, Fram
 
 impl Translate for Polygon2D {
     fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
-        translate_2d(&mut self.coords, self.z.as_deref_mut(), delta);
+        translate_2d(&mut self.coords, &mut self.z, delta);
         Ok(())
     }
 }
@@ -297,6 +297,22 @@ impl ForceTwoDimension for Polygon3D {
             z: None,
             appearance: self.appearance.take(),
         })))
+    }
+}
+
+impl Polygon2D {
+    /// The 3D counterpart of this leaf, with every coordinate placed at the
+    /// elevation the leaf lies at, or at `0.0` when it carries none.
+    /// The rings, their CSR offsets and the appearance are all indexed by
+    /// corner, and lifting neither adds nor drops a corner, so they carry over
+    /// verbatim.
+    pub(crate) fn into_3d(self) -> Polygon3D {
+        Polygon3D {
+            frame: self.frame,
+            coords: lift_coords(self.coords.iter(), self.z).into_boxed_slice(),
+            interior_offsets: self.interior_offsets,
+            appearance: self.appearance,
+        }
     }
 }
 

--- a/engine/runtime/geometry/src/polygon/ops.rs
+++ b/engine/runtime/geometry/src/polygon/ops.rs
@@ -37,7 +37,7 @@ impl Reproject for Polygon2D {
     ) -> crate::error::Result<()> {
         let from = self.frame.require_crs()?;
         if from != target {
-            transform_coords_2d(cache, from, target, &mut self.coords, self.z.as_deref_mut())?;
+            transform_coords_2d(cache, from, target, &mut self.coords, self.z.as_mut())?;
             self.frame = CoordinateFrame::Crs(target);
         }
         Ok(())
@@ -129,50 +129,33 @@ impl Triangulate for Polygon2D {
         // earcut emits triangle corner indices into the gathered ring vertices
         // (3 per triangle, each < the vertex count), so the unchecked assembly is
         // sound. The gathered `verts` is the output mesh's own pool (not scratch).
-        let mut mesh = match &self.z {
-            None => {
-                let mut verts: Vec<[f64; 2]> = Vec::with_capacity(buffers.positions.len());
-                // SAFETY: `positions` are in-range indices into `coords`.
-                verts.extend(
-                    buffers
-                        .positions
-                        .iter()
-                        .map(|&i| unsafe { *self.coords.get_unchecked(i as usize) }),
-                );
-                triangulate_2d(earcut, &verts, &buffers.holes, &mut buffers.out);
-                // SAFETY: every earcut index is `< verts.len()`; count is a multiple of 3.
-                unsafe {
-                    TriangularMesh2D::from_parts_unchecked(
-                        self.frame.clone(),
-                        verts,
-                        buffers.out.len() / 3,
-                        buffers.out.iter().copied(),
-                    )
-                }
-            }
-            Some(z) => {
-                let mut verts: Vec<[f64; 3]> = Vec::with_capacity(buffers.positions.len());
-                verts.extend(buffers.positions.iter().map(|&i| {
-                    let i = i as usize;
-                    // SAFETY: `positions` index `coords`, and `z` is parallel to `coords`.
-                    let [x, y] = unsafe { *self.coords.get_unchecked(i) };
-                    [x, y, unsafe { *z.get_unchecked(i) }]
-                }));
-                // Triangulate the planar (x, y) footprint; elevation rides along.
-                earcut.earcut(
-                    verts.iter().map(|&[x, y, _]| [x, y]),
-                    &buffers.holes,
-                    &mut buffers.out,
-                );
-                // SAFETY: every earcut index is `< verts.len()`; count is a multiple of 3.
-                unsafe {
-                    TriangularMesh2D::from_parts_with_elevation_unchecked(
-                        self.frame.clone(),
-                        verts,
-                        buffers.out.len() / 3,
-                        buffers.out.iter().copied(),
-                    )
-                }
+        let mut verts: Vec<[f64; 2]> = Vec::with_capacity(buffers.positions.len());
+        // SAFETY: `positions` are in-range indices into `coords`.
+        verts.extend(
+            buffers
+                .positions
+                .iter()
+                .map(|&i| unsafe { *self.coords.get_unchecked(i as usize) }),
+        );
+        triangulate_2d(earcut, &verts, &buffers.holes, &mut buffers.out);
+        // The face lies at one elevation, so the tessellation of its footprint
+        // lies at that same elevation: carry it across unchanged.
+        // SAFETY: every earcut index is `< verts.len()`; count is a multiple of 3.
+        let mut mesh = unsafe {
+            match self.z {
+                None => TriangularMesh2D::from_parts_unchecked(
+                    self.frame.clone(),
+                    verts,
+                    buffers.out.len() / 3,
+                    buffers.out.iter().copied(),
+                ),
+                Some(elevation) => TriangularMesh2D::from_parts_at_elevation_unchecked(
+                    self.frame.clone(),
+                    verts,
+                    buffers.out.len() / 3,
+                    buffers.out.iter().copied(),
+                    elevation,
+                ),
             }
         };
         let src_corner: Vec<u32> = buffers
@@ -380,21 +363,19 @@ mod tests {
 
     #[test]
     fn polygon2d_preserves_elevation() {
-        let g = Polygon2D::from_rings_with_elevation(
+        let g = Polygon2D::from_rings_at_elevation(
             CoordinateFrame::Euclidean,
-            [
-                [0.0, 0.0, 10.0],
-                [4.0, 0.0, 11.0],
-                [4.0, 4.0, 12.0],
-                [0.0, 0.0, 10.0],
-            ],
-            Vec::<Vec<[f64; 3]>>::new(),
+            [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 0.0]],
+            Vec::<Vec<[f64; 2]>>::new(),
+            10.0,
         )
         .triangulate(&mut Cache::new())
         .unwrap();
-        // A 2.5D polygon stays a 2D mesh (the elevation rides along in the z buffer).
+        // A 2.5D polygon stays a 2D mesh, tessellated at the same one elevation.
         assert!(matches!(g, Geometry::Euclidean2D(_)));
-        assert_eq!(tri_mesh_2d(&g).num_triangles(), 1);
+        let m = tri_mesh_2d(&g);
+        assert_eq!(m.num_triangles(), 1);
+        assert_eq!(m.elevation(), Some(10.0));
     }
 
     #[test]

--- a/engine/runtime/geometry/src/polygon/validation.rs
+++ b/engine/runtime/geometry/src/polygon/validation.rs
@@ -2,11 +2,13 @@ use super::{Polygon2D, Polygon3D};
 use crate::validation_next::{
     check_chain_simple_2d, check_chain_simple_3d, check_degenerate_ring_2d,
     check_degenerate_ring_3d, check_duplicate_points, check_face_orientation_3d, check_finite_2d,
-    check_finite_3d, check_holes_in_exterior_2d, check_holes_in_exterior_3d, check_planarity_3d,
-    check_ring_orientation_2d, check_ring_pair_2d, check_ring_pair_3d, check_too_few_points_2d,
-    check_too_few_points_3d, check_unclosed_ring_2d, check_unclosed_ring_3d, open_ring, Validate,
-    ValidationParams, ValidationReport, ValidationType,
+    check_finite_3d, check_finite_elevation, check_holes_in_exterior_2d,
+    check_holes_in_exterior_3d, check_planarity_3d, check_ring_orientation_2d, check_ring_pair_2d,
+    check_ring_pair_3d, check_too_few_points_2d, check_too_few_points_3d, check_unclosed_ring_2d,
+    check_unclosed_ring_3d, open_ring, Validate, ValidationParams, ValidationReport,
+    ValidationType,
 };
+use crate::{Euclidean2DGeometry, Geometry};
 
 /// The checks that apply to a 2D polygon face. Planarity is omitted: a 2D face
 /// lies in the coordinate plane by construction, and its single elevation only
@@ -46,7 +48,14 @@ impl Validate for Polygon2D {
         // `coords` holds the exterior ring then all interior rings concatenated;
         // finiteness is a per-coordinate property, so scanning the whole buffer
         // covers every ring at once.
-        ValidationReport::ran(|r| check_finite_2d(&self.frame, &self.coords, self.z, r))
+        ValidationReport::ran(|r| {
+            check_finite_elevation(
+                self.z,
+                || Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(Box::new(self.clone()))),
+                r,
+            );
+            check_finite_2d(&self.frame, &self.coords, r);
+        })
     }
 
     fn check_too_few_points(&self, _params: &ValidationParams) -> ValidationReport {
@@ -70,8 +79,8 @@ impl Validate for Polygon2D {
     }
 
     fn check_duplicate_points(&self, params: &ValidationParams) -> ValidationReport {
-        // Coincidences are per ring, excluding the closing vertex; elevation is
-        // not considered.
+        // Coincidences are per ring, excluding the closing vertex. The face lies
+        // at one elevation, so two vertices coincide exactly when their (x, y) do.
         ValidationReport::ran(|r| {
             for ring in std::iter::once(self.exterior()).chain(self.interiors()) {
                 check_duplicate_points(

--- a/engine/runtime/geometry/src/polygon/validation.rs
+++ b/engine/runtime/geometry/src/polygon/validation.rs
@@ -9,7 +9,9 @@ use crate::validation_next::{
 };
 
 /// The checks that apply to a 2D polygon face. Planarity is omitted: a 2D face
-/// lies in the coordinate plane by construction, so it is trivially planar.
+/// lies in the coordinate plane by construction, and its single elevation only
+/// lifts that whole plane, so it is trivially planar. (A boundary whose vertices
+/// sit at differing heights is a `Polygon3D`, which does run the check.)
 const POLYGON_2D_CHECKS: [ValidationType; 8] = [
     ValidationType::Finite,
     ValidationType::TooFewPoints,
@@ -44,7 +46,7 @@ impl Validate for Polygon2D {
         // `coords` holds the exterior ring then all interior rings concatenated;
         // finiteness is a per-coordinate property, so scanning the whole buffer
         // covers every ring at once.
-        ValidationReport::ran(|r| check_finite_2d(&self.frame, &self.coords, self.z.as_deref(), r))
+        ValidationReport::ran(|r| check_finite_2d(&self.frame, &self.coords, self.z, r))
     }
 
     fn check_too_few_points(&self, _params: &ValidationParams) -> ValidationReport {

--- a/engine/runtime/geometry/src/polygon/validation.rs
+++ b/engine/runtime/geometry/src/polygon/validation.rs
@@ -11,9 +11,7 @@ use crate::validation_next::{
 use crate::{Euclidean2DGeometry, Geometry};
 
 /// The checks that apply to a 2D polygon face. Planarity is omitted: a 2D face
-/// lies in the coordinate plane by construction, and its single elevation only
-/// lifts that whole plane, so it is trivially planar. (A boundary whose vertices
-/// sit at differing heights is a `Polygon3D`, which does run the check.)
+/// is trivially planar.
 const POLYGON_2D_CHECKS: [ValidationType; 8] = [
     ValidationType::Finite,
     ValidationType::TooFewPoints,
@@ -79,8 +77,8 @@ impl Validate for Polygon2D {
     }
 
     fn check_duplicate_points(&self, params: &ValidationParams) -> ValidationReport {
-        // Coincidences are per ring, excluding the closing vertex. The face lies
-        // at one elevation, so two vertices coincide exactly when their (x, y) do.
+        // Coincidences are per ring, excluding the closing vertex; elevation is
+        // not considered.
         ValidationReport::ran(|r| {
             for ring in std::iter::once(self.exterior()).chain(self.interiors()) {
                 check_duplicate_points(

--- a/engine/runtime/geometry/src/polygon_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/constructor.rs
@@ -223,8 +223,7 @@ impl PolygonMesh2D {
     }
 
     /// Build a 2.5D mesh: an `[x, y]` vertex pool lying wholly at `elevation`,
-    /// with index-list faces (no holes). A surface whose vertices sit at differing
-    /// heights is not representable here — that is a [`PolygonMesh3D`].
+    /// with index-list faces (no holes).
     pub fn from_parts_at_elevation(
         frame: CoordinateFrame,
         vertices: Vec<[f64; 2]>,
@@ -792,7 +791,6 @@ mod tests {
         )
         .unwrap();
         assert_eq!(m.vertices, vec![[0., 0.], [1., 0.], [0., 1.]]);
-        // One elevation for the mesh, not one per vertex.
         assert_eq!(m.elevation(), Some(10.));
     }
 

--- a/engine/runtime/geometry/src/polygon_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/constructor.rs
@@ -222,28 +222,22 @@ impl PolygonMesh2D {
         })
     }
 
-    /// Build a 2.5D mesh from `[x, y, z]` vertices (the `(x, y)` populate the pool,
-    /// the `z` a parallel elevation buffer) and index-list faces (no holes).
-    pub fn from_parts_with_elevation(
+    /// Build a 2.5D mesh: an `[x, y]` vertex pool lying wholly at `elevation`,
+    /// with index-list faces (no holes). A surface whose vertices sit at differing
+    /// heights is not representable here — that is a [`PolygonMesh3D`].
+    pub fn from_parts_at_elevation(
         frame: CoordinateFrame,
-        vertices: Vec<[f64; 3]>,
+        vertices: Vec<[f64; 2]>,
         faces: impl IntoIterator<Item = impl IntoIterator<Item = u32>>,
+        elevation: f64,
     ) -> Result<Self, Error> {
         let (face_indices, face_offsets) = index_faces(vertices.len(), faces)?;
-        // Split the `[x, y, z]` vertices into the 2D pool and a parallel elevation buffer.
-        let mut xy = Vec::with_capacity(vertices.len());
-        let mut z = Vec::with_capacity(vertices.len());
-        for [x, y, elevation] in vertices {
-            xy.push([x, y]);
-            z.push(elevation);
-        }
-        let z = z.into_boxed_slice();
         let (face_indices, face_offsets, interior_offsets) =
-            pack_csr(xy.len(), face_indices, face_offsets, Vec::new());
+            pack_csr(vertices.len(), face_indices, face_offsets, Vec::new());
         Ok(Self {
             frame,
-            vertices: xy,
-            z: Some(z),
+            vertices,
+            z: Some(elevation),
             face_indices,
             face_offsets,
             interior_offsets,
@@ -788,16 +782,18 @@ mod tests {
     }
 
     #[test]
-    fn from_parts_with_elevation_splits_z() {
-        let verts = vec![[0., 0., 10.], [1., 0., 11.], [0., 1., 12.]];
-        let m = PolygonMesh2D::from_parts_with_elevation(
+    fn from_parts_at_elevation_keeps_one_height() {
+        let verts = vec![[0., 0.], [1., 0.], [0., 1.]];
+        let m = PolygonMesh2D::from_parts_at_elevation(
             CoordinateFrame::Euclidean,
             verts,
             vec![vec![0u32, 1, 2]],
+            10.,
         )
         .unwrap();
         assert_eq!(m.vertices, vec![[0., 0.], [1., 0.], [0., 1.]]);
-        assert_eq!(m.z.as_deref(), Some(&[10., 11., 12.][..]));
+        // One elevation for the mesh, not one per vertex.
+        assert_eq!(m.elevation(), Some(10.));
     }
 
     #[test]

--- a/engine/runtime/geometry/src/polygon_mesh/faces.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/faces.rs
@@ -98,16 +98,18 @@ pub(crate) fn for_each_face_coords<const N: usize>(
 impl PolygonMesh2D {
     /// Invoke `f` once per face with that face rebuilt as a standalone bare
     /// [`Polygon2D`] in the mesh's frame. Faces are streamed rather than
-    /// collected. Per-vertex elevation and appearance are not carried onto them.
+    /// collected. Appearance is not carried onto them; the mesh's elevation is,
+    /// since every face of it lies at that one height.
     pub(crate) fn for_each_face_polygon(&self, mut f: impl FnMut(Polygon2D)) {
         let (face_indices, face_offsets, interior_offsets) = self.csr_buffers();
         let frame = self.frame();
+        let elevation = self.elevation();
         for_each_face_coords(
             self.vertices(),
             face_indices,
             face_offsets,
             interior_offsets,
-            |rings| f(polygon_2d_from_rings(frame, rings)),
+            |rings| f(polygon_2d_from_rings(frame, rings, elevation)),
         );
     }
 }
@@ -130,8 +132,13 @@ impl PolygonMesh3D {
     }
 }
 
-/// Build a [`Polygon2D`] from a face's rings (exterior first, then holes).
-fn polygon_2d_from_rings(frame: &CoordinateFrame, rings: &[Vec<[f64; 2]>]) -> Polygon2D {
+/// Build a [`Polygon2D`] from a face's rings (exterior first, then holes), at the
+/// host mesh's `elevation`.
+fn polygon_2d_from_rings(
+    frame: &CoordinateFrame,
+    rings: &[Vec<[f64; 2]>],
+    elevation: Option<f64>,
+) -> Polygon2D {
     let exterior = rings
         .first()
         .map(Vec::as_slice)
@@ -139,7 +146,12 @@ fn polygon_2d_from_rings(frame: &CoordinateFrame, rings: &[Vec<[f64; 2]>]) -> Po
         .iter()
         .copied();
     let interiors = rings.iter().skip(1).map(|hole| hole.iter().copied());
-    Polygon2D::from_rings(frame.clone(), exterior, interiors)
+    match elevation {
+        None => Polygon2D::from_rings(frame.clone(), exterior, interiors),
+        Some(elevation) => {
+            Polygon2D::from_rings_at_elevation(frame.clone(), exterior, interiors, elevation)
+        }
+    }
 }
 
 /// Build a [`Polygon3D`] from a face's rings (exterior first, then holes).

--- a/engine/runtime/geometry/src/polygon_mesh/faces.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/faces.rs
@@ -98,8 +98,7 @@ pub(crate) fn for_each_face_coords<const N: usize>(
 impl PolygonMesh2D {
     /// Invoke `f` once per face with that face rebuilt as a standalone bare
     /// [`Polygon2D`] in the mesh's frame. Faces are streamed rather than
-    /// collected. Appearance is not carried onto them; the mesh's elevation is,
-    /// since every face of it lies at that one height.
+    /// collected. Appearance is not carried onto them; the mesh's elevation is.
     pub(crate) fn for_each_face_polygon(&self, mut f: impl FnMut(Polygon2D)) {
         let (face_indices, face_offsets, interior_offsets) = self.csr_buffers();
         let frame = self.frame();

--- a/engine/runtime/geometry/src/polygon_mesh/mod.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/mod.rs
@@ -31,8 +31,7 @@ pub struct PolygonMesh2D {
     /// Coordinate frame these vertices are expressed in.
     frame: CoordinateFrame,
     vertices: Vec<[f64; 2]>,
-    /// The one elevation the whole mesh lies at; `None` = pure 2D. A surface whose
-    /// vertices sit at differing heights is a [`PolygonMesh3D`], not this.
+    /// The elevation the whole mesh lies at. `None` = pure 2D.
     z: Option<f64>,
     /// All rings of all faces concatenated; each face is its exterior ring then
     /// its hole rings. A valid face has the exterior wound counter-clockwise and

--- a/engine/runtime/geometry/src/polygon_mesh/mod.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/mod.rs
@@ -7,8 +7,8 @@
 //! marks each hole ring's start, mirroring `Polygon` one level up.
 //!
 //! Comes in 2D and 3D variants. The 2D variant carries `vertices: Vec<[f64; 2]>`
-//! plus an optional per-vertex elevation buffer parallel to `vertices`, matching
-//! the 2D leaf convention.
+//! plus the one optional elevation the whole surface lies at, matching the 2D leaf
+//! convention.
 
 use serde::{Deserialize, Serialize};
 
@@ -24,16 +24,16 @@ mod validation;
 
 pub(crate) use ops::build_open_rings;
 
-/// A connected, vertex-sharing polygon mesh in 2D space, with optional
-/// per-vertex elevation.
+/// A connected, vertex-sharing polygon mesh in 2D space, lying at a single
+/// optional elevation.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct PolygonMesh2D {
     /// Coordinate frame these vertices are expressed in.
     frame: CoordinateFrame,
     vertices: Vec<[f64; 2]>,
-    /// Optional per-vertex elevation, parallel to `vertices`. INVARIANT: when
-    /// `Some`, `z.len() == vertices.len()`. `None` = pure 2D.
-    z: Option<Box<[f64]>>,
+    /// The one elevation the whole mesh lies at; `None` = pure 2D. A surface whose
+    /// vertices sit at differing heights is a [`PolygonMesh3D`], not this.
+    z: Option<f64>,
     /// All rings of all faces concatenated; each face is its exterior ring then
     /// its hole rings. A valid face has the exterior wound counter-clockwise and
     /// interiors clockwise in canonical orientation (see [`crate::coordinate`]:
@@ -117,6 +117,12 @@ impl PolygonMesh2D {
     #[inline]
     pub fn vertices(&self) -> &[[f64; 2]] {
         &self.vertices
+    }
+
+    /// The elevation the mesh lies at, or `None` when it is pure 2D.
+    #[inline]
+    pub fn elevation(&self) -> Option<f64> {
+        self.z
     }
 
     /// The number of faces.

--- a/engine/runtime/geometry/src/polygon_mesh/ops.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/ops.rs
@@ -41,7 +41,7 @@ impl Reproject for PolygonMesh2D {
     ) -> crate::error::Result<()> {
         let from = self.frame.require_crs()?;
         if from != target {
-            transform_coords_2d(cache, from, target, &mut self.vertices, self.z.as_mut())?;
+            transform_coords_2d(cache, from, target, &mut self.vertices, &mut self.z)?;
             self.frame = CoordinateFrame::Crs(target);
         }
         Ok(())

--- a/engine/runtime/geometry/src/polygon_mesh/ops.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/ops.rs
@@ -33,18 +33,67 @@ impl BoundingBox for PolygonMesh3D {
     }
 }
 
+impl PolygonMesh2D {
+    /// Move the mesh out, leaving an empty husk.
+    fn take(&mut self) -> Self {
+        Self {
+            frame: std::mem::take(&mut self.frame),
+            vertices: std::mem::take(&mut self.vertices),
+            z: self.z.take(),
+            face_indices: std::mem::take(&mut self.face_indices),
+            face_offsets: std::mem::take(&mut self.face_offsets),
+            interior_offsets: std::mem::take(&mut self.interior_offsets),
+            appearance: self.appearance.take(),
+        }
+    }
+
+    /// The leaf moved out and wrapped as a [`Geometry`].
+    fn take_geometry(&mut self) -> Geometry {
+        Geometry::Euclidean2D(Euclidean2DGeometry::PolygonMesh(Box::new(self.take())))
+    }
+}
+
+impl PolygonMesh3D {
+    /// Move the mesh out, leaving an empty husk.
+    fn take(&mut self) -> Self {
+        Self {
+            frame: std::mem::take(&mut self.frame),
+            data: PolygonMesh3DData {
+                vertices: std::mem::take(&mut self.data.vertices),
+                face_indices: std::mem::take(&mut self.data.face_indices),
+                face_offsets: std::mem::take(&mut self.data.face_offsets),
+                interior_offsets: std::mem::take(&mut self.data.interior_offsets),
+                appearance: self.data.appearance.take(),
+            },
+        }
+    }
+
+    /// The leaf moved out and wrapped as a [`Geometry`].
+    fn take_geometry(&mut self) -> Geometry {
+        Geometry::Euclidean3D(Euclidean3DGeometry::PolygonMesh(Box::new(self.take())))
+    }
+}
+
 impl Reproject for PolygonMesh2D {
     fn reproject(
         &mut self,
         target: EpsgCode,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         let from = self.frame.require_crs()?;
-        if from != target {
-            transform_coords_2d(cache, from, target, &mut self.vertices, &mut self.z)?;
-            self.frame = CoordinateFrame::Crs(target);
+        if from == target {
+            return Ok(self.take_geometry());
         }
-        Ok(())
+        // One elevation cannot describe a position-varying vertical result.
+        if self.z.is_some() {
+            return self.take().into_3d().reproject(target, cache);
+        }
+        let mut m = self.take();
+        transform_coords_2d(cache, from, target, &mut m.vertices)?;
+        m.frame = CoordinateFrame::Crs(target);
+        Ok(Geometry::Euclidean2D(Euclidean2DGeometry::PolygonMesh(
+            Box::new(m),
+        )))
     }
 }
 
@@ -53,13 +102,16 @@ impl Reproject for PolygonMesh3D {
         &mut self,
         target: EpsgCode,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         let from = self.frame.require_crs()?;
+        let mut m = self.take();
         if from != target {
-            transform_coords_3d(cache, from, target, self.data.vertices_mut())?;
-            self.frame = CoordinateFrame::Crs(target);
+            transform_coords_3d(cache, from, target, m.data.vertices_mut())?;
+            m.frame = CoordinateFrame::Crs(target);
         }
-        Ok(())
+        Ok(Geometry::Euclidean3D(Euclidean3DGeometry::PolygonMesh(
+            Box::new(m),
+        )))
     }
 }
 
@@ -85,14 +137,14 @@ impl ConvertFrame for PolygonMesh2D {
         target: &CoordinateFrame,
         base_point: Option<[f64; 3]>,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         match plan_frame_step(&self.frame, target, base_point)? {
-            FrameStep::Noop => Ok(()),
+            FrameStep::Noop => Ok(self.take_geometry()),
             FrameStep::Reproject(to) => self.reproject(to, cache),
             FrameStep::Translate(offset, frame) => {
                 self.translate(offset)?;
                 self.frame = frame;
-                Ok(())
+                Ok(self.take_geometry())
             }
         }
     }
@@ -104,14 +156,14 @@ impl ConvertFrame for PolygonMesh3D {
         target: &CoordinateFrame,
         base_point: Option<[f64; 3]>,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         match plan_frame_step(&self.frame, target, base_point)? {
-            FrameStep::Noop => Ok(()),
+            FrameStep::Noop => Ok(self.take_geometry()),
             FrameStep::Reproject(to) => self.reproject(to, cache),
             FrameStep::Translate(offset, frame) => {
                 self.translate(offset)?;
                 self.frame = frame;
-                Ok(())
+                Ok(self.take_geometry())
             }
         }
     }

--- a/engine/runtime/geometry/src/polygon_mesh/ops.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/ops.rs
@@ -41,13 +41,7 @@ impl Reproject for PolygonMesh2D {
     ) -> crate::error::Result<()> {
         let from = self.frame.require_crs()?;
         if from != target {
-            transform_coords_2d(
-                cache,
-                from,
-                target,
-                &mut self.vertices,
-                self.z.as_deref_mut(),
-            )?;
+            transform_coords_2d(cache, from, target, &mut self.vertices, self.z.as_mut())?;
             self.frame = CoordinateFrame::Crs(target);
         }
         Ok(())
@@ -185,33 +179,26 @@ impl Triangulate for PolygonMesh2D {
             &buffers.corner_src,
         );
         let triangle_count = buffers.tris.len() / 3;
-        // `tris` index the existing pool (each `< vertices.len()`) in triples.
-        let mut mesh = match std::mem::take(&mut self.z) {
-            Some(z) => {
-                let verts3: Vec<[f64; 3]> = std::mem::take(&mut self.vertices)
-                    .into_iter()
-                    .zip(z)
-                    .map(|([x, y], zz)| [x, y, zz])
-                    .collect();
-                // SAFETY: every index is `< verts3.len()`; count is a multiple of 3.
-                unsafe {
-                    TriangularMesh2D::from_parts_with_elevation_unchecked(
-                        self.frame.clone(),
-                        verts3,
-                        triangle_count,
-                        buffers.tris.iter().copied(),
-                    )
-                }
-            }
-            // SAFETY: every index is `< vertices.len()`; count is a multiple of 3.
-            None => unsafe {
-                TriangularMesh2D::from_parts_unchecked(
+        // `tris` index the existing pool (each `< vertices.len()`) in triples. The
+        // mesh lies at one elevation, so its tessellation lies at that same
+        // elevation: carry it across unchanged.
+        // SAFETY: every index is `< vertices.len()`; count is a multiple of 3.
+        let mut mesh = unsafe {
+            match self.z.take() {
+                Some(elevation) => TriangularMesh2D::from_parts_at_elevation_unchecked(
                     self.frame.clone(),
                     std::mem::take(&mut self.vertices),
                     triangle_count,
                     buffers.tris.iter().copied(),
-                )
-            },
+                    elevation,
+                ),
+                None => TriangularMesh2D::from_parts_unchecked(
+                    self.frame.clone(),
+                    std::mem::take(&mut self.vertices),
+                    triangle_count,
+                    buffers.tris.iter().copied(),
+                ),
+            }
         };
         mesh.set_raw_appearance(appearance);
         Ok(Geometry::Euclidean2D(Euclidean2DGeometry::TriangularMesh(

--- a/engine/runtime/geometry/src/polygon_mesh/ops.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/ops.rs
@@ -6,7 +6,7 @@ use crate::ops::triangulation::{
     expand_appearance, triangulate_2d, triangulate_3d, Cache, Triangulated,
 };
 use crate::ops::{
-    Aabb, BoundingBox, Reproject, ReprojectionCache, Triangulate, UnsupportedOperation,
+    lift_coords, Aabb, BoundingBox, Reproject, ReprojectionCache, Triangulate, UnsupportedOperation,
 };
 use crate::triangular_mesh::{TriangularMesh2D, TriangularMesh3D, TriangularMesh3DData};
 use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
@@ -67,7 +67,7 @@ use crate::ops::{plan_frame_step, translate_2d, translate_3d, ConvertFrame, Fram
 
 impl Translate for PolygonMesh2D {
     fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
-        translate_2d(&mut self.vertices, self.z.as_deref_mut(), delta);
+        translate_2d(&mut self.vertices, &mut self.z, delta);
         Ok(())
     }
 }
@@ -484,6 +484,25 @@ impl ForceTwoDimension for PolygonMesh3D {
             ),
             appearance: self.data.appearance.take(),
         })))
+    }
+}
+
+impl PolygonMesh2D {
+    /// The 3D counterpart of this leaf, with every coordinate placed at the
+    /// elevation the leaf lies at, or at `0.0` when it carries none.
+    /// The CSR face topology indexes the vertex pool, whose length lifting
+    /// leaves unchanged, so every index buffer keeps its width and contents.
+    pub(crate) fn into_3d(self) -> PolygonMesh3D {
+        PolygonMesh3D::new(
+            self.frame,
+            PolygonMesh3DData {
+                vertices: lift_coords(self.vertices.iter(), self.z),
+                face_indices: self.face_indices,
+                face_offsets: self.face_offsets,
+                interior_offsets: self.interior_offsets,
+                appearance: self.appearance,
+            },
+        )
     }
 }
 

--- a/engine/runtime/geometry/src/polygon_mesh/ops.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/ops.rs
@@ -888,10 +888,11 @@ mod tests {
 
     #[test]
     fn polygon_mesh2d_force_2d_clears_elevation() {
-        let mut mesh = PolygonMesh2D::from_parts_with_elevation(
+        let mut mesh = PolygonMesh2D::from_parts_at_elevation(
             CoordinateFrame::Crs(EpsgCode::new(6697)),
-            vec![[0.0, 0.0, 5.0], [2.0, 0.0, 6.0], [2.0, 2.0, 7.0]],
+            vec![[0.0, 0.0], [2.0, 0.0], [2.0, 2.0]],
             vec![vec![0u32, 1, 2]],
+            5.0,
         )
         .unwrap();
         let forced = match mesh.force_2d().unwrap() {

--- a/engine/runtime/geometry/src/polygon_mesh/ops.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/ops.rs
@@ -84,7 +84,6 @@ impl Reproject for PolygonMesh2D {
         if from == target {
             return Ok(self.take_geometry());
         }
-        // One elevation cannot describe a position-varying vertical result.
         if self.z.is_some() {
             return self.take().into_3d().reproject(target, cache);
         }
@@ -231,9 +230,7 @@ impl Triangulate for PolygonMesh2D {
             &buffers.corner_src,
         );
         let triangle_count = buffers.tris.len() / 3;
-        // `tris` index the existing pool (each `< vertices.len()`) in triples. The
-        // mesh lies at one elevation, so its tessellation lies at that same
-        // elevation: carry it across unchanged.
+        // `tris` index the existing pool (each `< vertices.len()`) in triples.
         // SAFETY: every index is `< vertices.len()`; count is a multiple of 3.
         let mut mesh = unsafe {
             match self.z.take() {
@@ -542,8 +539,6 @@ impl ForceTwoDimension for PolygonMesh3D {
 impl PolygonMesh2D {
     /// The 3D counterpart of this leaf, with every coordinate placed at the
     /// elevation the leaf lies at, or at `0.0` when it carries none.
-    /// The CSR face topology indexes the vertex pool, whose length lifting
-    /// leaves unchanged, so every index buffer keeps its width and contents.
     pub(crate) fn into_3d(self) -> PolygonMesh3D {
         PolygonMesh3D::new(
             self.frame,

--- a/engine/runtime/geometry/src/polygon_mesh/validation.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/validation.rs
@@ -359,9 +359,7 @@ impl Validate for PolygonMesh2D {
     }
 
     fn check_finite(&self, _params: &ValidationParams) -> ValidationReport {
-        ValidationReport::ran(|r| {
-            check_finite_2d(&self.frame, &self.vertices, self.z.as_deref(), r)
-        })
+        ValidationReport::ran(|r| check_finite_2d(&self.frame, &self.vertices, self.z, r))
     }
 
     fn check_too_few_points(&self, _params: &ValidationParams) -> ValidationReport {

--- a/engine/runtime/geometry/src/polygon_mesh/validation.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/validation.rs
@@ -419,8 +419,8 @@ impl Validate for PolygonMesh2D {
     }
 
     fn check_duplicate_points(&self, params: &ValidationParams) -> ValidationReport {
-        // A shared vertex pool should hold no coincident vertices. The mesh lies
-        // at one elevation, so two vertices coincide exactly when their (x, y) do.
+        // A shared vertex pool should hold no coincident vertices; elevation is
+        // not considered.
         ValidationReport::ran(|r| {
             check_duplicate_points(
                 &self.frame,

--- a/engine/runtime/geometry/src/polygon_mesh/validation.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/validation.rs
@@ -14,10 +14,11 @@ use crate::predicates::view3d::TriangleSet;
 use crate::validation_next::{
     check_chain_simple_2d, check_chain_simple_3d, check_degenerate_ring_2d,
     check_degenerate_ring_3d, check_duplicate_points, check_finite_2d, check_finite_3d,
-    check_holes_in_exterior_2d, check_holes_in_exterior_3d, check_ring_orientation_2d,
-    check_ring_pair_2d, check_ring_pair_3d, check_too_few_points_2d, check_too_few_points_3d,
-    check_unclosed_ring_2d, check_unclosed_ring_3d, open_ring, tetra_volume_6x, EdgeOrientation,
-    FaceOrientation, FaceTopology, Validate, ValidationParams, ValidationReport, ValidationType,
+    check_finite_elevation, check_holes_in_exterior_2d, check_holes_in_exterior_3d,
+    check_ring_orientation_2d, check_ring_pair_2d, check_ring_pair_3d, check_too_few_points_2d,
+    check_too_few_points_3d, check_unclosed_ring_2d, check_unclosed_ring_3d, open_ring,
+    tetra_volume_6x, EdgeOrientation, FaceOrientation, FaceTopology, Validate, ValidationParams,
+    ValidationReport, ValidationType,
 };
 use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
 
@@ -359,7 +360,14 @@ impl Validate for PolygonMesh2D {
     }
 
     fn check_finite(&self, _params: &ValidationParams) -> ValidationReport {
-        ValidationReport::ran(|r| check_finite_2d(&self.frame, &self.vertices, self.z, r))
+        ValidationReport::ran(|r| {
+            check_finite_elevation(
+                self.z,
+                || Geometry::Euclidean2D(Euclidean2DGeometry::PolygonMesh(Box::new(self.clone()))),
+                r,
+            );
+            check_finite_2d(&self.frame, &self.vertices, r);
+        })
     }
 
     fn check_too_few_points(&self, _params: &ValidationParams) -> ValidationReport {
@@ -411,8 +419,8 @@ impl Validate for PolygonMesh2D {
     }
 
     fn check_duplicate_points(&self, params: &ValidationParams) -> ValidationReport {
-        // A shared vertex pool should hold no coincident vertices; elevation is
-        // not considered.
+        // A shared vertex pool should hold no coincident vertices. The mesh lies
+        // at one elevation, so two vertices coincide exactly when their (x, y) do.
         ValidationReport::ran(|r| {
             check_duplicate_points(
                 &self.frame,

--- a/engine/runtime/geometry/src/predicates/kernel.rs
+++ b/engine/runtime/geometry/src/predicates/kernel.rs
@@ -397,8 +397,8 @@ pub enum CoordPos {
 /// Point-in-ring by winding number, with an on-boundary short-circuit.
 ///
 /// `ring` is a closed ring (first vertex == last), the storage convention of the
-/// [`Polygon`](mod@crate::polygon) leaves. A 2.5D leaf's elevation lifts the whole
-/// ring, so it cannot change the answer: the test is the XY-projection algorithm.
+/// [`Polygon`](mod@crate::polygon) leaves. The test is the XY-projection
+/// algorithm; a 2.5D leaf's elevation is ignored.
 pub fn coord_pos_relative_to_ring(coord: [f64; 2], ring: &[[f64; 2]]) -> CoordPos {
     if ring.is_empty() {
         return CoordPos::Outside;

--- a/engine/runtime/geometry/src/predicates/kernel.rs
+++ b/engine/runtime/geometry/src/predicates/kernel.rs
@@ -397,8 +397,8 @@ pub enum CoordPos {
 /// Point-in-ring by winding number, with an on-boundary short-circuit.
 ///
 /// `ring` is a closed ring (first vertex == last), the storage convention of the
-/// [`Polygon`](mod@crate::polygon) leaves. The `z` of any 2.5D ring is ignored:
-/// the test is the XY-projection algorithm.
+/// [`Polygon`](mod@crate::polygon) leaves. A 2.5D leaf's elevation lifts the whole
+/// ring, so it cannot change the answer: the test is the XY-projection algorithm.
 pub fn coord_pos_relative_to_ring(coord: [f64; 2], ring: &[[f64; 2]]) -> CoordPos {
     if ring.is_empty() {
         return CoordPos::Outside;

--- a/engine/runtime/geometry/src/predicates/mod.rs
+++ b/engine/runtime/geometry/src/predicates/mod.rs
@@ -20,7 +20,7 @@
 //!   named predicate (touches, crosses, overlaps, ...) and arbitrary DE-9IM
 //!   patterns can be read; meshes relate as their dissolved face union.
 //!
-//! The 2D leaves' optional per-vertex elevation is ignored throughout. The
+//! The 2D leaves' optional elevation is ignored throughout. The
 //! constructed counterparts, boolean overlay, line clipping, segment
 //! intersection points, live in [`overlay`](crate::overlay) over the same
 //! views and kernel.

--- a/engine/runtime/geometry/src/predicates/position.rs
+++ b/engine/runtime/geometry/src/predicates/position.rs
@@ -20,7 +20,7 @@
 //!   classification wins (`Inside` > `OnBoundary` > `Outside`), with the
 //!   line-endpoint boundary counted mod 2 across all line members.
 //!
-//! The optional per-vertex elevation of 2D leaves is ignored throughout.
+//! The optional elevation of 2D leaves is ignored throughout.
 
 use super::kernel::{coord_pos_relative_to_edges, point_on_segment, same_direction, CoordPos};
 use super::view::{AreaView, FaceView, Leaf2D, Operand2D, RingView};

--- a/engine/runtime/geometry/src/solid/ops.rs
+++ b/engine/runtime/geometry/src/solid/ops.rs
@@ -5,6 +5,7 @@ use crate::ops::triangulation::Cache;
 use crate::ops::{
     Aabb, BoundingBox, Reproject, ReprojectionCache, Triangulate, UnsupportedOperation,
 };
+use crate::triangular_mesh::TriangularMesh3DData;
 use crate::{Euclidean3DGeometry, Geometry};
 
 impl BoundingBox for Solid {
@@ -50,21 +51,43 @@ impl Shell {
     }
 }
 
+impl Solid {
+    /// Move the solid out, leaving an empty husk.
+    fn take(&mut self) -> Self {
+        Self {
+            frame: std::mem::take(&mut self.frame),
+            exterior: std::mem::replace(
+                &mut self.exterior,
+                Shell::TriangularMesh(TriangularMesh3DData::empty()),
+            ),
+            interiors: std::mem::take(&mut self.interiors),
+        }
+    }
+
+    /// The leaf moved out and wrapped as a [`Geometry`].
+    fn take_geometry(&mut self) -> Geometry {
+        Geometry::Euclidean3D(Euclidean3DGeometry::Solid(Box::new(self.take())))
+    }
+}
+
 impl Reproject for Solid {
     fn reproject(
         &mut self,
         target: EpsgCode,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         let from = self.frame.require_crs()?;
+        let mut solid = self.take();
         if from != target {
-            reproject_shell(&mut self.exterior, from, target, cache)?;
-            for shell in &mut self.interiors {
+            reproject_shell(&mut solid.exterior, from, target, cache)?;
+            for shell in &mut solid.interiors {
                 reproject_shell(shell, from, target, cache)?;
             }
-            self.frame = CoordinateFrame::Crs(target);
+            solid.frame = CoordinateFrame::Crs(target);
         }
-        Ok(())
+        Ok(Geometry::Euclidean3D(Euclidean3DGeometry::Solid(Box::new(
+            solid,
+        ))))
     }
 }
 
@@ -103,14 +126,14 @@ impl ConvertFrame for Solid {
         target: &CoordinateFrame,
         base_point: Option<[f64; 3]>,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         match plan_frame_step(&self.frame, target, base_point)? {
-            FrameStep::Noop => Ok(()),
+            FrameStep::Noop => Ok(self.take_geometry()),
             FrameStep::Reproject(to) => self.reproject(to, cache),
             FrameStep::Translate(offset, frame) => {
                 self.translate(offset)?;
                 self.frame = frame;
-                Ok(())
+                Ok(self.take_geometry())
             }
         }
     }

--- a/engine/runtime/geometry/src/triangular_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/constructor.rs
@@ -229,49 +229,38 @@ impl TriangularMesh2D {
         })
     }
 
-    /// Build a 2.5D mesh from `[x, y, z]` vertices: the `(x, y)` populate the
-    /// vertex pool and the `z` the parallel elevation buffer.
-    pub fn from_parts_with_elevation(
+    /// Build a 2.5D mesh: an `[x, y]` vertex pool lying wholly at `elevation`. A
+    /// triangulated surface whose vertices sit at differing heights (a TIN) is not
+    /// representable here — that is a [`TriangularMesh3D`].
+    pub fn from_parts_at_elevation(
         frame: CoordinateFrame,
-        vertices: Vec<[f64; 3]>,
+        vertices: Vec<[f64; 2]>,
         indices: impl IntoIterator<Item = u32>,
+        elevation: f64,
     ) -> Result<Self, Error> {
         let width = index_width_for(vertices.len());
         let triangles = triangles_checked(indices, vertices.len())?;
-        // Split the `[x, y, z]` vertices into the 2D pool and a parallel elevation buffer.
-        let mut xy = Vec::with_capacity(vertices.len());
-        let mut z = Vec::with_capacity(vertices.len());
-        for [x, y, elevation] in vertices {
-            xy.push([x, y]);
-            z.push(elevation);
-        }
         Ok(Self {
             frame,
-            vertices: xy,
-            z: Some(z.into_boxed_slice()),
+            vertices,
+            z: Some(elevation),
             indices: pack_checked(width, triangles),
             appearance: None,
         })
     }
 
-    /// Build a 2.5D mesh from `[x, y, z]` vertices without validating indices.
+    /// Build a 2.5D mesh at one `elevation` without validating indices.
     ///
     /// # Safety
     /// Same contract as [`TriangularMesh3DData::from_parts_unchecked`].
-    pub unsafe fn from_parts_with_elevation_unchecked(
+    pub unsafe fn from_parts_at_elevation_unchecked(
         frame: CoordinateFrame,
-        vertices: Vec<[f64; 3]>,
+        vertices: Vec<[f64; 2]>,
         triangle_count: usize,
         indices: impl IntoIterator<Item = u32>,
+        elevation: f64,
     ) -> Self {
         let width = index_width_for(vertices.len());
-        // Split the `[x, y, z]` vertices into the 2D pool and a parallel elevation buffer.
-        let mut xy = Vec::with_capacity(vertices.len());
-        let mut z = Vec::with_capacity(vertices.len());
-        for [x, y, elevation] in vertices {
-            xy.push([x, y]);
-            z.push(elevation);
-        }
         Self {
             frame,
             indices: IndexBuffer::from_exact_unchecked(
@@ -279,8 +268,8 @@ impl TriangularMesh2D {
                 triangle_count,
                 group_triples(indices),
             ),
-            vertices: xy,
-            z: Some(z.into_boxed_slice()),
+            vertices,
+            z: Some(elevation),
             appearance: None,
         }
     }
@@ -588,16 +577,18 @@ mod tests {
     }
 
     #[test]
-    fn from_parts_with_elevation_splits_z() {
-        let verts = vec![[0.0, 0.0, 10.0], [1.0, 0.0, 11.0], [0.0, 1.0, 12.0]];
-        let m = TriangularMesh2D::from_parts_with_elevation(
+    fn from_parts_at_elevation_keeps_one_height() {
+        let verts = vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]];
+        let m = TriangularMesh2D::from_parts_at_elevation(
             CoordinateFrame::Euclidean,
             verts,
             [0u32, 1, 2],
+            10.0,
         )
         .unwrap();
         assert_eq!(m.vertices, vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]]);
-        assert_eq!(m.z.as_deref(), Some(&[10.0, 11.0, 12.0][..]));
+        // One elevation for the mesh, not one per vertex.
+        assert_eq!(m.elevation(), Some(10.0));
     }
 
     #[test]

--- a/engine/runtime/geometry/src/triangular_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/constructor.rs
@@ -238,9 +238,7 @@ impl TriangularMesh2D {
         })
     }
 
-    /// Build a 2.5D mesh: an `[x, y]` vertex pool lying wholly at `elevation`. A
-    /// triangulated surface whose vertices sit at differing heights (a TIN) is not
-    /// representable here — that is a [`TriangularMesh3D`].
+    /// Build a 2.5D mesh: an `[x, y]` vertex pool lying wholly at `elevation`.
     pub fn from_parts_at_elevation(
         frame: CoordinateFrame,
         vertices: Vec<[f64; 2]>,
@@ -596,7 +594,6 @@ mod tests {
         )
         .unwrap();
         assert_eq!(m.vertices, vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]]);
-        // One elevation for the mesh, not one per vertex.
         assert_eq!(m.elevation(), Some(10.0));
     }
 

--- a/engine/runtime/geometry/src/triangular_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/constructor.rs
@@ -36,6 +36,15 @@ use crate::index::{IndexBuffer, IndexWidth};
 use super::{TriangularMesh2D, TriangularMesh3D, TriangularMesh3DData};
 
 impl TriangularMesh3DData {
+    /// Mesh data with no vertices, no triangles and no appearance.
+    pub(crate) fn empty() -> Self {
+        Self {
+            vertices: Vec::new(),
+            indices: IndexBuffer::default(),
+            appearance: None,
+        }
+    }
+
     /// Build coordinate-free mesh data from a vertex pool and a flat `u32` index
     /// stream. Validates that the index count is a multiple of three and every
     /// index is `< vertices.len()`; the width is taken from the vertex count.

--- a/engine/runtime/geometry/src/triangular_mesh/mod.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/mod.rs
@@ -25,9 +25,7 @@ pub struct TriangularMesh2D {
     /// Coordinate frame these vertices are expressed in.
     frame: CoordinateFrame,
     vertices: Vec<[f64; 2]>,
-    /// The one elevation the whole mesh lies at; `None` = pure 2D. A triangulated
-    /// surface whose vertices sit at differing heights (a TIN) is a
-    /// [`TriangularMesh3D`], not this.
+    /// The elevation the whole mesh lies at. `None` = pure 2D.
     z: Option<f64>,
     /// Flat triangle index list; width from `vertices.len() - 1`. Each triangle is
     /// wound counter-clockwise in canonical orientation (see [`crate::coordinate`]:

--- a/engine/runtime/geometry/src/triangular_mesh/mod.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/mod.rs
@@ -5,8 +5,8 @@
 //! `vertices.len() - 1` at construction.
 //!
 //! Comes in 2D and 3D variants. The 2D variant carries `vertices: Vec<[f64; 2]>`
-//! plus an optional per-vertex elevation buffer parallel to `vertices`, matching
-//! the 2D leaf convention.
+//! plus the one optional elevation the whole surface lies at, matching the 2D leaf
+//! convention.
 
 use serde::{Deserialize, Serialize};
 
@@ -19,15 +19,16 @@ mod ops;
 #[cfg(feature = "new-geometry")]
 mod validation;
 
-/// A triangle mesh in 2D space, with optional per-vertex elevation.
+/// A triangle mesh in 2D space, lying at a single optional elevation.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct TriangularMesh2D {
     /// Coordinate frame these vertices are expressed in.
     frame: CoordinateFrame,
     vertices: Vec<[f64; 2]>,
-    /// Optional per-vertex elevation, parallel to `vertices`. INVARIANT: when
-    /// `Some`, `z.len() == vertices.len()`. `None` = pure 2D.
-    z: Option<Box<[f64]>>,
+    /// The one elevation the whole mesh lies at; `None` = pure 2D. A triangulated
+    /// surface whose vertices sit at differing heights (a TIN) is a
+    /// [`TriangularMesh3D`], not this.
+    z: Option<f64>,
     /// Flat triangle index list; width from `vertices.len() - 1`. Each triangle is
     /// wound counter-clockwise in canonical orientation (see [`crate::coordinate`]:
     /// judged after applying the frame's orientation sign, not by the raw signed
@@ -90,6 +91,12 @@ impl TriangularMesh2D {
     #[inline]
     pub fn vertices(&self) -> &[[f64; 2]] {
         &self.vertices
+    }
+
+    /// The elevation the mesh lies at, or `None` when it is pure 2D.
+    #[inline]
+    pub fn elevation(&self) -> Option<f64> {
+        self.z
     }
 
     /// The number of triangles in the mesh.

--- a/engine/runtime/geometry/src/triangular_mesh/ops.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/ops.rs
@@ -337,10 +337,11 @@ mod tests {
     fn triangular_mesh2d_force_2d_clears_elevation() {
         use crate::coordinate::EpsgCode;
 
-        let mut mesh = TriangularMesh2D::from_parts_with_elevation(
+        let mut mesh = TriangularMesh2D::from_parts_at_elevation(
             CoordinateFrame::Crs(EpsgCode::new(6697)),
-            vec![[0.0, 0.0, 5.0], [2.0, 0.0, 6.0], [2.0, 2.0, 7.0]],
+            vec![[0.0, 0.0], [2.0, 0.0], [2.0, 2.0]],
             [0u32, 1, 2],
+            5.0,
         )
         .unwrap();
         let forced = match mesh.force_2d().unwrap() {

--- a/engine/runtime/geometry/src/triangular_mesh/ops.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/ops.rs
@@ -76,7 +76,6 @@ impl Reproject for TriangularMesh2D {
         if from == target {
             return Ok(self.take_geometry());
         }
-        // One elevation cannot describe a position-varying vertical result.
         if self.z.is_some() {
             return self.take().into_3d().reproject(target, cache);
         }
@@ -168,8 +167,6 @@ impl Split for TriangularMesh2D {
     ) -> Result<(), UnsupportedOperation> {
         let vertices = self.vertices();
         let frame = self.frame();
-        // The mesh lies at one elevation, so every triangle split out of it lies
-        // at that same elevation.
         let elevation = self.elevation();
         for [i, j, k] in self.triangles() {
             let ring = [
@@ -259,8 +256,6 @@ impl ForceTwoDimension for TriangularMesh3D {
 impl TriangularMesh2D {
     /// The 3D counterpart of this leaf, with every coordinate placed at the
     /// elevation the leaf lies at, or at `0.0` when it carries none.
-    /// The triangle index list indexes the vertex pool, whose length lifting
-    /// leaves unchanged, so the buffer keeps its width and contents.
     pub(crate) fn into_3d(self) -> TriangularMesh3D {
         TriangularMesh3D::new(
             self.frame,

--- a/engine/runtime/geometry/src/triangular_mesh/ops.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/ops.rs
@@ -35,13 +35,7 @@ impl Reproject for TriangularMesh2D {
     ) -> crate::error::Result<()> {
         let from = self.frame.require_crs()?;
         if from != target {
-            transform_coords_2d(
-                cache,
-                from,
-                target,
-                &mut self.vertices,
-                self.z.as_deref_mut(),
-            )?;
+            transform_coords_2d(cache, from, target, &mut self.vertices, self.z.as_mut())?;
             self.frame = CoordinateFrame::Crs(target);
         }
         Ok(())

--- a/engine/runtime/geometry/src/triangular_mesh/ops.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/ops.rs
@@ -35,7 +35,7 @@ impl Reproject for TriangularMesh2D {
     ) -> crate::error::Result<()> {
         let from = self.frame.require_crs()?;
         if from != target {
-            transform_coords_2d(cache, from, target, &mut self.vertices, self.z.as_mut())?;
+            transform_coords_2d(cache, from, target, &mut self.vertices, &mut self.z)?;
             self.frame = CoordinateFrame::Crs(target);
         }
         Ok(())

--- a/engine/runtime/geometry/src/triangular_mesh/ops.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/ops.rs
@@ -29,18 +29,63 @@ impl BoundingBox for TriangularMesh3D {
     }
 }
 
+impl TriangularMesh2D {
+    /// Move the mesh out, leaving an empty husk.
+    fn take(&mut self) -> Self {
+        Self {
+            frame: std::mem::take(&mut self.frame),
+            vertices: std::mem::take(&mut self.vertices),
+            z: self.z.take(),
+            indices: std::mem::take(&mut self.indices),
+            appearance: self.appearance.take(),
+        }
+    }
+
+    /// The leaf moved out and wrapped as a [`Geometry`].
+    fn take_geometry(&mut self) -> Geometry {
+        Geometry::Euclidean2D(Euclidean2DGeometry::TriangularMesh(Box::new(self.take())))
+    }
+}
+
+impl TriangularMesh3D {
+    /// Move the mesh out, leaving an empty husk.
+    fn take(&mut self) -> Self {
+        Self {
+            frame: std::mem::take(&mut self.frame),
+            data: TriangularMesh3DData {
+                vertices: std::mem::take(&mut self.data.vertices),
+                indices: std::mem::take(&mut self.data.indices),
+                appearance: self.data.appearance.take(),
+            },
+        }
+    }
+
+    /// The leaf moved out and wrapped as a [`Geometry`].
+    fn take_geometry(&mut self) -> Geometry {
+        Geometry::Euclidean3D(Euclidean3DGeometry::TriangularMesh(Box::new(self.take())))
+    }
+}
+
 impl Reproject for TriangularMesh2D {
     fn reproject(
         &mut self,
         target: EpsgCode,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         let from = self.frame.require_crs()?;
-        if from != target {
-            transform_coords_2d(cache, from, target, &mut self.vertices, &mut self.z)?;
-            self.frame = CoordinateFrame::Crs(target);
+        if from == target {
+            return Ok(self.take_geometry());
         }
-        Ok(())
+        // One elevation cannot describe a position-varying vertical result.
+        if self.z.is_some() {
+            return self.take().into_3d().reproject(target, cache);
+        }
+        let mut m = self.take();
+        transform_coords_2d(cache, from, target, &mut m.vertices)?;
+        m.frame = CoordinateFrame::Crs(target);
+        Ok(Geometry::Euclidean2D(Euclidean2DGeometry::TriangularMesh(
+            Box::new(m),
+        )))
     }
 }
 
@@ -49,13 +94,16 @@ impl Reproject for TriangularMesh3D {
         &mut self,
         target: EpsgCode,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         let from = self.frame.require_crs()?;
+        let mut m = self.take();
         if from != target {
-            transform_coords_3d(cache, from, target, self.data.vertices_mut())?;
-            self.frame = CoordinateFrame::Crs(target);
+            transform_coords_3d(cache, from, target, m.data.vertices_mut())?;
+            m.frame = CoordinateFrame::Crs(target);
         }
-        Ok(())
+        Ok(Geometry::Euclidean3D(Euclidean3DGeometry::TriangularMesh(
+            Box::new(m),
+        )))
     }
 }
 
@@ -81,14 +129,14 @@ impl ConvertFrame for TriangularMesh2D {
         target: &CoordinateFrame,
         base_point: Option<[f64; 3]>,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         match plan_frame_step(&self.frame, target, base_point)? {
-            FrameStep::Noop => Ok(()),
+            FrameStep::Noop => Ok(self.take_geometry()),
             FrameStep::Reproject(to) => self.reproject(to, cache),
             FrameStep::Translate(offset, frame) => {
                 self.translate(offset)?;
                 self.frame = frame;
-                Ok(())
+                Ok(self.take_geometry())
             }
         }
     }
@@ -100,14 +148,14 @@ impl ConvertFrame for TriangularMesh3D {
         target: &CoordinateFrame,
         base_point: Option<[f64; 3]>,
         cache: &mut ReprojectionCache,
-    ) -> crate::error::Result<()> {
+    ) -> crate::error::Result<Geometry> {
         match plan_frame_step(&self.frame, target, base_point)? {
-            FrameStep::Noop => Ok(()),
+            FrameStep::Noop => Ok(self.take_geometry()),
             FrameStep::Reproject(to) => self.reproject(to, cache),
             FrameStep::Translate(offset, frame) => {
                 self.translate(offset)?;
                 self.frame = frame;
-                Ok(())
+                Ok(self.take_geometry())
             }
         }
     }

--- a/engine/runtime/geometry/src/triangular_mesh/ops.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/ops.rs
@@ -1,7 +1,9 @@
-use super::{TriangularMesh2D, TriangularMesh3D};
+use super::{TriangularMesh2D, TriangularMesh3D, TriangularMesh3DData};
 use crate::coordinate::{CoordinateFrame, EpsgCode};
 use crate::ops::reproject::{transform_coords_2d, transform_coords_3d};
-use crate::ops::{Aabb, BoundingBox, Reproject, ReprojectionCache, UnsupportedOperation};
+use crate::ops::{
+    lift_coords, Aabb, BoundingBox, Reproject, ReprojectionCache, UnsupportedOperation,
+};
 
 use reearth_flow_common::attribute::Attributes;
 
@@ -61,7 +63,7 @@ use crate::ops::{plan_frame_step, translate_2d, translate_3d, ConvertFrame, Fram
 
 impl Translate for TriangularMesh2D {
     fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
-        translate_2d(&mut self.vertices, self.z.as_deref_mut(), delta);
+        translate_2d(&mut self.vertices, &mut self.z, delta);
         Ok(())
     }
 }
@@ -118,6 +120,9 @@ impl Split for TriangularMesh2D {
     ) -> Result<(), UnsupportedOperation> {
         let vertices = self.vertices();
         let frame = self.frame();
+        // The mesh lies at one elevation, so every triangle split out of it lies
+        // at that same elevation.
+        let elevation = self.elevation();
         for [i, j, k] in self.triangles() {
             let ring = [
                 vertices[i as usize],
@@ -125,7 +130,13 @@ impl Split for TriangularMesh2D {
                 vertices[k as usize],
                 vertices[i as usize],
             ];
-            let polygon = Polygon2D::from_rings(frame.clone(), ring, Vec::<Vec<[f64; 2]>>::new());
+            let no_holes = Vec::<Vec<[f64; 2]>>::new();
+            let polygon = match elevation {
+                None => Polygon2D::from_rings(frame.clone(), ring, no_holes),
+                Some(elevation) => {
+                    Polygon2D::from_rings_at_elevation(frame.clone(), ring, no_holes, elevation)
+                }
+            };
             emit(
                 Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(Box::new(polygon))),
                 Attributes::new(),
@@ -194,6 +205,23 @@ impl ForceTwoDimension for TriangularMesh3D {
                 appearance: self.data.appearance.take(),
             },
         )))
+    }
+}
+
+impl TriangularMesh2D {
+    /// The 3D counterpart of this leaf, with every coordinate placed at the
+    /// elevation the leaf lies at, or at `0.0` when it carries none.
+    /// The triangle index list indexes the vertex pool, whose length lifting
+    /// leaves unchanged, so the buffer keeps its width and contents.
+    pub(crate) fn into_3d(self) -> TriangularMesh3D {
+        TriangularMesh3D::new(
+            self.frame,
+            TriangularMesh3DData {
+                vertices: lift_coords(self.vertices.iter(), self.z),
+                indices: self.indices,
+                appearance: self.appearance,
+            },
+        )
     }
 }
 

--- a/engine/runtime/geometry/src/triangular_mesh/validation.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/validation.rs
@@ -10,8 +10,9 @@ use crate::predicates::view::AreaView;
 use crate::predicates::view3d::TriangleSet;
 use crate::validation_next::{
     check_degenerate_ring_2d, check_degenerate_ring_3d, check_duplicate_points,
-    check_edge_orientation_3d, check_finite_2d, check_finite_3d, check_ring_orientation_2d,
-    tetra_volume_6x, FaceTopology, Validate, ValidationParams, ValidationReport, ValidationType,
+    check_edge_orientation_3d, check_finite_2d, check_finite_3d, check_finite_elevation,
+    check_ring_orientation_2d, tetra_volume_6x, FaceTopology, Validate, ValidationParams,
+    ValidationReport, ValidationType,
 };
 use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
 
@@ -73,7 +74,18 @@ impl Validate for TriangularMesh2D {
     }
 
     fn check_finite(&self, _params: &ValidationParams) -> ValidationReport {
-        ValidationReport::ran(|r| check_finite_2d(&self.frame, &self.vertices, self.z, r))
+        ValidationReport::ran(|r| {
+            check_finite_elevation(
+                self.z,
+                || {
+                    Geometry::Euclidean2D(Euclidean2DGeometry::TriangularMesh(Box::new(
+                        self.clone(),
+                    )))
+                },
+                r,
+            );
+            check_finite_2d(&self.frame, &self.vertices, r);
+        })
     }
 
     fn check_orientation(&self, _params: &ValidationParams) -> ValidationReport {

--- a/engine/runtime/geometry/src/triangular_mesh/validation.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/validation.rs
@@ -73,9 +73,7 @@ impl Validate for TriangularMesh2D {
     }
 
     fn check_finite(&self, _params: &ValidationParams) -> ValidationReport {
-        ValidationReport::ran(|r| {
-            check_finite_2d(&self.frame, &self.vertices, self.z.as_deref(), r)
-        })
+        ValidationReport::ran(|r| check_finite_2d(&self.frame, &self.vertices, self.z, r))
     }
 
     fn check_orientation(&self, _params: &ValidationParams) -> ValidationReport {

--- a/engine/runtime/geometry/src/validation_next.rs
+++ b/engine/runtime/geometry/src/validation_next.rs
@@ -30,7 +30,7 @@ use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize)]
 pub enum ValidationType {
     /// Whether every coordinate component is finite (non-NaN, non-infinite),
-    /// and, on a 2D leaf, whether the elevation it lies at is.
+    /// including a 2D leaf's elevation.
     Finite,
     /// Whether a line or ring has fewer points than its type requires (line ≥ 2,
     /// closed ring ≥ 4).
@@ -746,8 +746,7 @@ pub(crate) fn open_ring<T: PartialEq>(ring: &[T]) -> &[T] {
 /// [`ValidationType::Finite`] problem per offending coordinate into `report`,
 /// positioned at a 2D point leaf in `frame`.
 ///
-/// A 2D leaf's elevation is not a coordinate component, so it is not scanned
-/// here; see [`check_finite_elevation`].
+/// The leaf's elevation is not scanned here; see [`check_finite_elevation`].
 pub(crate) fn check_finite_2d(
     frame: &CoordinateFrame,
     coords: &[[f64; 2]],
@@ -764,14 +763,7 @@ pub(crate) fn check_finite_2d(
 
 /// Check a 2D leaf's single elevation for a non-finite value, pushing one
 /// [`ValidationType::Finite`] problem into `report` positioned at the whole leaf
-/// that `position` builds.
-///
-/// The elevation belongs to the leaf, not to any one of its coordinates, so a bad
-/// one is a single fault reported once against the leaf itself. Positioning it at
-/// coordinates would both multiply the report by the vertex count and leave a
-/// coordinate-less leaf with nowhere to record the fault.
-///
-/// `position` is a closure so the leaf is only materialized on the failure path.
+/// that `position` builds. `position` is called only on failure.
 pub(crate) fn check_finite_elevation(
     z: Option<f64>,
     position: impl FnOnce() -> Geometry,
@@ -1373,9 +1365,7 @@ mod tests {
             f64::NAN,
         );
         let positions = failures(&validate_leaf(&ls, &params()), ValidationType::Finite);
-        // One elevation, one fault: the report does not scale with the vertex count.
         assert_eq!(positions.len(), 1);
-        // Positioned at the whole leaf, since the elevation belongs to no coordinate.
         assert!(matches!(
             positions[0],
             Geometry::Euclidean2D(Euclidean2DGeometry::LineString(_))

--- a/engine/runtime/geometry/src/validation_next.rs
+++ b/engine/runtime/geometry/src/validation_next.rs
@@ -29,7 +29,8 @@ use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
 /// [validation matrix](validate#default-validation-per-leaf-type).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize)]
 pub enum ValidationType {
-    /// Whether every coordinate component is finite (non-NaN, non-infinite).
+    /// Whether every coordinate component is finite (non-NaN, non-infinite),
+    /// and, on a 2D leaf, whether the elevation it lies at is.
     Finite,
     /// Whether a line or ring has fewer points than its type requires (line ≥ 2,
     /// closed ring ≥ 4).
@@ -741,34 +742,43 @@ pub(crate) fn open_ring<T: PartialEq>(ring: &[T]) -> &[T] {
     }
 }
 
-/// Scan a 2D coordinate buffer (with the leaf's optional single elevation) for
-/// non-finite values, pushing one [`ValidationType::Finite`] problem per
-/// offending coordinate into `report`, positioned at a 2D point leaf in `frame`.
+/// Scan a 2D coordinate buffer for non-finite values, pushing one
+/// [`ValidationType::Finite`] problem per offending coordinate into `report`,
+/// positioned at a 2D point leaf in `frame`.
 ///
-/// A non-finite elevation belongs to the leaf as a whole, so it faults every
-/// coordinate rather than any one of them.
+/// A 2D leaf's elevation is not a coordinate component, so it is not scanned
+/// here; see [`check_finite_elevation`].
 pub(crate) fn check_finite_2d(
     frame: &CoordinateFrame,
     coords: &[[f64; 2]],
-    z: Option<f64>,
     report: &mut ValidationReport,
 ) {
-    let z_not_finite = z.is_some_and(|v| !v.is_finite());
     for c in coords.iter() {
-        if !c[0].is_finite() || !c[1].is_finite() || z_not_finite {
-            // When the elevation is the offending component, report a 3D point
-            // carrying it so the non-finite value is visible in the position;
-            // otherwise the finite [x, y] alone would hide where the fault is.
-            if z_not_finite {
-                report.push(Geometry::Euclidean3D(Euclidean3DGeometry::Point(
-                    Point3D::new(frame.clone(), [c[0], c[1], z.unwrap()]),
-                )));
-            } else {
-                report.push(Geometry::Euclidean2D(Euclidean2DGeometry::Point(
-                    Point2D::new(frame.clone(), *c),
-                )));
-            }
+        if !c[0].is_finite() || !c[1].is_finite() {
+            report.push(Geometry::Euclidean2D(Euclidean2DGeometry::Point(
+                Point2D::new(frame.clone(), *c),
+            )));
         }
+    }
+}
+
+/// Check a 2D leaf's single elevation for a non-finite value, pushing one
+/// [`ValidationType::Finite`] problem into `report` positioned at the whole leaf
+/// that `position` builds.
+///
+/// The elevation belongs to the leaf, not to any one of its coordinates, so a bad
+/// one is a single fault reported once against the leaf itself. Positioning it at
+/// coordinates would both multiply the report by the vertex count and leave a
+/// coordinate-less leaf with nowhere to record the fault.
+///
+/// `position` is a closure so the leaf is only materialized on the failure path.
+pub(crate) fn check_finite_elevation(
+    z: Option<f64>,
+    position: impl FnOnce() -> Geometry,
+    report: &mut ValidationReport,
+) {
+    if z.is_some_and(|v| !v.is_finite()) {
+        report.push(position());
     }
 }
 
@@ -1353,6 +1363,47 @@ mod tests {
         let second = offending_point(&positions[1]);
         assert!(second[1].is_nan());
         assert_eq!(second[0], 2.0);
+    }
+
+    #[test]
+    fn non_finite_elevation_reports_the_leaf_once() {
+        let ls = LineString2D::from_coords_at_elevation(
+            CoordinateFrame::Euclidean,
+            [[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]],
+            f64::NAN,
+        );
+        let positions = failures(&validate_leaf(&ls, &params()), ValidationType::Finite);
+        // One elevation, one fault: the report does not scale with the vertex count.
+        assert_eq!(positions.len(), 1);
+        // Positioned at the whole leaf, since the elevation belongs to no coordinate.
+        assert!(matches!(
+            positions[0],
+            Geometry::Euclidean2D(Euclidean2DGeometry::LineString(_))
+        ));
+    }
+
+    #[test]
+    fn non_finite_elevation_is_reported_without_coordinates() {
+        let ls = LineString2D::from_coords_at_elevation(
+            CoordinateFrame::Euclidean,
+            Vec::<[f64; 2]>::new(),
+            f64::INFINITY,
+        );
+        let positions = failures(&validate_leaf(&ls, &params()), ValidationType::Finite);
+        assert_eq!(positions.len(), 1);
+    }
+
+    #[test]
+    fn finite_elevation_passes() {
+        let ls = LineString2D::from_coords_at_elevation(
+            CoordinateFrame::Euclidean,
+            [[0.0, 0.0], [1.0, 0.0]],
+            10.0,
+        );
+        assert_eq!(
+            validate_leaf(&ls, &params())[&ValidationType::Finite],
+            ValidationResult::Success
+        );
     }
 
     #[test]

--- a/engine/runtime/geometry/src/validation_next.rs
+++ b/engine/runtime/geometry/src/validation_next.rs
@@ -741,25 +741,27 @@ pub(crate) fn open_ring<T: PartialEq>(ring: &[T]) -> &[T] {
     }
 }
 
-/// Scan a 2D coordinate buffer (with an optional parallel elevation buffer) for
+/// Scan a 2D coordinate buffer (with the leaf's optional single elevation) for
 /// non-finite values, pushing one [`ValidationType::Finite`] problem per
 /// offending coordinate into `report`, positioned at a 2D point leaf in `frame`.
+///
+/// A non-finite elevation belongs to the leaf as a whole, so it faults every
+/// coordinate rather than any one of them.
 pub(crate) fn check_finite_2d(
     frame: &CoordinateFrame,
     coords: &[[f64; 2]],
-    z: Option<&[f64]>,
+    z: Option<f64>,
     report: &mut ValidationReport,
 ) {
-    for (i, c) in coords.iter().enumerate() {
-        let zi = z.and_then(|zs| zs.get(i)).copied();
-        let z_not_finite = zi.is_some_and(|v| !v.is_finite());
+    let z_not_finite = z.is_some_and(|v| !v.is_finite());
+    for c in coords.iter() {
         if !c[0].is_finite() || !c[1].is_finite() || z_not_finite {
             // When the elevation is the offending component, report a 3D point
             // carrying it so the non-finite value is visible in the position;
             // otherwise the finite [x, y] alone would hide where the fault is.
             if z_not_finite {
                 report.push(Geometry::Euclidean3D(Euclidean3DGeometry::Point(
-                    Point3D::new(frame.clone(), [c[0], c[1], zi.unwrap()]),
+                    Point3D::new(frame.clone(), [c[0], c[1], z.unwrap()]),
                 )));
             } else {
                 report.push(Geometry::Euclidean2D(Euclidean2DGeometry::Point(

--- a/engine/runtime/geometry/src/validation_next/measure.rs
+++ b/engine/runtime/geometry/src/validation_next/measure.rs
@@ -11,7 +11,8 @@ use crate::line_string::{LineString2D, LineString3D};
 use crate::types::coordinate::Coordinate3D;
 use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
 
-/// The total Euclidean length of a 2D chain (elevation ignored).
+/// The total Euclidean length of a 2D chain. A 2.5D leaf's elevation lifts the
+/// whole chain, so it does not change the length.
 pub(crate) fn chain_length_2d(coords: &[[f64; 2]]) -> f64 {
     coords
         .windows(2)

--- a/engine/runtime/geometry/src/validation_next/measure.rs
+++ b/engine/runtime/geometry/src/validation_next/measure.rs
@@ -11,8 +11,7 @@ use crate::line_string::{LineString2D, LineString3D};
 use crate::types::coordinate::Coordinate3D;
 use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
 
-/// The total Euclidean length of a 2D chain. A 2.5D leaf's elevation lifts the
-/// whole chain, so it does not change the length.
+/// The total Euclidean length of a 2D chain (elevation ignored).
 pub(crate) fn chain_length_2d(coords: &[[f64; 2]]) -> f64 {
     coords
         .windows(2)

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.89"
+version = "0.2.90"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.279"
+version = "0.1.280"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
# Overview
This PR fixes the 2.5D geometry definition; it's been optionally carrying one z-value per vertex, but this should really be one z-value per the whole geometry. The leaf types that fixed are; `LineString2D`, `Polygon2D`, `PolygonMesh2D`, and `TriangularMesh2D`.

## What's fixed downstream
- Constructors: (Currently no action uses it)
- Triangulations: (Currently no action uses it)
- Reprojections and Coordinate Frame Reprojection: When reprojecting between CRS coordinates, 2.5D geometries will be converted 3D geometry first, and then get reprojected as a 3D geometry, in order to take the vertical reprojection into account. For Euclidean <=> CRS conversion, 2.5D geometry stays 2.5D.
- Validations: A guard is added for empty vertex pool, as empty vertex pool could still have NaN coordinate though the coordinate check is no-op. Everything else is unchanged.

## What's added
- `take()` functions is added for each leaf type in order to achieve zero-copy on type-changing reprojections.