### PR TITLE
docs(engine): FlowExpr extension spec for flow attributes/env

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "futures",
  "once_cell",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "approx",
  "async-trait",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "Inflector",
  "approx",
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "bytes",
  "clap",
@@ -5058,7 +5058,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5101,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5129,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5142,7 +5142,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "approx",
  "bvh",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5287,7 +5287,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "bytes",
  "futures",
@@ -5335,7 +5335,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "bytes",
  "futures",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "ahash",
  "bytes",
@@ -5438,7 +5438,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.466"
+version = "0.0.467"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.466"
+version = "0.0.467"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/expr/docs/extensions/1-attributes-env.md
+++ b/engine/runtime/expr/docs/extensions/1-attributes-env.md
@@ -36,7 +36,7 @@ Unlike `attributes`, always bound, even when there is no current feature.
 
 ### `env[key]`
 
-Returns the value of the environment variable named `key`.  Errors if `key` is absent.
+Returns the value of the environment variable named `key`. Errors if `key` is absent.
 
 ### `env.get(key)`
 

--- a/engine/runtime/expr/docs/extensions/1-attributes-env.md
+++ b/engine/runtime/expr/docs/extensions/1-attributes-env.md
@@ -1,0 +1,45 @@
+# (DRAFT) `attributes` and `env`
+
+reearth-flow injects two global objects into expressions,
+`attributes` and `env`.
+
+## `attributes`
+
+Bound to the current feature's attributes.
+
+Not bound when there is no current feature, referencing `attributes` in that context is an error.
+
+### `attributes[key]`
+
+Returns the value of the attribute named `key`.
+Errors if `key` is absent.
+
+### `attributes.get(key)`
+
+Returns the value of the attribute named `key`, or `null` if `key` is absent.
+
+`attributes.get(key, default)` returns `default` instead of `null` when `key` is absent.
+
+### `key in attributes` / `key not in attributes`
+
+Returns whether `key` names an attribute present on the current feature.
+
+### `for key in attributes`
+
+Iterates the names of the feature's attributes.
+
+## `env`
+
+Bound to the workflow's environment variables.
+
+Unlike `attributes`, always bound, even when there is no current feature.
+
+### `env[key]`
+
+Returns the value of the environment variable named `key`.  Errors if `key` is absent.
+
+### `env.get(key)`
+
+Returns the value of the environment variable named `key`, or `null` if `key` is absent.
+
+`env.get(key, default)` returns `default` instead of `null` when `key` is absent.

--- a/engine/runtime/expr/docs/extensions/README.md
+++ b/engine/runtime/expr/docs/extensions/README.md
@@ -2,4 +2,4 @@
 
 Documents globals and objects a FlowExpr *host* injects into the evaluation environment.
 
-Same naming convention and writing style guideline as [../spec/README.md](../spec/README.md).
+Same naming convention and the writing style guidelines as [../spec/README.md](../spec/README.md).

--- a/engine/runtime/expr/docs/extensions/README.md
+++ b/engine/runtime/expr/docs/extensions/README.md
@@ -1,0 +1,5 @@
+# FlowExpr Extension Specs
+
+Documents globals and objects a FlowExpr *host* injects into the evaluation environment.
+
+Same naming convention and writing style guideline as [../spec/README.md](../spec/README.md).


### PR DESCRIPTION
# Overview

This PR adds a small extension spec for flow-injected attributes/env objects in FlowExpr.