### PR TITLE
fix(ui): sanitize non-finite node positions to prevent canvas crash on open

### DIFF
--- a/ui/src/features/Editor/hooks.ts
+++ b/ui/src/features/Editor/hooks.ts
@@ -32,6 +32,7 @@ import type { YWorkflow } from "@flow/lib/yjs/types";
 import useWorkflowTabs from "@flow/lib/yjs/useWorkflowTabs";
 import { useCurrentProject } from "@flow/stores";
 import type { Algorithm, Direction, Edge, Node } from "@flow/types";
+import { toFinitePosition } from "@flow/utils/toFinitePosition";
 
 import useCanvasCopyPaste from "./useCanvasCopyPaste";
 import useDebugRun from "./useDebugRun";
@@ -123,6 +124,9 @@ export default ({
       Object.values(rawNodes)
         .map((node) => ({
           ...node,
+          // A non-finite position persisted in the doc would give ReactFlow a
+          // NaN viewport and crash the canvas (React #185). Sanitize on read.
+          position: toFinitePosition(node.position),
           selected:
             selectedNodeIds.includes(node.id) && !node.selected
               ? true

--- a/ui/src/features/SharedCanvas/hooks.ts
+++ b/ui/src/features/SharedCanvas/hooks.ts
@@ -9,6 +9,7 @@ import { YWorkflow } from "@flow/lib/yjs/types";
 import useWorkflowTabs from "@flow/lib/yjs/useWorkflowTabs";
 import useYNode from "@flow/lib/yjs/useYNode";
 import type { Edge, Node } from "@flow/types";
+import { toFinitePosition } from "@flow/utils/toFinitePosition";
 
 export default ({
   yWorkflows,
@@ -45,6 +46,9 @@ export default ({
     () =>
       Object.values(rawNodes).map((node) => ({
         ...node,
+        // Sanitize non-finite positions so a poisoned doc cannot crash the
+        // canvas with a NaN viewport (React #185).
+        position: toFinitePosition(node.position),
         selected:
           selectedNodeIds.includes(node.id) && !node.selected
             ? true

--- a/ui/src/features/VersionCanvas/hooks.ts
+++ b/ui/src/features/VersionCanvas/hooks.ts
@@ -8,6 +8,7 @@ import { rebuildWorkflow } from "@flow/lib/yjs/conversions";
 import { YWorkflow } from "@flow/lib/yjs/types";
 import useWorkflowTabs from "@flow/lib/yjs/useWorkflowTabs";
 import { Edge, Node } from "@flow/types";
+import { toFinitePosition } from "@flow/utils/toFinitePosition";
 
 export default ({ yWorkflows }: { yWorkflows: YMap<YWorkflow> }) => {
   const { fitView } = useReactFlow();
@@ -36,6 +37,9 @@ export default ({ yWorkflows }: { yWorkflows: YMap<YWorkflow> }) => {
     () =>
       Object.values(rawNodes).map((node) => ({
         ...node,
+        // Sanitize non-finite positions so a poisoned doc cannot crash the
+        // canvas with a NaN viewport (React #185).
+        position: toFinitePosition(node.position),
         selected:
           selectedNodeIds.includes(node.id) && !node.selected
             ? true

--- a/ui/src/lib/yjs/conversions/rebuildWorkflow.test.ts
+++ b/ui/src/lib/yjs/conversions/rebuildWorkflow.test.ts
@@ -2,9 +2,9 @@ import * as Y from "yjs";
 
 import { Edge, Node } from "@flow/types";
 
-import { YWorkflow } from "../types";
+import { YNode, YWorkflow } from "../types";
 
-import { rebuildWorkflow } from "./rebuildWorkflow";
+import { reassembleNode, rebuildWorkflow } from "./rebuildWorkflow";
 import { yWorkflowConstructor } from "./yWorkflowConstructor";
 
 describe("rebuildWorkflow", () => {
@@ -72,6 +72,66 @@ describe("rebuildWorkflow", () => {
     expect(workflow.name).toEqual(name);
     expect(workflow.nodes).toEqual(nodes);
     expect(workflow.edges).toEqual(edges);
+  });
+
+  // Builds the exact poisoned-node shape decoded from the test-env doc:
+  // a node integrated in a Y.Doc whose `position` map holds the given x/y.
+  const makePoisonedYNode = (
+    officialName: string,
+    setPosition: (positionMap: Y.Map<unknown>) => void,
+  ): YNode => {
+    const yDoc = new Y.Doc();
+    const yNodes = yDoc.getMap<Y.Map<unknown>>("nodes");
+    const yNode = new Y.Map<unknown>();
+    yNode.set("id", `node-${officialName}`);
+    yNode.set("type", "transformer");
+    yNode.set("dragging", false);
+    const position = new Y.Map<unknown>();
+    yNode.set("position", position);
+    const data = new Y.Map<unknown>();
+    data.set("officialName", officialName);
+    yNode.set("data", data);
+    yNodes.set(`node-${officialName}`, yNode);
+    // Mutate the position AFTER integration, mirroring useYNode's raw
+    // `existingPosition.set("x", change.position.x)` write path.
+    setPosition(position);
+    return yNode as unknown as YNode;
+  };
+
+  test("reassembleNode returns a finite position when the stored position is NaN", () => {
+    // Reproduces the test-env room-open crash: screenToFlowPosition returns NaN
+    // when a node is added before the canvas pane is measured; the raw useYNode
+    // write persists it, and reassembleNode's `?? 0` does not catch NaN
+    // (NaN ?? 0 === NaN), so a NaN reaches ReactFlow and triggers the render loop.
+    const yNode = makePoisonedYNode("HorizontalReprojector", (position) => {
+      position.set("x", NaN);
+      position.set("y", NaN);
+    });
+
+    // Guard the reproduction: the stored value really is NaN.
+    expect((yNode.get("position") as Y.Map<number>).get("x")).toBeNaN();
+
+    const rebuilt = reassembleNode(yNode);
+
+    expect(Number.isFinite(rebuilt.position.x)).toBe(true);
+    expect(Number.isFinite(rebuilt.position.y)).toBe(true);
+    expect(rebuilt.position).toEqual({ x: 0, y: 0 });
+  });
+
+  test("reassembleNode returns a finite position when the position map is empty", () => {
+    // The sibling anomaly in the poisoned doc: a `position` Y.Map that exists
+    // but has no x/y keys. reassembleNode must still yield a finite point.
+    const yNode = makePoisonedYNode("VerticalReprojector", () => {
+      // intentionally set no x/y keys
+    });
+
+    expect([...(yNode.get("position") as Y.Map<number>).keys()]).toEqual([]);
+
+    const rebuilt = reassembleNode(yNode);
+
+    expect(Number.isFinite(rebuilt.position.x)).toBe(true);
+    expect(Number.isFinite(rebuilt.position.y)).toBe(true);
+    expect(rebuilt.position).toEqual({ x: 0, y: 0 });
   });
 
   test("should handle empty workflow", () => {

--- a/ui/src/lib/yjs/conversions/rebuildWorkflow.ts
+++ b/ui/src/lib/yjs/conversions/rebuildWorkflow.ts
@@ -3,17 +3,22 @@ import * as Y from "yjs";
 import { ProjectCorruptionError } from "@flow/errors";
 import { Workflow } from "@flow/types";
 import type { Edge, Node, NodeData, NodeType } from "@flow/types";
+import { toFinitePosition } from "@flow/utils/toFinitePosition";
 
 import type { YWorkflow, YEdge, YNode, YNodesMap, YEdgesMap } from "../types";
 
 export const reassembleNode = (yNode: YNode): Node => {
   const id = yNode.get("id")?.toString() as string;
 
+  // Guard against non-finite / missing coordinates. A NaN position (e.g. from
+  // screenToFlowPosition running before the canvas is measured) would otherwise
+  // reach ReactFlow and trigger an infinite render loop, making the project
+  // impossible to open. `?? 0` alone does NOT catch NaN (NaN ?? 0 === NaN).
   const positionMap = yNode.get("position") as Y.Map<any>;
-  const position = {
-    x: positionMap?.get("x") ?? 0,
-    y: positionMap?.get("y") ?? 0,
-  };
+  const position = toFinitePosition({
+    x: positionMap?.get("x"),
+    y: positionMap?.get("y"),
+  });
 
   const type = yNode.get("type")?.toString() as NodeType;
   const dragging = yNode.get("dragging") as boolean;

--- a/ui/src/utils/toFinitePosition.test.ts
+++ b/ui/src/utils/toFinitePosition.test.ts
@@ -1,0 +1,47 @@
+import { toFiniteNumber, toFinitePosition } from "./toFinitePosition";
+
+describe("toFiniteNumber", () => {
+  test("passes through a finite number", () => {
+    expect(toFiniteNumber(429)).toBe(429);
+    expect(toFiniteNumber(-200.25)).toBe(-200.25);
+    expect(toFiniteNumber(0)).toBe(0);
+  });
+
+  test("replaces NaN with the fallback", () => {
+    // This is the exact production gap: `NaN ?? 0` is NaN, so a nullish
+    // fallback does not catch it. A persisted NaN position reaches ReactFlow
+    // and triggers an infinite render loop (React #185), so the project cannot
+    // be opened.
+    expect(toFiniteNumber(NaN)).toBe(0);
+  });
+
+  test("replaces Infinity with the fallback", () => {
+    expect(toFiniteNumber(Infinity)).toBe(0);
+    expect(toFiniteNumber(-Infinity)).toBe(0);
+  });
+
+  test("replaces missing / non-numeric values with the fallback", () => {
+    expect(toFiniteNumber(undefined)).toBe(0);
+    expect(toFiniteNumber(null)).toBe(0);
+    expect(toFiniteNumber("429")).toBe(0);
+  });
+});
+
+describe("toFinitePosition", () => {
+  test("passes through a valid position", () => {
+    expect(toFinitePosition({ x: 429, y: 132 })).toEqual({ x: 429, y: 132 });
+  });
+
+  test("coerces a NaN position to the origin", () => {
+    expect(toFinitePosition({ x: NaN, y: NaN })).toEqual({ x: 0, y: 0 });
+  });
+
+  test("coerces an empty / missing position to the origin", () => {
+    expect(toFinitePosition({})).toEqual({ x: 0, y: 0 });
+    expect(toFinitePosition(undefined)).toEqual({ x: 0, y: 0 });
+  });
+
+  test("fills only the non-finite axis", () => {
+    expect(toFinitePosition({ x: 429, y: NaN })).toEqual({ x: 429, y: 0 });
+  });
+});

--- a/ui/src/utils/toFinitePosition.ts
+++ b/ui/src/utils/toFinitePosition.ts
@@ -1,0 +1,17 @@
+export type XYPosition = { x: number; y: number };
+
+// Coerce anything that is not a finite number to `fallback`. Unlike `?? 0`,
+// this catches NaN and Infinity (NaN ?? 0 === NaN). A non-finite node position
+// persisted in the Yjs doc — e.g. from screenToFlowPosition running before the
+// canvas is measured — otherwise reaches ReactFlow, produces a NaN viewport
+// transform, and triggers an infinite render loop (React #185) that makes the
+// project impossible to open.
+export const toFiniteNumber = (value: unknown, fallback = 0): number =>
+  typeof value === "number" && Number.isFinite(value) ? value : fallback;
+
+export const toFinitePosition = (
+  position?: { x?: unknown; y?: unknown } | null,
+): XYPosition => ({
+  x: toFiniteNumber(position?.x),
+  y: toFiniteNumber(position?.y),
+});


### PR DESCRIPTION
## Summary

Opening certain projects on the test environment fails: the canvas shows "something went wrong" and never loads. This fixes the crash by sanitizing non-finite node positions on every path that reads nodes out of the Yjs doc for rendering. It is a client-side fix and requires no server change.

## Symptoms

When opening an affected project (including a project that was shared and reimported), the console shows:

```
<circle> attribute cx: Expected length, "NaN".
<circle> attribute cy: Expected length, "NaN".
<pattern> attribute x/y: Expected length, "NaN".
Minified React error #185          (maximum update depth exceeded)
WebSocket ... closed before the connection is established   (repeated)
[yjs#509] Not same Y.Doc
```

The server logs stay clean the entire time.

## Root cause

A node in the doc has a non-finite `position`. Decoding the actual failing room off the WebSocket showed:

| node | position | notes |
|---|---|---|
| GeoPackage Reader | `{x:429, y:132}` | healthy |
| Vertical Reprojector | `{}` | position map present but empty (no x/y) |
| Horizontal Reprojector | `{x:NaN, y:NaN}` | non-finite |

The canvas builds its ReactFlow `nodes` from the Yjs doc and read positions with `?? 0`, which does not catch `NaN` (`NaN ?? 0 === NaN`). The `NaN` reaches ReactFlow, produces a `NaN` viewport transform (hence the NaN SVG attributes), and drives an infinite render loop (React #185). That loop remounts the editor subtree, which tears down each in-flight WebSocket before its handshake completes, so the socket errors and the `Not same Y.Doc` warning are downstream symptoms, not the cause. Because the failure is entirely client side, the server never logs anything.

## How the crash reaches the canvas

The three live canvases (Editor, SharedCanvas, VersionCanvas) feed ReactFlow via `useY(nodesMap)` and a `useMemo` that spreads each node through unchanged. That path does not go through `reassembleNode`, so the guard has to sit on those `useMemo`s as well, not only in `reassembleNode`. This PR covers all of them.

## Forensics: what the failing doc tells us

Reading the raw CRDT items in the failing doc (client id and clock of each write):

- The doc was edited by **three different client ids** (collaborative editing).
- The Horizontal Reprojector's `NaN` x/y were written by a **freshly joined client as its clock 2 and 3 operations**, i.e. its first two edits right after connecting, before any user interaction. This is an on-open write.
- The Vertical Reprojector's x/y were **written and then deleted** by another client (delete tombstones in the CRDT), consistent with a concurrent-edit artifact rather than a silent drop.
- All three nodes have valid `measured` dimensions, so this is not a missing-dimensions issue at rest.

This matches the reported "import, open, close, reopen, breaks every time" pattern: opening a doc that already contains a NaN node makes `fitView` compute a NaN viewport and the app re-persists NaN positions, so each open-and-close made the corruption stick harder.

## Why this surfaced now / behavior under yrs

This is a pre-existing client-side data-integrity gap, not an ygo regression; the same poisoned doc crashes identically on the old Rust (yrs) server.

- Positions are guarded with `?? 0` on both write (`yNodeConstructor`) and read (`reassembleNode`), and `?? 0` never catches `NaN`. Once a NaN position exists it survives every save, sync, and reimport (reimport copies the doc verbatim as a binary CRDT update).
- The NaN value is client-written (see forensics above); the server only stored it.
- We did not pin the genesis of the very first NaN, and we explicitly ruled out one earlier hypothesis: `screenToFlowPosition` returning NaN before the pane is measured. The installed `@xyflow/react` (12.11.1) returns finite coordinates in that case, so it is not the origin.
- ygo preserves nested maps and even `NaN` faithfully across V1/V2/persist round-trips, verified in reearth/ygo#194 and the companion websocket-go test #2305. So the persistence layer is not the source.

## Fix

Add a small, tested helper `toFinitePosition` that coerces any non-finite or missing coordinate to `0`, and apply it on every path that reads node positions out of the Yjs doc:

- `Editor/hooks.ts`, `SharedCanvas/hooks.ts`, `VersionCanvas/hooks.ts` (the three live canvas render paths that feed ReactFlow via `useY`).
- `reassembleNode` in `rebuildWorkflow.ts` (used by export, deployment, undo, and version rebuild).

Effect: a previously unopenable project now opens with the affected node parked at the origin (draggable back into place), for any already-poisoned doc, with no server change.

## Verification

- New unit tests for `toFinitePosition` (finite passthrough, NaN, Infinity, missing, non-numeric, single-axis) driven red then green.
- `rebuildWorkflow` tests extended with the exact poisoned-node shapes (NaN position, empty position map).
- Applied the helper to the actual decoded failing doc through the canvas transform: all three nodes come out finite.
- Full UI suite green (220 tests), `yarn type` clean, `yarn lint` 0 errors, Prettier clean.

## Scope and follow-up

This is the read-side guard: it stops the crash for any already-poisoned project. It does not stop the poisoning from being created. A follow-up should:

1. Guard the write side where positions enter the doc (`yNodeConstructor`, the `useYNode` position writer, and `toYjsMap`), so a non-finite value can never be persisted.
2. Prevent the on-open amplification: once one NaN node exists, `fitView` poisons the viewport transform and adjacent adds (e.g. the ActionPicker relative-position arithmetic `lastSelectedNode.position.x + 250`) inherit NaN. Guarding the write side plus sanitizing before `fitView` closes this.
3. Reset the module-level dagre graph in `autoLayout.ts` (a separate latent NaN source behind the auto-layout action).

Companion PRs (persistence layer is not the cause): reearth/ygo#194, reearth-flow#2305.
