### PR TITLE
feat(engine): support Hole Counter in new-geometry

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.97"
+version = "0.2.98"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "futures",
  "once_cell",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "approx",
  "async-trait",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "Inflector",
  "approx",
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "bytes",
  "clap",
@@ -5058,7 +5058,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5101,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5129,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5142,7 +5142,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "approx",
  "bvh",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5287,7 +5287,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "bytes",
  "futures",
@@ -5335,7 +5335,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "bytes",
  "futures",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "ahash",
  "bytes",
@@ -5438,7 +5438,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.467"
+version = "0.0.468"
 dependencies = [
  "async-trait",
  "axum",
@@ -8204,7 +8204,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.287"
+version = "0.1.288"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.467"
+version = "0.0.468"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/action-processor/src/geometry/hole_counter.rs
+++ b/engine/runtime/action-processor/src/geometry/hole_counter.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
+#[cfg(not(feature = "new-geometry"))]
 use reearth_flow_geometry::algorithm::hole::HoleCounter as HoleCounterAlgorithm;
+#[cfg(feature = "new-geometry")]
+use reearth_flow_geometry::ops::CountHoles;
 use reearth_flow_runtime::{
     errors::BoxedError,
     event::EventHub,
@@ -8,7 +11,9 @@ use reearth_flow_runtime::{
     forwarder::ProcessorChannelForwarder,
     node::{Port, Processor, ProcessorFactory, FEATURES_PORT},
 };
-use reearth_flow_types::{Attribute, AttributeValue, GeometryValue};
+#[cfg(not(feature = "new-geometry"))]
+use reearth_flow_types::GeometryValue;
+use reearth_flow_types::{Attribute, AttributeValue};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -132,7 +137,26 @@ impl Processor for HoleCounter {
         Ok(())
     }
 
-    #[cfg(not(feature = "new-geometry"))]
+    /// Attach the number of interior rings the geometry's faces carry to the
+    /// feature. Counting is total: a geometry that cannot hold a hole — and an
+    /// absent one — yields zero rather than being rejected, so every feature
+    /// leaves with the attribute set.
+    #[cfg(feature = "new-geometry")]
+    fn process(
+        &mut self,
+        ctx: ExecutorContext,
+        fw: &ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        let count = ctx.feature.geometry.count_holes();
+        let mut feature = ctx.feature.clone();
+        feature.attributes_mut().insert(
+            self.output_attribute.clone(),
+            AttributeValue::Number(count.into()),
+        );
+        fw.send(ctx.new_with_feature_and_port(feature, FEATURES_PORT.clone()));
+        Ok(())
+    }
+
     fn finish(
         &mut self,
         _ctx: NodeContext,
@@ -143,5 +167,133 @@ impl Processor for HoleCounter {
 
     fn name(&self) -> &str {
         "Hole Counter"
+    }
+}
+
+#[cfg(all(test, feature = "new-geometry"))]
+mod tests {
+    use super::*;
+    use crate::tests::utils::create_default_execute_context;
+    use pretty_assertions::assert_eq;
+    use reearth_flow_geometry::coordinate::CoordinateFrame;
+    use reearth_flow_geometry::point::Point3D;
+    use reearth_flow_geometry::polygon::Polygon3D;
+    use reearth_flow_geometry::{Euclidean3DGeometry, Geometry};
+    use reearth_flow_runtime::forwarder::NoopChannelForwarder;
+    use reearth_flow_types::Feature;
+
+    const SQUARE: [[f64; 3]; 5] = [
+        [0.0, 0.0, 0.0],
+        [4.0, 0.0, 0.0],
+        [4.0, 4.0, 0.0],
+        [0.0, 4.0, 0.0],
+        [0.0, 0.0, 0.0],
+    ];
+
+    /// A square face carrying `n` holes.
+    fn face_with_holes(n: usize) -> Geometry {
+        let holes: Vec<_> = (0..n)
+            .map(|i| {
+                let x = 1.0 + i as f64 * 1.5;
+                vec![
+                    [x, 1.0, 0.0],
+                    [x + 1.0, 1.0, 0.0],
+                    [x + 1.0, 2.0, 0.0],
+                    [x, 2.0, 0.0],
+                    [x, 1.0, 0.0],
+                ]
+            })
+            .collect();
+        Geometry::Euclidean3D(Euclidean3DGeometry::Polygon(Box::new(
+            Polygon3D::from_rings(CoordinateFrame::Euclidean, SQUARE, holes),
+        )))
+    }
+
+    /// Run the processor over `feature`, returning the single feature it forwards.
+    fn count(feature: Feature) -> Feature {
+        let fw = ProcessorChannelForwarder::Noop(NoopChannelForwarder::default());
+        let ctx = create_default_execute_context(&feature);
+        HoleCounter {
+            output_attribute: Attribute::new("holeCount"),
+        }
+        .process(ctx, &fw)
+        .unwrap();
+
+        let ProcessorChannelForwarder::Noop(noop) = fw else {
+            unreachable!("the forwarder is the one built above");
+        };
+        let ports = noop.send_ports.lock().unwrap();
+        assert_eq!(ports.len(), 1);
+        assert_eq!(ports[0], *FEATURES_PORT);
+        let features = noop.send_features.lock().unwrap();
+        assert_eq!(features.len(), 1);
+        features[0].clone()
+    }
+
+    fn hole_count(feature: &Feature) -> Option<&AttributeValue> {
+        feature.attributes.get(&Attribute::new("holeCount"))
+    }
+
+    #[test]
+    fn a_face_with_holes_reports_their_number() {
+        let feature = count(Feature::from(face_with_holes(2)));
+        assert_eq!(
+            hole_count(&feature),
+            Some(&AttributeValue::Number(2.into()))
+        );
+    }
+
+    #[test]
+    fn a_face_without_holes_reports_zero() {
+        let feature = count(Feature::from(face_with_holes(0)));
+        assert_eq!(
+            hole_count(&feature),
+            Some(&AttributeValue::Number(0.into()))
+        );
+    }
+
+    #[test]
+    fn a_geometry_that_cannot_carry_a_hole_reports_zero() {
+        let point = Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
+            CoordinateFrame::Euclidean,
+            [1.0, 2.0, 3.0],
+        )));
+        let feature = count(Feature::from(point));
+        assert_eq!(
+            hole_count(&feature),
+            Some(&AttributeValue::Number(0.into()))
+        );
+    }
+
+    /// Unlike the legacy processor, which passes a feature with no geometry
+    /// through untouched, the attribute is always set — matching FME, where every
+    /// other kind of geometry receives a hole count of zero.
+    #[test]
+    fn a_feature_without_geometry_reports_zero() {
+        let feature = count(Feature::from(Geometry::None));
+        assert_eq!(
+            hole_count(&feature),
+            Some(&AttributeValue::Number(0.into()))
+        );
+    }
+
+    #[test]
+    fn existing_attributes_and_the_feature_id_are_preserved() {
+        let mut input = Feature::from(face_with_holes(1));
+        input
+            .attributes_mut()
+            .insert(Attribute::new("gmlId"), AttributeValue::String("x".into()));
+        let id = input.id;
+
+        let feature = count(input);
+        assert_eq!(feature.id, id);
+        assert_eq!(
+            feature.attributes.get(&Attribute::new("gmlId")),
+            Some(&AttributeValue::String("x".into()))
+        );
+        assert_eq!(
+            hole_count(&feature),
+            Some(&AttributeValue::Number(1.into()))
+        );
     }
 }

--- a/engine/runtime/action-processor/src/geometry/hole_counter.rs
+++ b/engine/runtime/action-processor/src/geometry/hole_counter.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 #[cfg(not(feature = "new-geometry"))]
-use reearth_flow_geometry::algorithm::hole::HoleCounter as HoleCounterAlgorithm;
+use reearth_flow_geometry::algorithm::hole::HoleCounter as _;
 #[cfg(feature = "new-geometry")]
 use reearth_flow_geometry::ops::CountHoles;
 use reearth_flow_runtime::{

--- a/engine/runtime/geometry/src/collection.rs
+++ b/engine/runtime/geometry/src/collection.rs
@@ -299,6 +299,24 @@ impl crate::ops::RemoveAppearance for Collection3D {
     }
 }
 
+impl crate::ops::CountHoles for Collection2D {
+    fn count_holes(&self) -> usize {
+        self.members()
+            .iter()
+            .map(Euclidean2DGeometry::count_holes)
+            .sum()
+    }
+}
+
+impl crate::ops::CountHoles for Collection3D {
+    fn count_holes(&self) -> usize {
+        self.members()
+            .iter()
+            .map(Euclidean3DGeometry::count_holes)
+            .sum()
+    }
+}
+
 impl crate::ops::Split for Collection2D {
     fn split(
         &mut self,

--- a/engine/runtime/geometry/src/csg/mod.rs
+++ b/engine/runtime/geometry/src/csg/mod.rs
@@ -35,5 +35,9 @@ pub enum Csg {
 // Tessellation is defined only for `Polygon` / `PolygonMesh`.
 crate::unsupported!(Csg: Triangulate, Reproject, ConvertFrame, ForceTwoDimension);
 
+// An unevaluated boolean tree has no faces of its own; counting the rings of its
+// operands would describe a surface the tree does not yet have.
+crate::unsupported!(Csg: CountHoles);
+
 // A boolean tree is one logical solid, not a multi-part container.
 crate::unsupported!(Csg: Split);

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -53,8 +53,8 @@ use serde::{Deserialize, Serialize};
 
 use ops::triangulation::Cache;
 use ops::{
-    Aabb, BoundingBox, ConvertFrame, ForceTwoDimension, ForceTwoDimensionError, RemoveAppearance,
-    Reproject, ReprojectionCache, Translate, Triangulate, UnsupportedOperation,
+    Aabb, BoundingBox, ConvertFrame, CountHoles, ForceTwoDimension, ForceTwoDimensionError,
+    RemoveAppearance, Reproject, ReprojectionCache, Translate, Triangulate, UnsupportedOperation,
 };
 // `ValidationParams` / `ValidationType` / `ValidationReport` are named by the
 // `enum_dispatch`-generated `Validate` impls on the geometry enums, so they must
@@ -167,7 +167,8 @@ impl GeometryCollection {
         Translate,
         Split,
         ForceTwoDimension,
-        RemoveAppearance
+        RemoveAppearance,
+        CountHoles
     )
 )]
 #[cfg_attr(
@@ -181,7 +182,8 @@ impl GeometryCollection {
         Translate,
         Split,
         ForceTwoDimension,
-        RemoveAppearance
+        RemoveAppearance,
+        CountHoles
     )
 )]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -215,7 +217,8 @@ pub enum Euclidean2DGeometry {
         Translate,
         Split,
         ForceTwoDimension,
-        RemoveAppearance
+        RemoveAppearance,
+        CountHoles
     )
 )]
 #[cfg_attr(
@@ -229,7 +232,8 @@ pub enum Euclidean2DGeometry {
         Translate,
         Split,
         ForceTwoDimension,
-        RemoveAppearance
+        RemoveAppearance,
+        CountHoles
     )
 )]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -450,6 +454,24 @@ impl RemoveAppearance for GeometryCollection {
         for member in self.members_mut() {
             member.remove_appearance();
         }
+    }
+}
+
+impl CountHoles for Geometry {
+    fn count_holes(&self) -> usize {
+        match self {
+            // An absent geometry has no faces, so no holes.
+            Geometry::None => 0,
+            Geometry::Euclidean2D(g) => g.count_holes(),
+            Geometry::Euclidean3D(g) => g.count_holes(),
+            Geometry::GeometryCollection(c) => c.count_holes(),
+        }
+    }
+}
+
+impl CountHoles for GeometryCollection {
+    fn count_holes(&self) -> usize {
+        self.members.iter().map(Geometry::count_holes).sum()
     }
 }
 
@@ -1206,5 +1228,203 @@ mod remove_appearance_tests {
         let mut none = Geometry::None;
         none.remove_appearance();
         assert_eq!(none, Geometry::None);
+    }
+}
+
+#[cfg(test)]
+mod count_holes_tests {
+    use super::*;
+    use coordinate::CoordinateFrame;
+    use line_string::LineString3D;
+    use point::Point3D;
+    use point_cloud::PointCloud;
+    use polygon::{Polygon2D, Polygon3D};
+    use polygon_mesh::{PolygonMesh2D, PolygonMesh3D, PolygonMesh3DData};
+    use solid::{Shell, Solid};
+    use triangular_mesh::TriangularMesh3D;
+
+    /// A unit square, as an exterior ring.
+    const SQUARE: [[f64; 3]; 5] = [
+        [0.0, 0.0, 0.0],
+        [4.0, 0.0, 0.0],
+        [4.0, 4.0, 0.0],
+        [0.0, 4.0, 0.0],
+        [0.0, 0.0, 0.0],
+    ];
+
+    /// A closed square hole ring of side 1, with its lower-left corner at `(x, y)`.
+    fn hole(x: f64, y: f64) -> Vec<[f64; 3]> {
+        vec![
+            [x, y, 0.0],
+            [x + 1.0, y, 0.0],
+            [x + 1.0, y + 1.0, 0.0],
+            [x, y + 1.0, 0.0],
+            [x, y, 0.0],
+        ]
+    }
+
+    /// A square face carrying `n` holes.
+    fn face_with_holes(n: usize) -> Polygon3D {
+        let holes: Vec<_> = (0..n).map(|i| hole(1.0 + i as f64 * 1.5, 1.0)).collect();
+        Polygon3D::from_rings(CoordinateFrame::Euclidean, SQUARE, holes)
+    }
+
+    /// A one-quad shell mesh whose single face carries `n` holes.
+    fn shell_with_holes(n: usize) -> PolygonMesh3DData {
+        PolygonMesh3DData::from_polygons([&face_with_holes(n)])
+    }
+
+    fn geometry_3d(g: Euclidean3DGeometry) -> Geometry {
+        Geometry::Euclidean3D(g)
+    }
+
+    #[test]
+    fn a_polygon_counts_its_interior_rings() {
+        assert_eq!(face_with_holes(0).count_holes(), 0);
+        assert_eq!(face_with_holes(2).count_holes(), 2);
+    }
+
+    #[test]
+    fn a_2d_polygon_counts_its_interior_rings() {
+        let square = [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]];
+        let hole = vec![[1.0, 1.0], [2.0, 1.0], [2.0, 2.0], [1.0, 2.0], [1.0, 1.0]];
+        let p = Polygon2D::from_rings_at_elevation(
+            CoordinateFrame::Euclidean,
+            square,
+            vec![hole],
+            10.0,
+        );
+        assert_eq!(p.count_holes(), 1);
+    }
+
+    #[test]
+    fn a_mesh_counts_the_holes_of_every_face() {
+        // Two faces, one with two holes and one with none: three rings in the
+        // shared `interior_offsets`, counted once each.
+        let mesh = PolygonMesh3D::from_polygons(
+            CoordinateFrame::Euclidean,
+            [&face_with_holes(2), &face_with_holes(0)],
+        )
+        .unwrap();
+        assert_eq!(mesh.num_faces(), 2);
+        assert_eq!(mesh.count_holes(), 2);
+    }
+
+    #[test]
+    fn a_mesh_without_holes_counts_zero() {
+        let mesh = PolygonMesh2D::from_parts(
+            CoordinateFrame::Euclidean,
+            vec![[0.0, 0.0], [3.0, 0.0], [3.0, 2.0]],
+            vec![vec![0u32, 1, 2]],
+        )
+        .unwrap();
+        assert_eq!(mesh.count_holes(), 0);
+    }
+
+    #[test]
+    fn a_2d_mesh_counts_the_holes_of_every_face() {
+        // One quad face (corners 0..4) with one hole ring (corners 4..8).
+        let mesh = PolygonMesh2D::from_raw_parts(
+            CoordinateFrame::Euclidean,
+            vec![
+                [0.0, 0.0],
+                [4.0, 0.0],
+                [4.0, 4.0],
+                [0.0, 4.0],
+                [1.0, 1.0],
+                [2.0, 1.0],
+                [2.0, 2.0],
+                [1.0, 2.0],
+            ],
+            vec![0, 1, 2, 3, 4, 5, 6, 7],
+            Vec::new(),
+            vec![4],
+        )
+        .unwrap();
+        assert_eq!(mesh.count_holes(), 1);
+    }
+
+    #[test]
+    fn a_solid_counts_the_holes_in_the_faces_of_every_shell() {
+        // Exterior face has two holes, the void shell's face has one: three in
+        // all. The void shell itself is not a hole and adds nothing.
+        let solid = Solid::new(
+            CoordinateFrame::Euclidean,
+            shell_with_holes(2),
+            vec![Shell::from(shell_with_holes(1))],
+        );
+        assert_eq!(solid.interiors().len(), 1);
+        assert_eq!(solid.count_holes(), 3);
+    }
+
+    #[test]
+    fn a_solid_bounded_by_triangles_counts_zero() {
+        let mesh = triangular_mesh::TriangularMesh3DData::from_parts(
+            vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            [0u32, 1, 2],
+        )
+        .unwrap();
+        let solid = Solid::from_exterior(CoordinateFrame::Euclidean, mesh);
+        assert_eq!(solid.count_holes(), 0);
+    }
+
+    #[test]
+    fn a_type_that_cannot_carry_a_hole_counts_zero() {
+        let tris = TriangularMesh3D::from_parts(
+            CoordinateFrame::Euclidean,
+            vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            [0u32, 1, 2],
+        )
+        .unwrap();
+        let cloud = PointCloud::from_positions(CoordinateFrame::Euclidean, [[0.0, 0.0, 0.0]]);
+        let csg = csg::Csg::union(
+            Solid::from_exterior(CoordinateFrame::Euclidean, shell_with_holes(2)),
+            Solid::from_exterior(CoordinateFrame::Euclidean, shell_with_holes(1)),
+        );
+
+        for g in [
+            Euclidean3DGeometry::Point(Point3D::new(CoordinateFrame::Euclidean, [1.0, 2.0, 3.0])),
+            Euclidean3DGeometry::LineString(LineString3D::from_coords(
+                CoordinateFrame::Euclidean,
+                [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
+            )),
+            Euclidean3DGeometry::TriangularMesh(Box::new(tris)),
+            Euclidean3DGeometry::PointCloud(Box::new(cloud)),
+            // An unevaluated tree has no faces of its own, so its operands'
+            // holes do not surface.
+            Euclidean3DGeometry::Csg(csg),
+        ] {
+            assert_eq!(geometry_3d(g).count_holes(), 0);
+        }
+    }
+
+    #[test]
+    fn an_absent_geometry_counts_zero() {
+        assert_eq!(Geometry::None.count_holes(), 0);
+    }
+
+    #[test]
+    fn a_collection_sums_its_members() {
+        let c = collection::Collection3D::new([
+            Euclidean3DGeometry::Polygon(Box::new(face_with_holes(2))),
+            Euclidean3DGeometry::Point(Point3D::new(CoordinateFrame::Euclidean, [0.0, 0.0, 0.0])),
+        ]);
+        assert_eq!(
+            geometry_3d(Euclidean3DGeometry::Collection(c)).count_holes(),
+            2
+        );
+    }
+
+    #[test]
+    fn counting_reaches_through_nested_collections() {
+        let inner = Geometry::GeometryCollection(GeometryCollection::new([geometry_3d(
+            Euclidean3DGeometry::Polygon(Box::new(face_with_holes(1))),
+        )]));
+        let outer = Geometry::GeometryCollection(GeometryCollection::new([
+            inner,
+            geometry_3d(Euclidean3DGeometry::Polygon(Box::new(face_with_holes(3)))),
+            Geometry::None,
+        ]));
+        assert_eq!(outer.count_holes(), 4);
     }
 }

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -1243,7 +1243,7 @@ mod count_holes_tests {
     use solid::{Shell, Solid};
     use triangular_mesh::TriangularMesh3D;
 
-    /// A unit square, as an exterior ring.
+    /// A 4x4 square, as an exterior ring.
     const SQUARE: [[f64; 3]; 5] = [
         [0.0, 0.0, 0.0],
         [4.0, 0.0, 0.0],
@@ -1299,8 +1299,9 @@ mod count_holes_tests {
 
     #[test]
     fn a_mesh_counts_the_holes_of_every_face() {
-        // Two faces, one with two holes and one with none: three rings in the
-        // shared `interior_offsets`, counted once each.
+        // Two faces, one with two holes and one with none: the shared
+        // `interior_offsets` holds one entry per interior ring, so the mesh-wide
+        // count needs no per-face walk and cannot count a ring twice.
         let mesh = PolygonMesh3D::from_polygons(
             CoordinateFrame::Euclidean,
             [&face_with_holes(2), &face_with_holes(0)],

--- a/engine/runtime/geometry/src/line_string/mod.rs
+++ b/engine/runtime/geometry/src/line_string/mod.rs
@@ -75,3 +75,6 @@ crate::unsupported!(LineString3D: Split);
 
 crate::unsupported!(LineString2D: RemoveAppearance);
 crate::unsupported!(LineString3D: RemoveAppearance);
+
+crate::unsupported!(LineString2D: CountHoles);
+crate::unsupported!(LineString3D: CountHoles);

--- a/engine/runtime/geometry/src/ops/mod.rs
+++ b/engine/runtime/geometry/src/ops/mod.rs
@@ -268,6 +268,31 @@ impl<T: RemoveAppearance + ?Sized> RemoveAppearance for Box<T> {
     }
 }
 
+/// Count the interior (hole) rings a geometry's faces carry.
+///
+/// Total over the hierarchy: a type that cannot carry a hole inherits the `0`
+/// default, so counting never fails and a caller cannot tell "has no holes" from
+/// "cannot have holes". The unit counted is the ring, not the face: a face with
+/// two holes contributes two, matching the inner boundaries a donut reports.
+///
+/// A [`Solid`](crate::solid::Solid)'s void shells are not holes in this sense —
+/// they are hollow volumes, not boundaries of a face — so they are not counted;
+/// the holes in the faces of those shells are.
+#[enum_dispatch::enum_dispatch]
+pub trait CountHoles {
+    /// The number of interior rings across this geometry, recursing into
+    /// collections.
+    fn count_holes(&self) -> usize {
+        0
+    }
+}
+
+impl<T: CountHoles + ?Sized> CountHoles for Box<T> {
+    fn count_holes(&self) -> usize {
+        (**self).count_holes()
+    }
+}
+
 /// Why a geometry could not be re-represented in a pure 2D embedding.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ForceTwoDimensionError {

--- a/engine/runtime/geometry/src/point/mod.rs
+++ b/engine/runtime/geometry/src/point/mod.rs
@@ -63,3 +63,6 @@ crate::unsupported!(Point3D: Split);
 
 crate::unsupported!(Point2D: RemoveAppearance);
 crate::unsupported!(Point3D: RemoveAppearance);
+
+crate::unsupported!(Point2D: CountHoles);
+crate::unsupported!(Point3D: CountHoles);

--- a/engine/runtime/geometry/src/point_cloud/mod.rs
+++ b/engine/runtime/geometry/src/point_cloud/mod.rs
@@ -155,5 +155,6 @@ crate::unsupported!(
     Reproject,
     ConvertFrame,
     ForceTwoDimension,
-    RemoveAppearance
+    RemoveAppearance,
+    CountHoles
 );

--- a/engine/runtime/geometry/src/polygon/ops.rs
+++ b/engine/runtime/geometry/src/polygon/ops.rs
@@ -356,7 +356,20 @@ impl Polygon2D {
     }
 }
 
-use crate::ops::RemoveAppearance;
+use crate::ops::{CountHoles, RemoveAppearance};
+
+// One offset per interior ring, so the count is the offsets' length.
+impl CountHoles for Polygon2D {
+    fn count_holes(&self) -> usize {
+        self.interior_offsets.len()
+    }
+}
+
+impl CountHoles for Polygon3D {
+    fn count_holes(&self) -> usize {
+        self.interior_offsets.len()
+    }
+}
 
 impl RemoveAppearance for Polygon2D {
     fn remove_appearance(&mut self) {

--- a/engine/runtime/geometry/src/polygon_mesh/mod.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/mod.rs
@@ -234,6 +234,13 @@ impl PolygonMesh3DData {
 }
 
 impl PolygonMesh3DData {
+    /// The number of hole rings across every face. Crate-internal: lets a
+    /// [`Solid`](crate::solid::Solid) shell count its own holes.
+    #[inline]
+    pub(crate) fn num_holes(&self) -> usize {
+        self.interior_offsets.len()
+    }
+
     /// Drop the appearance.
     pub(crate) fn remove_appearance(&mut self) {
         self.appearance = None;

--- a/engine/runtime/geometry/src/polygon_mesh/ops.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/ops.rs
@@ -553,7 +553,21 @@ impl PolygonMesh2D {
     }
 }
 
-use crate::ops::RemoveAppearance;
+use crate::ops::{CountHoles, RemoveAppearance};
+
+// `interior_offsets` already spans every face, so the mesh-wide count is its
+// length — no per-face walk, and no risk of counting a ring twice.
+impl CountHoles for PolygonMesh2D {
+    fn count_holes(&self) -> usize {
+        self.interior_offsets.len()
+    }
+}
+
+impl CountHoles for PolygonMesh3D {
+    fn count_holes(&self) -> usize {
+        self.data().num_holes()
+    }
+}
 
 impl RemoveAppearance for PolygonMesh2D {
     fn remove_appearance(&mut self) {

--- a/engine/runtime/geometry/src/solid/ops.rs
+++ b/engine/runtime/geometry/src/solid/ops.rs
@@ -143,7 +143,23 @@ impl ConvertFrame for Solid {
 // result, so it has no 2D counterpart.
 crate::unsupported!(Solid: ForceTwoDimension);
 
-use crate::ops::RemoveAppearance;
+use crate::ops::{CountHoles, RemoveAppearance};
+
+impl CountHoles for Solid {
+    /// The holes in the boundary faces of every shell. The void shells
+    /// themselves are hollow volumes rather than face boundaries, so they are
+    /// not counted; only the rings inside their faces are. A triangle-mesh shell
+    /// carries no rings and contributes nothing.
+    fn count_holes(&self) -> usize {
+        std::iter::once(&self.exterior)
+            .chain(self.interiors.iter())
+            .map(|shell| match shell {
+                Shell::PolygonMesh(data) => data.num_holes(),
+                Shell::TriangularMesh(_) => 0,
+            })
+            .sum()
+    }
+}
 
 impl RemoveAppearance for Solid {
     fn remove_appearance(&mut self) {

--- a/engine/runtime/geometry/src/triangular_mesh/mod.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/mod.rs
@@ -212,6 +212,10 @@ impl TriangularMesh3DData {
 crate::unsupported!(TriangularMesh2D: Triangulate);
 crate::unsupported!(TriangularMesh3D: Triangulate);
 
+// Triangles carry no interior rings, so the hole count is always zero.
+crate::unsupported!(TriangularMesh2D: CountHoles);
+crate::unsupported!(TriangularMesh3D: CountHoles);
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.97"
+version = "0.2.98"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.287"
+version = "0.1.288"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
# Overview

Makes the Hole Counter processor work in the new geometry world. It attaches the number of interior (hole) rings a feature's geometry carries to the feature as an attribute.

## What I've done

Counting is total, following FME: every feature leaves with the attribute set. A geometry that cannot carry a hole — a point, a line, a triangular mesh, a point cloud — and an absent geometry all yield `0` rather than being rejected. This differs from the legacy processor, which passes a feature with no geometry through without the attribute, and panics on a triangular mesh.

The unit counted is the ring, not the face: a face with two holes contributes two. Collections are summed recursively. A `Solid` counts the holes in the faces of all its shells; its void shells are hollow volumes rather than face boundaries, so they are not counted themselves. An unevaluated CSG tree yields `0`, since it has no faces of its own yet.

## What I haven't done

- The legacy geometry path is untouched, so the behavior above applies only under the `new-geometry` feature.
- No workflow-level test — `workflow-tests` is excluded from the `new-geometry` build, so coverage is unit tests only.

## How I tested

- `cargo test -p reearth-flow-geometry --features new-geometry count_holes` — 11 passed.
- `cargo test -p reearth-flow-action-processor --features new-geometry hole_counter` — 5 passed.

## Screenshot

## Which point I want you to review particularly

- Whether matching FME by returning `0` for unsupported and absent geometries, instead of rejecting them as the legacy processor does, is the semantics we want.
- Whether excluding a `Solid`'s void shells from the count, while counting the holes in their faces, is the right reading.

## Memo