### PR TITLE
feat(engine): support Geometry Filter in new-geometry with detailed type mode

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.96"
+version = "0.2.97"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "futures",
  "once_cell",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "approx",
  "async-trait",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "Inflector",
  "approx",
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "bytes",
  "clap",
@@ -5058,7 +5058,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5101,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5129,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5142,7 +5142,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "approx",
  "bvh",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5287,7 +5287,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "bytes",
  "futures",
@@ -5335,7 +5335,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "bytes",
  "futures",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "ahash",
  "bytes",
@@ -5438,7 +5438,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.465"
+version = "0.0.466"
 dependencies = [
  "async-trait",
  "axum",
@@ -8204,7 +8204,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.286"
+version = "0.1.287"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.465"
+version = "0.0.466"
 
 [profile.dev]
 opt-level = 0

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -5303,6 +5303,8 @@ Filter Features by Geometry Type
   "description": "Configure how to filter features based on their geometry type",
   "oneOf": [
     {
+      "title": "No Geometry",
+      "description": "Separates the features that carry no geometry at all from the ones that do.",
       "type": "object",
       "required": [
         "filterType"
@@ -5317,6 +5319,8 @@ Filter Features by Geometry Type
       }
     },
     {
+      "title": "Multiple Geometries",
+      "description": "Separates the features whose geometry is a container that can hold more than one part.",
       "type": "object",
       "required": [
         "filterType"
@@ -5331,6 +5335,8 @@ Filter Features by Geometry Type
       }
     },
     {
+      "title": "Geometry Type",
+      "description": "Routes by the geometry family a feature belongs to: point, curve, surface, triangle or solid.",
       "type": "object",
       "required": [
         "filterType"

--- a/engine/runtime/action-processor/src/geometry/filter.rs
+++ b/engine/runtime/action-processor/src/geometry/filter.rs
@@ -94,13 +94,21 @@ pub struct GeometryFilter {
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[serde(tag = "filterType", rename_all = "camelCase")]
 pub enum GeometryFilterParam {
+    /// # No Geometry
+    /// Separates the features that carry no geometry at all from the ones that do.
     None,
+    /// # Multiple Geometries
+    /// Separates the features whose geometry is a container that can hold more
+    /// than one part.
     #[cfg(not(feature = "new-geometry"))]
     Multiple,
+    /// # Geometry Type
+    /// Routes by the geometry family a feature belongs to: point, curve,
+    /// surface, triangle or solid.
     GeometryType,
     /// # Detailed Geometry Type
-    /// Route by the exact geometry type instead of the coarse family, so a face,
-    /// a surface mesh and a multi-surface each leave by their own port.
+    /// Routes by the exact geometry type rather than the family, so a face, a
+    /// surface mesh and a multi-surface each leave by their own port.
     #[cfg(feature = "new-geometry")]
     DetailedGeometryType,
 }
@@ -138,9 +146,10 @@ impl GeometryFilterParam {
     }
 
     /// `geometryType` keeps the coarse ports the legacy world exposed, and
-    /// `detailedGeometryType` adds one port per exact type. The two modes share
-    /// `point` and `solid`, which land on the same geometry either way, so the
-    /// lists are merged rather than concatenated.
+    /// `detailedGeometryType` adds one port per exact type. The names `point` and
+    /// `solid` appear in both lists, the coarse ones covering more types than
+    /// their detailed namesakes, so the lists are merged rather than concatenated
+    /// to declare each port once.
     #[cfg(feature = "new-geometry")]
     fn all_ports() -> Vec<Port> {
         let mut result = vec![Self::none_port()];
@@ -159,7 +168,7 @@ impl GeometryFilterParam {
 
 impl Processor for GeometryFilter {
     // Routes without touching the feature: every mode only picks the port. A
-    // geometry no port claims leaves by `unfiltered`, which is the catch-all
+    // geometry that no port claims leaves by `unfiltered`, which is the catch-all
     // rather than an error outlet, so there is no rejected port here.
     #[cfg(feature = "new-geometry")]
     fn process(
@@ -970,10 +979,6 @@ mod new_geometry_tests {
             ]))])),
             port("surface")
         );
-        assert_eq!(
-            coarse(geometry_collection([three_d(triangular_mesh_3d())])),
-            port("triangle")
-        );
     }
 
     #[test]
@@ -992,6 +997,10 @@ mod new_geometry_tests {
         assert_eq!(detailed(three_d(point_cloud())), port("point-cloud"));
         assert_eq!(detailed(two_d(line_string_2d())), port("line-string"));
         assert_eq!(detailed(three_d(line_string_3d())), port("line-string"));
+        // The distinction the coarse mode cannot express: a footprint in the plane
+        // and a face in space are separate types, as they are in FME.
+        assert_eq!(detailed(two_d(polygon_2d())), port("polygon"));
+        assert_eq!(detailed(three_d(polygon_3d())), port("face"));
         assert_eq!(detailed(two_d(polygon_mesh_2d())), port("polygon-mesh"));
         assert_eq!(detailed(three_d(polygon_mesh_3d())), port("polygon-mesh"));
         assert_eq!(
@@ -1005,14 +1014,6 @@ mod new_geometry_tests {
         assert_eq!(detailed(three_d(solid())), port("solid"));
         assert_eq!(detailed(three_d(csg())), port("csg"));
         assert_eq!(detailed(Geometry::None), UNFILTERED_PORT.clone());
-    }
-
-    // The distinction the legacy world could not express: a footprint in the plane
-    // and a face in space are separate types, as they are in FME.
-    #[test]
-    fn detailed_mode_separates_a_planar_polygon_from_a_face() {
-        assert_eq!(detailed(two_d(polygon_2d())), port("polygon"));
-        assert_eq!(detailed(three_d(polygon_3d())), port("face"));
     }
 
     #[test]
@@ -1059,52 +1060,22 @@ mod new_geometry_tests {
         assert_eq!(detailed(geometry_collection([])), UNFILTERED_PORT.clone());
     }
 
-    // The three types the PLATEAU reference workflows filter on in FME's detailed
-    // mode: Face, BRepSolid and CompositeSurface. The coarse mode flattens the
-    // first and the last into one port, which is why the mode exists.
+    // A bucket routing to a port the factory never declared silently drops every
+    // feature that reaches it, and a declared port nothing routes to is a dead
+    // outlet, so the two lists are compared as a whole rather than one at a time.
     #[test]
-    fn detailed_mode_separates_the_types_the_reference_workflows_filter_on() {
-        assert_eq!(detailed(three_d(polygon_3d())), port("face"));
-        assert_eq!(detailed(three_d(solid())), port("solid"));
-        assert_eq!(detailed(three_d(polygon_mesh_3d())), port("polygon-mesh"));
-        assert_eq!(coarse(three_d(polygon_3d())), port("surface"));
-        assert_eq!(coarse(three_d(polygon_mesh_3d())), port("surface"));
-    }
-
-    // A GML multi-surface: coarse routing keeps it on the port existing workflows
-    // wire, and detailed routing sees the collection.
-    #[test]
-    fn the_two_modes_agree_on_a_multi_surface() {
-        let multi_surface = || three_d(collection_3d([polygon_3d(), polygon_3d()]));
-        assert_eq!(coarse(multi_surface()), port("surface"));
-        assert_eq!(detailed(multi_surface()), port("multi-surface"));
-    }
-
-    // A bucket that routes to a port the factory never declared silently drops
-    // every feature that reaches it, so the two lists have to be checked against
-    // each other rather than one bucket at a time.
-    #[test]
-    fn every_port_a_bucket_routes_to_is_declared_by_the_factory() {
+    fn the_declared_ports_are_exactly_the_ports_buckets_route_to() {
         let declared = GeometryFilterFactory.get_output_ports();
-        let mut seen = std::collections::HashSet::new();
+        let mut unique = std::collections::HashSet::new();
         for port in &declared {
-            assert!(seen.insert(port.clone()), "port {port} is declared twice");
+            assert!(unique.insert(port.clone()), "port {port} is declared twice");
         }
-        let routable = [UNFILTERED_PORT.clone(), GeometryFilterParam::none_port()]
-            .into_iter()
-            .chain(CoarseType::ALL.iter().map(|ty| ty.port()))
-            .chain(DetailedType::ALL.iter().map(|ty| ty.port()));
-        for port in routable {
-            assert!(declared.contains(&port), "port {port} is not declared");
-        }
-    }
-
-    // The legacy `contains` port has no producer in this world: `multiple` is gone
-    // and the detailed buckets replace it.
-    #[test]
-    fn the_factory_declares_no_contains_port() {
-        assert!(!GeometryFilterFactory
-            .get_output_ports()
-            .contains(&port("contains")));
+        let routable: std::collections::HashSet<Port> =
+            [UNFILTERED_PORT.clone(), GeometryFilterParam::none_port()]
+                .into_iter()
+                .chain(CoarseType::ALL.iter().map(|ty| ty.port()))
+                .chain(DetailedType::ALL.iter().map(|ty| ty.port()))
+                .collect();
+        assert_eq!(unique, routable);
     }
 }

--- a/engine/runtime/action-processor/src/geometry/filter.rs
+++ b/engine/runtime/action-processor/src/geometry/filter.rs
@@ -1,8 +1,12 @@
 use std::collections::HashMap;
 
+#[cfg(not(feature = "new-geometry"))]
 use inflector::cases::camelcase::to_camel_case;
 use once_cell::sync::Lazy;
+#[cfg(not(feature = "new-geometry"))]
 use reearth_flow_geometry::types::geometry::{Geometry2D, Geometry3D};
+#[cfg(feature = "new-geometry")]
+use reearth_flow_geometry::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
 use reearth_flow_runtime::{
     errors::BoxedError,
     event::EventHub,
@@ -10,6 +14,7 @@ use reearth_flow_runtime::{
     forwarder::ProcessorChannelForwarder,
     node::{Port, Processor, ProcessorFactory, FEATURES_PORT},
 };
+#[cfg(not(feature = "new-geometry"))]
 use reearth_flow_types::{Feature, Geometry, GeometryType, GeometryValue};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -90,19 +95,31 @@ pub struct GeometryFilter {
 #[serde(tag = "filterType", rename_all = "camelCase")]
 pub enum GeometryFilterParam {
     None,
+    #[cfg(not(feature = "new-geometry"))]
     Multiple,
     GeometryType,
+    /// # Detailed Geometry Type
+    /// Route by the exact geometry type instead of the coarse family, so a face,
+    /// a surface mesh and a multi-surface each leave by their own port.
+    #[cfg(feature = "new-geometry")]
+    DetailedGeometryType,
 }
 
 impl GeometryFilterParam {
+    fn none_port() -> Port {
+        Port::new("none")
+    }
+
+    #[cfg(not(feature = "new-geometry"))]
     fn output_port(&self) -> Port {
         match self {
-            GeometryFilterParam::None => Port::new("none"),
+            GeometryFilterParam::None => Self::none_port(),
             GeometryFilterParam::Multiple => Port::new("contains"),
             GeometryFilterParam::GeometryType => unreachable!(),
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn all_feature_type_ports() -> Vec<Port> {
         GeometryType::all_type_names()
             .iter()
@@ -110,6 +127,7 @@ impl GeometryFilterParam {
             .collect()
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn all_ports() -> Vec<Port> {
         let mut result = vec![
             GeometryFilterParam::None.output_port(),
@@ -118,9 +136,59 @@ impl GeometryFilterParam {
         result.extend(GeometryFilterParam::all_feature_type_ports());
         result
     }
+
+    /// `geometryType` keeps the coarse ports the legacy world exposed, and
+    /// `detailedGeometryType` adds one port per exact type. The two modes share
+    /// `point` and `solid`, which land on the same geometry either way, so the
+    /// lists are merged rather than concatenated.
+    #[cfg(feature = "new-geometry")]
+    fn all_ports() -> Vec<Port> {
+        let mut result = vec![Self::none_port()];
+        for port in CoarseType::ALL
+            .iter()
+            .map(|ty| ty.port())
+            .chain(DetailedType::ALL.iter().map(|ty| ty.port()))
+        {
+            if !result.contains(&port) {
+                result.push(port);
+            }
+        }
+        result
+    }
 }
 
 impl Processor for GeometryFilter {
+    // Routes without touching the feature: every mode only picks the port. A
+    // geometry no port claims leaves by `unfiltered`, which is the catch-all
+    // rather than an error outlet, so there is no rejected port here.
+    #[cfg(feature = "new-geometry")]
+    fn process(
+        &mut self,
+        ctx: ExecutorContext,
+        fw: &ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        let geometry = &ctx.feature.geometry;
+        let port = match self.params {
+            // An absent geometry only, never an empty collection: this mode is
+            // wired as a "has a geometry at all" gate.
+            GeometryFilterParam::None => {
+                if matches!(**geometry, Geometry::None) {
+                    GeometryFilterParam::none_port()
+                } else {
+                    UNFILTERED_PORT.clone()
+                }
+            }
+            GeometryFilterParam::GeometryType => {
+                port_or_unfiltered(coarse_type(geometry).map(CoarseType::port))
+            }
+            GeometryFilterParam::DetailedGeometryType => {
+                port_or_unfiltered(detailed_type(geometry).map(DetailedType::port))
+            }
+        };
+        fw.send(ctx.new_with_feature_and_port(ctx.feature.clone(), port));
+        Ok(())
+    }
+
     #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
@@ -156,7 +224,6 @@ impl Processor for GeometryFilter {
         Ok(())
     }
 
-    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,
@@ -170,6 +237,7 @@ impl Processor for GeometryFilter {
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn filter_multiple_geometry(
     ctx: &ExecutorContext,
     fw: &ProcessorChannelForwarder,
@@ -215,6 +283,7 @@ fn filter_multiple_geometry(
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn filter_geometry_type(
     ctx: &ExecutorContext,
     fw: &ProcessorChannelForwarder,
@@ -258,7 +327,273 @@ fn filter_geometry_type(
     }
 }
 
-#[cfg(test)]
+/// The coarse family a geometry belongs to under `filterType: geometryType`.
+///
+/// These are the only distinctions the legacy geometry world could draw, and the
+/// mode keeps them so that workflows wired against the old ports keep routing the
+/// same features to the same downstream nodes. Both embedding dimensions collapse
+/// into one family; `detailedGeometryType` is where they separate.
+#[cfg(feature = "new-geometry")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CoarseType {
+    Point,
+    Curve,
+    Surface,
+    Triangle,
+    Solid,
+}
+
+#[cfg(feature = "new-geometry")]
+impl CoarseType {
+    const ALL: &[Self] = &[
+        Self::Point,
+        Self::Curve,
+        Self::Surface,
+        Self::Triangle,
+        Self::Solid,
+    ];
+
+    fn port(self) -> Port {
+        Port::new(match self {
+            Self::Point => "point",
+            Self::Curve => "curve",
+            Self::Surface => "surface",
+            Self::Triangle => "triangle",
+            Self::Solid => "solid",
+        })
+    }
+}
+
+/// The exact type a geometry is under `filterType: detailedGeometryType`, one
+/// bucket per type the geometry model distinguishes.
+///
+/// A planar `Polygon` and a `Face` in space are separate buckets, as are a
+/// collection and the leaf it holds — the granularity the FME reference
+/// workflows filter at, which the legacy world flattened away.
+#[cfg(feature = "new-geometry")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DetailedType {
+    Point,
+    MultiPoint,
+    PointCloud,
+    LineString,
+    MultiCurve,
+    Polygon,
+    MultiArea,
+    Face,
+    PolygonMesh,
+    TriangularMesh,
+    MultiSurface,
+    Solid,
+    Csg,
+    MultiSolid,
+    Aggregate,
+}
+
+#[cfg(feature = "new-geometry")]
+impl DetailedType {
+    const ALL: &[Self] = &[
+        Self::Point,
+        Self::MultiPoint,
+        Self::PointCloud,
+        Self::LineString,
+        Self::MultiCurve,
+        Self::Polygon,
+        Self::MultiArea,
+        Self::Face,
+        Self::PolygonMesh,
+        Self::TriangularMesh,
+        Self::MultiSurface,
+        Self::Solid,
+        Self::Csg,
+        Self::MultiSolid,
+        Self::Aggregate,
+    ];
+
+    fn port(self) -> Port {
+        Port::new(match self {
+            Self::Point => "point",
+            Self::MultiPoint => "multi-point",
+            Self::PointCloud => "point-cloud",
+            Self::LineString => "line-string",
+            Self::MultiCurve => "multi-curve",
+            Self::Polygon => "polygon",
+            Self::MultiArea => "multi-area",
+            Self::Face => "face",
+            Self::PolygonMesh => "polygon-mesh",
+            Self::TriangularMesh => "triangular-mesh",
+            Self::MultiSurface => "multi-surface",
+            Self::Solid => "solid",
+            Self::Csg => "csg",
+            Self::MultiSolid => "multi-solid",
+            Self::Aggregate => "aggregate",
+        })
+    }
+}
+
+#[cfg(feature = "new-geometry")]
+fn port_or_unfiltered(port: Option<Port>) -> Port {
+    port.unwrap_or_else(|| UNFILTERED_PORT.clone())
+}
+
+/// The single value every item agrees on, or `None` if there are no items, if any
+/// item has no value, or if two items disagree.
+#[cfg(feature = "new-geometry")]
+fn unify<T: Copy + PartialEq>(items: impl IntoIterator<Item = Option<T>>) -> Option<T> {
+    let mut items = items.into_iter();
+    let agreed = items.next()??;
+    for item in items {
+        if item? != agreed {
+            return None;
+        }
+    }
+    Some(agreed)
+}
+
+/// `None` where no family claims the geometry, which routes it to `unfiltered`.
+#[cfg(feature = "new-geometry")]
+fn coarse_type(geometry: &Geometry) -> Option<CoarseType> {
+    match geometry {
+        Geometry::None => None,
+        Geometry::Euclidean2D(geometry) => coarse_type_2d(geometry),
+        Geometry::Euclidean3D(geometry) => coarse_type_3d(geometry),
+        // A one-member collection is the shape a reader gives a feature with a
+        // single geometry property, so it filters as that member. Anything
+        // holding more is a container the coarse families cannot name.
+        Geometry::GeometryCollection(collection) => match collection.members() {
+            [member] => coarse_type(member),
+            _ => None,
+        },
+    }
+}
+
+#[cfg(feature = "new-geometry")]
+fn coarse_type_2d(geometry: &Euclidean2DGeometry) -> Option<CoarseType> {
+    match geometry {
+        Euclidean2DGeometry::Point(_) => Some(CoarseType::Point),
+        Euclidean2DGeometry::LineString(_) => Some(CoarseType::Curve),
+        Euclidean2DGeometry::Polygon(_) | Euclidean2DGeometry::PolygonMesh(_) => {
+            Some(CoarseType::Surface)
+        }
+        Euclidean2DGeometry::TriangularMesh(_) => Some(CoarseType::Triangle),
+        // A collection takes its members' family, so a multi-surface filters as a
+        // surface the way it did before. Mixed families have no single answer.
+        Euclidean2DGeometry::Collection(collection) => {
+            unify(collection.members().iter().map(coarse_type_2d))
+        }
+    }
+}
+
+#[cfg(feature = "new-geometry")]
+fn coarse_type_3d(geometry: &Euclidean3DGeometry) -> Option<CoarseType> {
+    match geometry {
+        Euclidean3DGeometry::Point(_) | Euclidean3DGeometry::PointCloud(_) => {
+            Some(CoarseType::Point)
+        }
+        Euclidean3DGeometry::LineString(_) => Some(CoarseType::Curve),
+        Euclidean3DGeometry::Polygon(_) | Euclidean3DGeometry::PolygonMesh(_) => {
+            Some(CoarseType::Surface)
+        }
+        Euclidean3DGeometry::TriangularMesh(_) => Some(CoarseType::Triangle),
+        Euclidean3DGeometry::Solid(_) | Euclidean3DGeometry::Csg(_) => Some(CoarseType::Solid),
+        Euclidean3DGeometry::Collection(collection) => {
+            unify(collection.members().iter().map(coarse_type_3d))
+        }
+    }
+}
+
+/// `None` where no bucket claims the geometry, which routes it to `unfiltered`.
+#[cfg(feature = "new-geometry")]
+fn detailed_type(geometry: &Geometry) -> Option<DetailedType> {
+    match geometry {
+        Geometry::None => None,
+        Geometry::Euclidean2D(geometry) => detailed_type_2d(geometry),
+        Geometry::Euclidean3D(geometry) => detailed_type_3d(geometry),
+        Geometry::GeometryCollection(collection) => match collection.members() {
+            [] => None,
+            [member] => detailed_type(member),
+            // Several members of possibly unrelated types: the case FME calls an
+            // aggregate, and what a reader produces for a feature carrying more
+            // than one geometry property.
+            _ => Some(DetailedType::Aggregate),
+        },
+    }
+}
+
+#[cfg(feature = "new-geometry")]
+fn detailed_type_2d(geometry: &Euclidean2DGeometry) -> Option<DetailedType> {
+    match geometry {
+        Euclidean2DGeometry::Point(_) => Some(DetailedType::Point),
+        Euclidean2DGeometry::LineString(_) => Some(DetailedType::LineString),
+        Euclidean2DGeometry::Polygon(_) => Some(DetailedType::Polygon),
+        Euclidean2DGeometry::PolygonMesh(_) => Some(DetailedType::PolygonMesh),
+        Euclidean2DGeometry::TriangularMesh(_) => Some(DetailedType::TriangularMesh),
+        Euclidean2DGeometry::Collection(collection) => {
+            unify(collection.members().iter().map(multi_type_2d))
+        }
+    }
+}
+
+#[cfg(feature = "new-geometry")]
+fn detailed_type_3d(geometry: &Euclidean3DGeometry) -> Option<DetailedType> {
+    match geometry {
+        Euclidean3DGeometry::Point(_) => Some(DetailedType::Point),
+        Euclidean3DGeometry::PointCloud(_) => Some(DetailedType::PointCloud),
+        Euclidean3DGeometry::LineString(_) => Some(DetailedType::LineString),
+        Euclidean3DGeometry::Polygon(_) => Some(DetailedType::Face),
+        Euclidean3DGeometry::PolygonMesh(_) => Some(DetailedType::PolygonMesh),
+        Euclidean3DGeometry::TriangularMesh(_) => Some(DetailedType::TriangularMesh),
+        Euclidean3DGeometry::Solid(_) => Some(DetailedType::Solid),
+        Euclidean3DGeometry::Csg(_) => Some(DetailedType::Csg),
+        Euclidean3DGeometry::Collection(collection) => {
+            unify(collection.members().iter().map(multi_type_3d))
+        }
+    }
+}
+
+/// The `Multi*` bucket a 2D collection whose members all look like this one falls
+/// in.
+///
+/// Members are grouped by family, not by exact type: a multi-surface read from
+/// GML mixes rings and oriented surfaces, which become polygons and meshes here,
+/// and it has to stay one collection. A nested collection contributes the bucket
+/// it is itself named by.
+#[cfg(feature = "new-geometry")]
+fn multi_type_2d(member: &Euclidean2DGeometry) -> Option<DetailedType> {
+    match member {
+        Euclidean2DGeometry::Point(_) => Some(DetailedType::MultiPoint),
+        Euclidean2DGeometry::LineString(_) => Some(DetailedType::MultiCurve),
+        Euclidean2DGeometry::Polygon(_)
+        | Euclidean2DGeometry::PolygonMesh(_)
+        | Euclidean2DGeometry::TriangularMesh(_) => Some(DetailedType::MultiArea),
+        Euclidean2DGeometry::Collection(collection) => {
+            unify(collection.members().iter().map(multi_type_2d))
+        }
+    }
+}
+
+/// The `Multi*` bucket a 3D collection whose members all look like this one falls
+/// in; see [`multi_type_2d`] for how members are grouped.
+#[cfg(feature = "new-geometry")]
+fn multi_type_3d(member: &Euclidean3DGeometry) -> Option<DetailedType> {
+    match member {
+        Euclidean3DGeometry::Point(_) | Euclidean3DGeometry::PointCloud(_) => {
+            Some(DetailedType::MultiPoint)
+        }
+        Euclidean3DGeometry::LineString(_) => Some(DetailedType::MultiCurve),
+        Euclidean3DGeometry::Polygon(_)
+        | Euclidean3DGeometry::PolygonMesh(_)
+        | Euclidean3DGeometry::TriangularMesh(_) => Some(DetailedType::MultiSurface),
+        Euclidean3DGeometry::Solid(_) | Euclidean3DGeometry::Csg(_) => {
+            Some(DetailedType::MultiSolid)
+        }
+        Euclidean3DGeometry::Collection(collection) => {
+            unify(collection.members().iter().map(multi_type_3d))
+        }
+    }
+}
+
+#[cfg(all(test, not(feature = "new-geometry")))]
 mod tests {
     use reearth_flow_runtime::forwarder::NoopChannelForwarder;
     use reearth_flow_types::feature::Attributes;
@@ -286,7 +621,6 @@ mod tests {
         }
     }
 
-    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_filter_multiple_geometry_3d_multipolygon() {
         let noop = NoopChannelForwarder::default();
@@ -308,7 +642,6 @@ mod tests {
         }
     }
 
-    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_filter_multiple_geometry_3d_geometry_collection() {
         let noop = NoopChannelForwarder::default();
@@ -332,7 +665,6 @@ mod tests {
         }
     }
 
-    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_filter_multiple_geometry_3d_other_geometry() {
         let noop = NoopChannelForwarder::default();
@@ -355,4 +687,424 @@ mod tests {
     }
 
     // Add more tests for other scenarios...
+}
+
+#[cfg(all(test, feature = "new-geometry"))]
+mod new_geometry_tests {
+    use pretty_assertions::assert_eq;
+    use reearth_flow_geometry::collection::{Collection2D, Collection3D};
+    use reearth_flow_geometry::coordinate::CoordinateFrame;
+    use reearth_flow_geometry::csg::Csg;
+    use reearth_flow_geometry::line_string::{LineString2D, LineString3D};
+    use reearth_flow_geometry::point::{Point2D, Point3D};
+    use reearth_flow_geometry::point_cloud::PointCloud;
+    use reearth_flow_geometry::polygon::{Polygon2D, Polygon3D};
+    use reearth_flow_geometry::polygon_mesh::{PolygonMesh2D, PolygonMesh3D};
+    use reearth_flow_geometry::solid::Solid;
+    use reearth_flow_geometry::triangular_mesh::{
+        TriangularMesh2D, TriangularMesh3D, TriangularMesh3DData,
+    };
+    use reearth_flow_geometry::GeometryCollection;
+    use reearth_flow_runtime::forwarder::NoopChannelForwarder;
+    use reearth_flow_types::Feature;
+
+    use crate::tests::utils::create_default_execute_context;
+
+    use super::*;
+
+    fn frame() -> CoordinateFrame {
+        CoordinateFrame::Euclidean
+    }
+
+    /// The port a feature carrying `geometry` leaves the filter by.
+    fn route(params: GeometryFilterParam, geometry: Geometry) -> Port {
+        let noop = NoopChannelForwarder::default();
+        let fw = ProcessorChannelForwarder::Noop(noop);
+        let feature = Feature::from(geometry);
+        let ctx = create_default_execute_context(&feature);
+        GeometryFilter { params }.process(ctx, &fw).unwrap();
+        let ProcessorChannelForwarder::Noop(noop) = fw else {
+            unreachable!()
+        };
+        let sent = noop.send_ports.lock().unwrap().first().cloned();
+        sent.expect("the filter sends every feature somewhere")
+    }
+
+    fn null_gate(geometry: Geometry) -> Port {
+        route(GeometryFilterParam::None, geometry)
+    }
+
+    fn coarse(geometry: Geometry) -> Port {
+        route(GeometryFilterParam::GeometryType, geometry)
+    }
+
+    fn detailed(geometry: Geometry) -> Port {
+        route(GeometryFilterParam::DetailedGeometryType, geometry)
+    }
+
+    fn port(name: &str) -> Port {
+        Port::new(name)
+    }
+
+    fn two_d(geometry: Euclidean2DGeometry) -> Geometry {
+        Geometry::Euclidean2D(geometry)
+    }
+
+    fn three_d(geometry: Euclidean3DGeometry) -> Geometry {
+        Geometry::Euclidean3D(geometry)
+    }
+
+    fn point_2d() -> Euclidean2DGeometry {
+        Euclidean2DGeometry::Point(Point2D::new(frame(), [0.0, 0.0]))
+    }
+
+    fn point_3d() -> Euclidean3DGeometry {
+        Euclidean3DGeometry::Point(Point3D::new(frame(), [0.0, 0.0, 0.0]))
+    }
+
+    fn point_cloud() -> Euclidean3DGeometry {
+        Euclidean3DGeometry::PointCloud(Box::new(PointCloud::from_positions(
+            frame(),
+            [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
+        )))
+    }
+
+    fn line_string_2d() -> Euclidean2DGeometry {
+        Euclidean2DGeometry::LineString(LineString2D::from_coords(
+            frame(),
+            [[0.0, 0.0], [1.0, 1.0]],
+        ))
+    }
+
+    fn line_string_3d() -> Euclidean3DGeometry {
+        Euclidean3DGeometry::LineString(LineString3D::from_coords(
+            frame(),
+            [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
+        ))
+    }
+
+    fn polygon_2d() -> Euclidean2DGeometry {
+        Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings(
+            frame(),
+            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0]],
+            Vec::<Vec<[f64; 2]>>::new(),
+        )))
+    }
+
+    fn polygon_3d() -> Euclidean3DGeometry {
+        Euclidean3DGeometry::Polygon(Box::new(Polygon3D::from_rings(
+            frame(),
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [1.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0],
+            ],
+            Vec::<Vec<[f64; 3]>>::new(),
+        )))
+    }
+
+    fn polygon_mesh_2d() -> Euclidean2DGeometry {
+        Euclidean2DGeometry::PolygonMesh(Box::new(
+            PolygonMesh2D::from_parts(
+                frame(),
+                vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]],
+                [[0u32, 1, 2]],
+            )
+            .unwrap(),
+        ))
+    }
+
+    fn polygon_mesh_3d() -> Euclidean3DGeometry {
+        Euclidean3DGeometry::PolygonMesh(Box::new(
+            PolygonMesh3D::from_parts(
+                frame(),
+                vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0]],
+                [[0u32, 1, 2]],
+            )
+            .unwrap(),
+        ))
+    }
+
+    fn triangular_mesh_2d() -> Euclidean2DGeometry {
+        Euclidean2DGeometry::TriangularMesh(Box::new(
+            TriangularMesh2D::from_parts(
+                frame(),
+                vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]],
+                [0u32, 1, 2],
+            )
+            .unwrap(),
+        ))
+    }
+
+    fn triangular_mesh_3d() -> Euclidean3DGeometry {
+        Euclidean3DGeometry::TriangularMesh(Box::new(
+            TriangularMesh3D::from_parts(
+                frame(),
+                vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0]],
+                [0u32, 1, 2],
+            )
+            .unwrap(),
+        ))
+    }
+
+    fn bare_solid() -> Solid {
+        // Construction does not check closure, so an open shell is a fine stand-in.
+        Solid::from_exterior(
+            frame(),
+            TriangularMesh3DData::from_parts(
+                vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0]],
+                [0u32, 1, 2],
+            )
+            .unwrap(),
+        )
+    }
+
+    fn solid() -> Euclidean3DGeometry {
+        Euclidean3DGeometry::Solid(Box::new(bare_solid()))
+    }
+
+    fn csg() -> Euclidean3DGeometry {
+        Euclidean3DGeometry::Csg(Csg::union(bare_solid(), bare_solid()))
+    }
+
+    fn collection_2d(
+        members: impl IntoIterator<Item = Euclidean2DGeometry>,
+    ) -> Euclidean2DGeometry {
+        Euclidean2DGeometry::Collection(Collection2D::new(members))
+    }
+
+    fn collection_3d(
+        members: impl IntoIterator<Item = Euclidean3DGeometry>,
+    ) -> Euclidean3DGeometry {
+        Euclidean3DGeometry::Collection(Collection3D::new(members))
+    }
+
+    fn geometry_collection(members: impl IntoIterator<Item = Geometry>) -> Geometry {
+        Geometry::GeometryCollection(GeometryCollection::new(members))
+    }
+
+    #[test]
+    fn null_gate_admits_only_an_absent_geometry() {
+        assert_eq!(null_gate(Geometry::None), port("none"));
+        assert_eq!(null_gate(three_d(point_3d())), UNFILTERED_PORT.clone());
+    }
+
+    // An empty collection is a geometry, just an empty one, so the gate must not
+    // treat it as absent: workflows use this mode to keep features that have a
+    // geometry at all.
+    #[test]
+    fn null_gate_rejects_an_empty_collection() {
+        assert_eq!(
+            null_gate(three_d(collection_3d([]))),
+            UNFILTERED_PORT.clone()
+        );
+        assert_eq!(null_gate(geometry_collection([])), UNFILTERED_PORT.clone());
+    }
+
+    #[test]
+    fn coarse_mode_maps_every_leaf_to_its_family() {
+        assert_eq!(coarse(two_d(point_2d())), port("point"));
+        assert_eq!(coarse(three_d(point_3d())), port("point"));
+        assert_eq!(coarse(three_d(point_cloud())), port("point"));
+        assert_eq!(coarse(two_d(line_string_2d())), port("curve"));
+        assert_eq!(coarse(three_d(line_string_3d())), port("curve"));
+        assert_eq!(coarse(two_d(polygon_2d())), port("surface"));
+        assert_eq!(coarse(three_d(polygon_3d())), port("surface"));
+        assert_eq!(coarse(two_d(polygon_mesh_2d())), port("surface"));
+        assert_eq!(coarse(three_d(polygon_mesh_3d())), port("surface"));
+        assert_eq!(coarse(two_d(triangular_mesh_2d())), port("triangle"));
+        assert_eq!(coarse(three_d(triangular_mesh_3d())), port("triangle"));
+        assert_eq!(coarse(three_d(solid())), port("solid"));
+        assert_eq!(coarse(three_d(csg())), port("solid"));
+        assert_eq!(coarse(Geometry::None), UNFILTERED_PORT.clone());
+    }
+
+    #[test]
+    fn coarse_mode_gives_a_collection_its_members_family() {
+        assert_eq!(
+            coarse(three_d(collection_3d([polygon_3d(), polygon_3d()]))),
+            port("surface")
+        );
+        // A GML multi-surface can hold both plain polygons and oriented surfaces,
+        // which land as polygons and meshes: still one surface collection.
+        assert_eq!(
+            coarse(three_d(collection_3d([polygon_3d(), polygon_mesh_3d()]))),
+            port("surface")
+        );
+        assert_eq!(
+            coarse(three_d(collection_3d([solid(), solid()]))),
+            port("solid")
+        );
+        assert_eq!(
+            coarse(three_d(collection_3d([
+                collection_3d([polygon_3d()]),
+                polygon_3d()
+            ]))),
+            port("surface")
+        );
+    }
+
+    #[test]
+    fn coarse_mode_unfilters_a_collection_without_one_family() {
+        assert_eq!(
+            coarse(three_d(collection_3d([polygon_3d(), point_3d()]))),
+            UNFILTERED_PORT.clone()
+        );
+        assert_eq!(coarse(three_d(collection_3d([]))), UNFILTERED_PORT.clone());
+    }
+
+    // The shape a CityGML reader produces: one member per geometry property, so a
+    // feature with a single property still filters as that geometry. This is what
+    // the quality-check workflows route on.
+    #[test]
+    fn coarse_mode_looks_through_a_single_member_geometry_collection() {
+        assert_eq!(
+            coarse(geometry_collection([three_d(solid())])),
+            port("solid")
+        );
+        assert_eq!(
+            coarse(geometry_collection([three_d(collection_3d([
+                polygon_3d(),
+                polygon_3d()
+            ]))])),
+            port("surface")
+        );
+        assert_eq!(
+            coarse(geometry_collection([three_d(triangular_mesh_3d())])),
+            port("triangle")
+        );
+    }
+
+    #[test]
+    fn coarse_mode_unfilters_a_multi_member_geometry_collection() {
+        assert_eq!(
+            coarse(geometry_collection([three_d(solid()), three_d(solid())])),
+            UNFILTERED_PORT.clone()
+        );
+        assert_eq!(coarse(geometry_collection([])), UNFILTERED_PORT.clone());
+    }
+
+    #[test]
+    fn detailed_mode_maps_every_leaf_to_its_own_port() {
+        assert_eq!(detailed(two_d(point_2d())), port("point"));
+        assert_eq!(detailed(three_d(point_3d())), port("point"));
+        assert_eq!(detailed(three_d(point_cloud())), port("point-cloud"));
+        assert_eq!(detailed(two_d(line_string_2d())), port("line-string"));
+        assert_eq!(detailed(three_d(line_string_3d())), port("line-string"));
+        assert_eq!(detailed(two_d(polygon_mesh_2d())), port("polygon-mesh"));
+        assert_eq!(detailed(three_d(polygon_mesh_3d())), port("polygon-mesh"));
+        assert_eq!(
+            detailed(two_d(triangular_mesh_2d())),
+            port("triangular-mesh")
+        );
+        assert_eq!(
+            detailed(three_d(triangular_mesh_3d())),
+            port("triangular-mesh")
+        );
+        assert_eq!(detailed(three_d(solid())), port("solid"));
+        assert_eq!(detailed(three_d(csg())), port("csg"));
+        assert_eq!(detailed(Geometry::None), UNFILTERED_PORT.clone());
+    }
+
+    // The distinction the legacy world could not express: a footprint in the plane
+    // and a face in space are separate types, as they are in FME.
+    #[test]
+    fn detailed_mode_separates_a_planar_polygon_from_a_face() {
+        assert_eq!(detailed(two_d(polygon_2d())), port("polygon"));
+        assert_eq!(detailed(three_d(polygon_3d())), port("face"));
+    }
+
+    #[test]
+    fn detailed_mode_names_a_collection_by_its_members_family() {
+        assert_eq!(
+            detailed(two_d(collection_2d([point_2d(), point_2d()]))),
+            port("multi-point")
+        );
+        assert_eq!(
+            detailed(three_d(collection_3d([line_string_3d()]))),
+            port("multi-curve")
+        );
+        assert_eq!(
+            detailed(two_d(collection_2d([polygon_2d(), polygon_2d()]))),
+            port("multi-area")
+        );
+        assert_eq!(
+            detailed(three_d(collection_3d([polygon_3d(), polygon_mesh_3d()]))),
+            port("multi-surface")
+        );
+        assert_eq!(
+            detailed(three_d(collection_3d([solid(), solid()]))),
+            port("multi-solid")
+        );
+        assert_eq!(
+            detailed(three_d(collection_3d([polygon_3d(), point_3d()]))),
+            UNFILTERED_PORT.clone()
+        );
+    }
+
+    #[test]
+    fn detailed_mode_calls_a_multi_member_geometry_collection_an_aggregate() {
+        assert_eq!(
+            detailed(geometry_collection([
+                three_d(solid()),
+                three_d(collection_3d([polygon_3d()]))
+            ])),
+            port("aggregate")
+        );
+        assert_eq!(
+            detailed(geometry_collection([three_d(solid())])),
+            port("solid")
+        );
+        assert_eq!(detailed(geometry_collection([])), UNFILTERED_PORT.clone());
+    }
+
+    // The three types the PLATEAU reference workflows filter on in FME's detailed
+    // mode: Face, BRepSolid and CompositeSurface. The coarse mode flattens the
+    // first and the last into one port, which is why the mode exists.
+    #[test]
+    fn detailed_mode_separates_the_types_the_reference_workflows_filter_on() {
+        assert_eq!(detailed(three_d(polygon_3d())), port("face"));
+        assert_eq!(detailed(three_d(solid())), port("solid"));
+        assert_eq!(detailed(three_d(polygon_mesh_3d())), port("polygon-mesh"));
+        assert_eq!(coarse(three_d(polygon_3d())), port("surface"));
+        assert_eq!(coarse(three_d(polygon_mesh_3d())), port("surface"));
+    }
+
+    // A GML multi-surface: coarse routing keeps it on the port existing workflows
+    // wire, and detailed routing sees the collection.
+    #[test]
+    fn the_two_modes_agree_on_a_multi_surface() {
+        let multi_surface = || three_d(collection_3d([polygon_3d(), polygon_3d()]));
+        assert_eq!(coarse(multi_surface()), port("surface"));
+        assert_eq!(detailed(multi_surface()), port("multi-surface"));
+    }
+
+    // A bucket that routes to a port the factory never declared silently drops
+    // every feature that reaches it, so the two lists have to be checked against
+    // each other rather than one bucket at a time.
+    #[test]
+    fn every_port_a_bucket_routes_to_is_declared_by_the_factory() {
+        let declared = GeometryFilterFactory.get_output_ports();
+        let mut seen = std::collections::HashSet::new();
+        for port in &declared {
+            assert!(seen.insert(port.clone()), "port {port} is declared twice");
+        }
+        let routable = [UNFILTERED_PORT.clone(), GeometryFilterParam::none_port()]
+            .into_iter()
+            .chain(CoarseType::ALL.iter().map(|ty| ty.port()))
+            .chain(DetailedType::ALL.iter().map(|ty| ty.port()));
+        for port in routable {
+            assert!(declared.contains(&port), "port {port} is not declared");
+        }
+    }
+
+    // The legacy `contains` port has no producer in this world: `multiple` is gone
+    // and the detailed buckets replace it.
+    #[test]
+    fn the_factory_declares_no_contains_port() {
+        assert!(!GeometryFilterFactory
+            .get_output_ports()
+            .contains(&port("contains")));
+    }
 }

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -5449,6 +5449,8 @@
         "description": "Configure how to filter features based on their geometry type",
         "oneOf": [
           {
+            "title": "No Geometry",
+            "description": "Separates the features that carry no geometry at all from the ones that do.",
             "type": "object",
             "required": [
               "filterType"
@@ -5463,6 +5465,8 @@
             }
           },
           {
+            "title": "Multiple Geometries",
+            "description": "Separates the features whose geometry is a container that can hold more than one part.",
             "type": "object",
             "required": [
               "filterType"
@@ -5477,6 +5481,8 @@
             }
           },
           {
+            "title": "Geometry Type",
+            "description": "Routes by the geometry family a feature belongs to: point, curve, surface, triangle or solid.",
             "type": "object",
             "required": [
               "filterType"

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -5449,6 +5449,8 @@
         "description": "Configure how to filter features based on their geometry type",
         "oneOf": [
           {
+            "title": "No Geometry",
+            "description": "Separates the features that carry no geometry at all from the ones that do.",
             "type": "object",
             "required": [
               "filterType"
@@ -5463,6 +5465,8 @@
             }
           },
           {
+            "title": "Multiple Geometries",
+            "description": "Separates the features whose geometry is a container that can hold more than one part.",
             "type": "object",
             "required": [
               "filterType"
@@ -5477,6 +5481,8 @@
             }
           },
           {
+            "title": "Geometry Type",
+            "description": "Routes by the geometry family a feature belongs to: point, curve, surface, triangle or solid.",
             "type": "object",
             "required": [
               "filterType"

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -5449,6 +5449,8 @@
         "description": "Configure how to filter features based on their geometry type",
         "oneOf": [
           {
+            "title": "No Geometry",
+            "description": "Separates the features that carry no geometry at all from the ones that do.",
             "type": "object",
             "required": [
               "filterType"
@@ -5463,6 +5465,8 @@
             }
           },
           {
+            "title": "Multiple Geometries",
+            "description": "Separates the features whose geometry is a container that can hold more than one part.",
             "type": "object",
             "required": [
               "filterType"
@@ -5477,6 +5481,8 @@
             }
           },
           {
+            "title": "Geometry Type",
+            "description": "Routes by the geometry family a feature belongs to: point, curve, surface, triangle or solid.",
             "type": "object",
             "required": [
               "filterType"

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -5452,6 +5452,8 @@
         "description": "ジオメトリタイプに基づいてフィーチャーをフィルタリングする方法を設定する",
         "oneOf": [
           {
+            "title": "No Geometry",
+            "description": "Separates the features that carry no geometry at all from the ones that do.",
             "type": "object",
             "required": [
               "filterType"
@@ -5466,6 +5468,8 @@
             }
           },
           {
+            "title": "Multiple Geometries",
+            "description": "Separates the features whose geometry is a container that can hold more than one part.",
             "type": "object",
             "required": [
               "filterType"
@@ -5480,6 +5484,8 @@
             }
           },
           {
+            "title": "Geometry Type",
+            "description": "Routes by the geometry family a feature belongs to: point, curve, surface, triangle or solid.",
             "type": "object",
             "required": [
               "filterType"

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -5449,6 +5449,8 @@
         "description": "Configure how to filter features based on their geometry type",
         "oneOf": [
           {
+            "title": "No Geometry",
+            "description": "Separates the features that carry no geometry at all from the ones that do.",
             "type": "object",
             "required": [
               "filterType"
@@ -5463,6 +5465,8 @@
             }
           },
           {
+            "title": "Multiple Geometries",
+            "description": "Separates the features whose geometry is a container that can hold more than one part.",
             "type": "object",
             "required": [
               "filterType"
@@ -5477,6 +5481,8 @@
             }
           },
           {
+            "title": "Geometry Type",
+            "description": "Routes by the geometry family a feature belongs to: point, curve, surface, triangle or solid.",
             "type": "object",
             "required": [
               "filterType"

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.96"
+version = "0.2.97"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.286"
+version = "0.1.287"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
# Overview

Ports the `GeometryFilter` processor to the `new-geometry` world and adds a `detailedGeometryType` filter mode that routes features by their exact geometry type.

## What I've done

- Implemented `process` for `GeometryFilter` under `#[cfg(feature = "new-geometry")]`, routing on the new `Geometry` / `Euclidean2DGeometry` / `Euclidean3DGeometry` enums.
- Kept `none` and `geometryType` behaving as before, so existing workflows route to the same ports.
- Added `detailedGeometryType`, which gives each exact type its own port (`face`, `polygon-mesh`, `multi-surface`, `csg`, `aggregate`, …). The coarse mode collapses `Face` / `CompositeSurface` into one `surface` port; this mode separates them, matching what the FME reference workflows filter on.
- Dropped `multiple` / the `contains` port from the new-geometry build: it is not used by any existing workflow and has no FME counterpart. The legacy build is unchanged.

## What I haven't done

- No workflow-level integration test; coverage is unit tests only.

## How I tested

- Added a `new_geometry_tests` module covering every leaf type in both modes, collection unification (uniform / mixed / nested / empty), single- vs multi-member `GeometryCollection`, and the `polygon` vs `face` split.
- Added a test asserting every port a bucket can route to is declared by the factory — an undeclared port would silently drop features.
- `cargo make format` / `clippy` / `test` pass.

## Screenshot

## Which point I want you to review particularly

- The `Multi*` grouping in `multi_type_2d` / `multi_type_3d`: members are grouped by family, not exact type, so a GML multi-surface mixing polygons and oriented surfaces stays one `multi-surface`.
- Port naming: kebab-case (`multi-point`, `point-cloud`) vs the legacy camelCase names.

## Memo