### PR TITLE
test(ui): align e2e suite with renamed engine actions, ports, and form labels

### DIFF
--- a/ui/e2e/pages/editorPage.ts
+++ b/ui/e2e/pages/editorPage.ts
@@ -267,7 +267,7 @@ export class EditorPage {
     source: Locator,
     target: Locator,
     sourcePortId: string,
-    targetPortId = "default",
+    targetPortId = "features",
   ) {
     await this.connectAndVerify(
       source.locator(
@@ -365,7 +365,7 @@ export class EditorPage {
       .catch(() => false);
     if (hasTab) await tabTrigger.click();
 
-    const textarea = this.flowExprDialog.locator("textarea");
+    const textarea = this.flowExprDialog.locator("textarea:visible").first();
     await textarea.waitFor({ state: "visible" });
     await textarea.fill(value);
 
@@ -388,9 +388,16 @@ export class EditorPage {
   }
 
   async setParamCheckbox(fieldId: string, checked: boolean) {
-    const box = this.paramsDialog.locator(`#${fieldId}`);
+    // Base UI checkboxes put the id on a hidden native input; click the
+    // adjacent role=checkbox element instead.
+    const box = this.paramsDialog
+      .locator(`input#${fieldId}`)
+      .locator('xpath=preceding-sibling::*[@role="checkbox"][1]')
+      .first();
     await box.waitFor({ state: "visible" });
-    const isChecked = (await box.getAttribute("data-state")) === "checked";
+    const isChecked =
+      (await box.getAttribute("aria-checked")) === "true" ||
+      (await box.getAttribute("data-checked")) !== null;
     if (isChecked !== checked) await box.click();
   }
 

--- a/ui/e2e/tests/area-calculator-ui-built.spec.ts
+++ b/ui/e2e/tests/area-calculator-ui-built.spec.ts
@@ -97,27 +97,27 @@ test.describe.serial(
       expect(await editor.isInEditor()).toBe(true);
     });
 
-    test("builds GeoJsonReader → AreaCalculator → GeoJsonWriter and configures each node", async () => {
+    test("builds GeoJSON Reader → Area Calculator → GeoJSON Writer and configures each node", async () => {
       await editor.addSpecificActionNode(
         "reader",
-        "GeoJsonReader",
+        "GeoJSON Reader",
         await editor.canvasPoint(0.25, 0.4),
       );
       await editor.addSpecificActionNode(
         "transformer",
-        "AreaCalculator",
+        "Area Calculator",
         await editor.canvasPoint(0.5, 0.4),
       );
       await editor.addSpecificActionNode(
         "writer",
-        "GeoJsonWriter",
+        "GeoJSON Writer",
         await editor.canvasPoint(0.75, 0.4),
       );
       await expect(editor.nodes).toHaveCount(3);
 
-      const readerNode = editor.nodeByName("GeoJsonReader");
-      const areaNode = editor.nodeByName("AreaCalculator");
-      const writerNode = editor.nodeByName("GeoJsonWriter");
+      const readerNode = editor.nodeByName("GeoJSON Reader");
+      const areaNode = editor.nodeByName("Area Calculator");
+      const writerNode = editor.nodeByName("GeoJSON Writer");
 
       await editor.connectNodes(readerNode, areaNode);
       await editor.connectNodes(areaNode, writerNode);
@@ -137,7 +137,7 @@ test.describe.serial(
       await editor.submitParams();
 
       await editor.openNodeParamsForm(writerNode);
-      await editor.setParamCodeString("output", "park-areas.geojson");
+      await editor.setParamCodeString("Output File", "park-areas.geojson");
       await editor.submitParams();
     });
 

--- a/ui/e2e/tests/cafe-clean-export-ui-built.spec.ts
+++ b/ui/e2e/tests/cafe-clean-export-ui-built.spec.ts
@@ -135,27 +135,27 @@ test.describe.serial(
     test("builds and configures the five nodes", async () => {
       csvReader = await editor.addActionNodeAndGet(
         "reader",
-        "CsvReader",
+        "CSV Reader",
         await editor.canvasPoint(0.5, 0.5),
       );
       featureFilter = await editor.addActionNodeAndGet(
         "transformer",
-        "FeatureFilter",
+        "Feature Filter",
         await editor.canvasPoint(0.1, 0.18),
       );
       attributeManager = await editor.addActionNodeAndGet(
         "transformer",
-        "AttributeManager",
+        "Attribute Manager",
         await editor.canvasPoint(0.82, 0.18),
       );
       geoJsonWriter = await editor.addActionNodeAndGet(
         "writer",
-        "GeoJsonWriter",
+        "GeoJSON Writer",
         await editor.canvasPoint(0.82, 0.82),
       );
       csvWriter = await editor.addActionNodeAndGet(
         "writer",
-        "CsvWriter",
+        "CSV Writer",
         await editor.canvasPoint(0.1, 0.82),
       );
       await expect(editor.nodes).toHaveCount(5);
@@ -170,7 +170,7 @@ test.describe.serial(
       await editor.openNodeParamsForm(featureFilter);
       await editor.addParamArrayItem();
       await editor.setParamFlowExpr(
-        "Condition expression",
+        "Condition Expression",
         'attributes["is_closed"] == "False"',
       );
       await editor.setParamText("root_conditions_0_outputPort", OPEN_PORT);
@@ -178,40 +178,40 @@ test.describe.serial(
       await editor.openNodeParamsForm(attributeManager);
       await editor.addParamArrayItem();
       await editor.setParamText("root_operations_0_attribute", HIGH_RATED_ATTR);
-      await editor.setParamSelect("Operation to perform", "create");
+      await editor.setParamSelect("Method", "Create");
       await editor.setParamFlowExpr(
         "Value",
         'float(attributes["rating"]) >= 4.0',
       );
       await editor.submitParams();
       await editor.openNodeParamsForm(geoJsonWriter);
-      await editor.setParamCodeString("output", GEOJSON_OUTPUT);
+      await editor.setParamCodeString("Output File", GEOJSON_OUTPUT);
       await editor.submitParams();
 
       await editor.openNodeParamsForm(csvWriter);
-      await editor.setParamSelect("format", "CSV (Comma-Separated Values)");
+      await editor.setParamSelect("File Format", "CSV (Comma-Separated Values)");
       await editor.setCsvCoordinateGeometry("longitude", "latitude");
-      await editor.setParamCodeString("output", CSV_OUTPUT);
+      await editor.setParamCodeString("Output File", CSV_OUTPUT);
       await editor.submitParams();
 
-      await editor.connectFromPort(csvReader, featureFilter, "default");
+      await editor.connectFromPort(csvReader, featureFilter, "features");
       await editor.connectFromPort(
         featureFilter,
         attributeManager,
         OPEN_PORT,
-        "default",
+        "features",
       );
       await editor.connectFromPort(
         attributeManager,
         geoJsonWriter,
-        "default",
-        "default",
+        "features",
+        "features",
       );
       await editor.connectFromPort(
         attributeManager,
         csvWriter,
-        "default",
-        "default",
+        "features",
+        "features",
       );
       await expect(editor.edges).toHaveCount(4);
     });

--- a/ui/e2e/tests/cafe-clean-export-ui-built.spec.ts
+++ b/ui/e2e/tests/cafe-clean-export-ui-built.spec.ts
@@ -189,7 +189,10 @@ test.describe.serial(
       await editor.submitParams();
 
       await editor.openNodeParamsForm(csvWriter);
-      await editor.setParamSelect("File Format", "CSV (Comma-Separated Values)");
+      await editor.setParamSelect(
+        "File Format",
+        "CSV (Comma-Separated Values)",
+      );
       await editor.setCsvCoordinateGeometry("longitude", "latitude");
       await editor.setParamCodeString("Output File", CSV_OUTPUT);
       await editor.submitParams();

--- a/ui/e2e/tests/fixtures/sample-workflow.json
+++ b/ui/e2e/tests/fixtures/sample-workflow.json
@@ -11,7 +11,7 @@
           "id": "11111111-1111-4111-8111-111111111111",
           "name": "Create Features",
           "type": "action",
-          "action": "FeatureCreator",
+          "action": "Feature Creator",
           "with": {
             "creator": "[#{ name: \"alpha\", value: 10 }, #{ name: \"beta\", value: 25 }, #{ name: \"gamma\", value: 40 }]"
           }
@@ -20,7 +20,7 @@
           "id": "22222222-2222-4222-8222-222222222222",
           "name": "Manage Attributes",
           "type": "action",
-          "action": "AttributeManager",
+          "action": "Attribute Manager",
           "with": {
             "operations": [
               {
@@ -38,7 +38,7 @@
           "id": "33333333-3333-4333-8333-333333333333",
           "name": "Write Output",
           "type": "action",
-          "action": "JsonWriter",
+          "action": "JSON Writer",
           "with": {
             "output": "file::join_path(env.get(\"workerArtifactPath\"), \"result.json\")"
           }
@@ -49,15 +49,15 @@
           "id": "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa",
           "from": "11111111-1111-4111-8111-111111111111",
           "to": "22222222-2222-4222-8222-222222222222",
-          "fromPort": "default",
-          "toPort": "default"
+          "fromPort": "features",
+          "toPort": "features"
         },
         {
           "id": "bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb",
           "from": "22222222-2222-4222-8222-222222222222",
           "to": "33333333-3333-4333-8333-333333333333",
-          "fromPort": "default",
-          "toPort": "default"
+          "fromPort": "features",
+          "toPort": "features"
         }
       ]
     }

--- a/ui/e2e/tests/fixtures/workflows/area-calculator.yml
+++ b/ui/e2e/tests/fixtures/workflows/area-calculator.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/reearth/reearth-flow/main/engine/schema/workflow.json
-#   GeoJsonReader ──> AreaCalculator ──> GeoJsonWriter
+#   GeoJSON Reader ──> Area Calculator ──> GeoJSON Writer
 #
 id: 7efa24a6-19fa-4be1-8f5b-7e5e14b6e551
 name: "Area Calculator"
@@ -18,7 +18,7 @@ graphs:
       - id: 975a786f-5738-48a1-8666-8e7ecf38cb93
         name: Read Park Boundaries
         type: action
-        action: GeoJsonReader
+        action: GeoJSON Reader
         with:
           inline:
             type: flowExpr
@@ -27,7 +27,7 @@ graphs:
       - id: 854740f8-8159-480c-80c1-b0b7596a03f2
         name: Calculate Area
         type: action
-        action: AreaCalculator
+        action: Area Calculator
         with:
           areaType: planeArea
           # Coordinates are EPSG:4326 degrees, so the raw planar area is in
@@ -39,7 +39,7 @@ graphs:
       - id: a287e65d-e503-40cb-9188-5edf1d0e263b
         name: Write Park Areas
         type: action
-        action: GeoJsonWriter
+        action: GeoJSON Writer
         with:
           # Sink outputs must be relative paths; the engine resolves them
           # against the job's artifact sandbox and rejects absolute URIs.
@@ -51,10 +51,10 @@ graphs:
       - id: f5fe8722-2c01-4227-a61a-5d5a91071fd2
         from: 975a786f-5738-48a1-8666-8e7ecf38cb93
         to: 854740f8-8159-480c-80c1-b0b7596a03f2
-        fromPort: default
-        toPort: default
+        fromPort: features
+        toPort: features
       - id: c81306e8-a0c5-4c6f-bf25-a5e4821dc2f4
         from: 854740f8-8159-480c-80c1-b0b7596a03f2
         to: a287e65d-e503-40cb-9188-5edf1d0e263b
-        fromPort: default
-        toPort: default
+        fromPort: features
+        toPort: features

--- a/ui/e2e/tests/fixtures/workflows/csv-to-geojson.yml
+++ b/ui/e2e/tests/fixtures/workflows/csv-to-geojson.yml
@@ -16,7 +16,7 @@ graphs:
       - id: aae4eebe-21ab-48b9-a5fc-c141c0ead1a1
         name: Read Stations CSV
         type: action
-        action: CsvReader
+        action: CSV Reader
         with:
           format: csv
           inline:
@@ -31,7 +31,7 @@ graphs:
       - id: a78a9422-2de7-4635-8a72-c256788055b2
         name: Derive Attributes
         type: action
-        action: AttributeManager
+        action: Attribute Manager
         with:
           operations:
             - attribute: dailyRiders
@@ -50,7 +50,7 @@ graphs:
       - id: ce50d0c1-1997-4238-a07c-4f221056f5e3
         name: Write Stations GeoJSON
         type: action
-        action: GeoJsonWriter
+        action: GeoJSON Writer
         with:
           # Sink outputs must be relative paths; the engine resolves them
           # against the job's artifact sandbox and rejects absolute URIs.
@@ -62,10 +62,10 @@ graphs:
       - id: 0b12ab32-6f2a-427c-8459-f31fcf7f0f92
         from: aae4eebe-21ab-48b9-a5fc-c141c0ead1a1
         to: a78a9422-2de7-4635-8a72-c256788055b2
-        fromPort: default
-        toPort: default
+        fromPort: features
+        toPort: features
       - id: 20c6bea5-89ce-40e4-93f5-8e20d65e8d0e
         from: a78a9422-2de7-4635-8a72-c256788055b2
         to: ce50d0c1-1997-4238-a07c-4f221056f5e3
-        fromPort: default
-        toPort: default
+        fromPort: features
+        toPort: features

--- a/ui/e2e/tests/fixtures/workflows/plateau-citygml.yml
+++ b/ui/e2e/tests/fixtures/workflows/plateau-citygml.yml
@@ -12,7 +12,7 @@ graphs:
       - id: 84c5508a-68f0-4726-a868-411c90dd44e7
         name: Download City Archive
         type: action
-        action: FilePathExtractor
+        action: File Path Extractor
         with:
           sourceDataset:
             type: flowExpr
@@ -22,13 +22,13 @@ graphs:
       - id: 8d830d0f-8f5c-4bac-9c5a-0a4f0c68c697
         name: Keep GML Files
         type: action
-        action: FeatureFilter
+        action: Feature Filter
         with:
           conditions:
             - expr:
                 type: flowExpr
                 value: attributes["extension"] == "gml"
-              outputPort: default
+              outputPort: features
 
       - id: b8bd3903-c1f2-4c66-8c98-54085f1ecc1d
         name: Extract UDX Folders
@@ -42,18 +42,18 @@ graphs:
       - id: abd47145-383b-4703-8710-e5becfdc055a
         name: Keep Building Package
         type: action
-        action: FeatureFilter
+        action: Feature Filter
         with:
           conditions:
             - expr:
                 type: flowExpr
                 value: attributes["package"] in env["targetPackages"]
-              outputPort: default
+              outputPort: features
 
       - id: 30a2626c-886c-4bd5-96d4-30e4c9c26f07
         name: Read Building CityGML
         type: action
-        action: FeatureCityGmlReader
+        action: Feature CityGML Reader
         with:
           dataset:
             type: flowExpr
@@ -62,7 +62,7 @@ graphs:
       - id: 5f5f1dbd-7891-40db-8e4d-629cd5586b0a
         name: Keep Core Attributes
         type: action
-        action: AttributeMapper
+        action: Attribute Mapper
         with:
           mappers:
             - attribute: gmlId
@@ -79,7 +79,7 @@ graphs:
       - id: 7c438ee6-ef16-4462-a7a7-05752e1550ec
         name: Write Buildings GeoJSON
         type: action
-        action: GeoJsonWriter
+        action: GeoJSON Writer
         with:
           # Sink outputs must be relative paths; the engine resolves them
           # against the job's artifact sandbox and rejects absolute URIs.
@@ -91,30 +91,30 @@ graphs:
       - id: a16b6de3-4262-4270-828e-5396dc58ada2
         from: 84c5508a-68f0-4726-a868-411c90dd44e7
         to: 8d830d0f-8f5c-4bac-9c5a-0a4f0c68c697
-        fromPort: default
-        toPort: default
+        fromPort: features
+        toPort: features
       - id: 015df6a0-8383-48bc-8c4d-6653d48e0856
         from: 8d830d0f-8f5c-4bac-9c5a-0a4f0c68c697
         to: b8bd3903-c1f2-4c66-8c98-54085f1ecc1d
-        fromPort: default
-        toPort: default
+        fromPort: features
+        toPort: features
       - id: 7327e079-b453-4016-97a1-15c6ab763687
         from: b8bd3903-c1f2-4c66-8c98-54085f1ecc1d
         to: abd47145-383b-4703-8710-e5becfdc055a
-        fromPort: default
-        toPort: default
+        fromPort: features
+        toPort: features
       - id: 1448f49f-5aa3-4dd7-a0ee-189c4a0e5c04
         from: abd47145-383b-4703-8710-e5becfdc055a
         to: 30a2626c-886c-4bd5-96d4-30e4c9c26f07
-        fromPort: default
-        toPort: default
+        fromPort: features
+        toPort: features
       - id: 920dce8f-dae7-4d78-9457-c0b44837b571
         from: 30a2626c-886c-4bd5-96d4-30e4c9c26f07
         to: 5f5f1dbd-7891-40db-8e4d-629cd5586b0a
-        fromPort: default
-        toPort: default
+        fromPort: features
+        toPort: features
       - id: e6493d04-4e01-4a2c-b3a0-67ca07faf298
         from: 5f5f1dbd-7891-40db-8e4d-629cd5586b0a
         to: 7c438ee6-ef16-4462-a7a7-05752e1550ec
-        fromPort: default
-        toPort: default
+        fromPort: features
+        toPort: features

--- a/ui/e2e/tests/plateau-citygml-ui-built.spec.ts
+++ b/ui/e2e/tests/plateau-citygml-ui-built.spec.ts
@@ -64,32 +64,32 @@ test.describe.serial(
     test("builds and configures the six available nodes", async () => {
       fileExtractor = await editor.addActionNodeAndGet(
         "reader",
-        "FilePathExtractor",
+        "File Path Extractor",
         await editor.canvasPoint(0.15, 0.25),
       );
       filterGml = await editor.addActionNodeAndGet(
         "transformer",
-        "FeatureFilter",
+        "Feature Filter",
         await editor.canvasPoint(0.42, 0.22),
       );
       filterBuilding = await editor.addActionNodeAndGet(
         "transformer",
-        "FeatureFilter",
+        "Feature Filter",
         await editor.canvasPoint(0.72, 0.22),
       );
       cityGmlReader = await editor.addActionNodeAndGet(
         "transformer",
-        "FeatureCityGmlReader",
+        "Feature CityGML Reader",
         await editor.canvasPoint(0.72, 0.72),
       );
       attributeMapper = await editor.addActionNodeAndGet(
         "transformer",
-        "AttributeMapper",
+        "Attribute Mapper",
         await editor.canvasPoint(0.42, 0.72),
       );
       geoJsonWriter = await editor.addActionNodeAndGet(
         "writer",
-        "GeoJsonWriter",
+        "GeoJSON Writer",
         await editor.canvasPoint(0.15, 0.72),
       );
       await expect(editor.nodes).toHaveCount(6);
@@ -102,19 +102,19 @@ test.describe.serial(
       await editor.openNodeParamsForm(filterGml);
       await editor.addParamArrayItem();
       await editor.setParamFlowExpr(
-        "Condition expression",
+        "Condition Expression",
         'attributes["extension"] == "gml"',
       );
-      await editor.setParamText("root_conditions_0_outputPort", "default");
+      await editor.setParamText("root_conditions_0_outputPort", "features");
       await editor.submitParams();
 
       await editor.openNodeParamsForm(filterBuilding);
       await editor.addParamArrayItem();
       await editor.setParamFlowExpr(
-        "Condition expression",
+        "Condition Expression",
         'attributes["package"] == "bldg"',
       );
-      await editor.setParamText("root_conditions_0_outputPort", "default");
+      await editor.setParamText("root_conditions_0_outputPort", "features");
       await editor.submitParams();
 
       await editor.openNodeParamsForm(cityGmlReader);
@@ -131,20 +131,20 @@ test.describe.serial(
       await editor.setParamText("root_mappers_2_valueAttribute", "maxLod");
       await editor.setParamText("root_mappers_3_attribute", "meshcode");
       await editor.setParamFlowExpr(
-        "Expression to evaluate",
+        "Value Expression",
         'attributes["path"].split("/")[-1].split("_")[0]',
         3,
       );
       await editor.submitParams();
 
       await editor.openNodeParamsForm(geoJsonWriter);
-      await editor.setParamCodeString("output", "toshima-buildings.geojson");
+      await editor.setParamCodeString("Output File", "toshima-buildings.geojson");
       await editor.submitParams();
 
-      await editor.connectFromPort(fileExtractor, filterGml, "default");
-      await editor.connectFromPort(filterBuilding, cityGmlReader, "default");
-      await editor.connectFromPort(cityGmlReader, attributeMapper, "default");
-      await editor.connectFromPort(attributeMapper, geoJsonWriter, "default");
+      await editor.connectFromPort(fileExtractor, filterGml, "features");
+      await editor.connectFromPort(filterBuilding, cityGmlReader, "features");
+      await editor.connectFromPort(cityGmlReader, attributeMapper, "features");
+      await editor.connectFromPort(attributeMapper, geoJsonWriter, "features");
       await expect(editor.edges).toHaveCount(4);
     });
 
@@ -181,8 +181,8 @@ test.describe.serial(
       );
       await editor.submitParams();
 
-      await editor.connectFromPort(filterGml, udxExtractor, "default");
-      await editor.connectFromPort(udxExtractor, filterBuilding, "default");
+      await editor.connectFromPort(filterGml, udxExtractor, "features");
+      await editor.connectFromPort(udxExtractor, filterBuilding, "features");
       await expect(editor.edges).toHaveCount(6);
 
       await editor.deploy(deploymentDescription);

--- a/ui/e2e/tests/plateau-citygml-ui-built.spec.ts
+++ b/ui/e2e/tests/plateau-citygml-ui-built.spec.ts
@@ -138,7 +138,10 @@ test.describe.serial(
       await editor.submitParams();
 
       await editor.openNodeParamsForm(geoJsonWriter);
-      await editor.setParamCodeString("Output File", "toshima-buildings.geojson");
+      await editor.setParamCodeString(
+        "Output File",
+        "toshima-buildings.geojson",
+      );
       await editor.submitParams();
 
       await editor.connectFromPort(fileExtractor, filterGml, "features");

--- a/ui/e2e/tests/school-parks-ui-built.spec.ts
+++ b/ui/e2e/tests/school-parks-ui-built.spec.ts
@@ -119,7 +119,7 @@ test.describe.serial(
     test("builds and configures the five nodes", async () => {
       shapefileReader = await editor.addActionNodeAndGet(
         "reader",
-        "ShapefileReader",
+        "Shapefile Reader",
         await editor.canvasPoint(0.12, 0.25),
       );
       bufferer = await editor.addActionNodeAndGet(
@@ -129,17 +129,17 @@ test.describe.serial(
       );
       geoJsonReader = await editor.addActionNodeAndGet(
         "reader",
-        "GeoJsonReader",
+        "GeoJSON Reader",
         await editor.canvasPoint(0.12, 0.7),
       );
       spatialFilter = await editor.addActionNodeAndGet(
         "transformer",
-        "SpatialFilter",
+        "Spatial Filter",
         await editor.canvasPoint(0.62, 0.48),
       );
       geoJsonWriter = await editor.addActionNodeAndGet(
         "writer",
-        "GeoJsonWriter",
+        "GeoJSON Writer",
         await editor.canvasPoint(0.86, 0.48),
       );
       await expect(editor.nodes).toHaveCount(5);
@@ -172,27 +172,27 @@ test.describe.serial(
       // Sink outputs must be relative paths; the engine resolves them against
       // the job's artifact sandbox.
       await editor.openNodeParamsForm(geoJsonWriter);
-      await editor.setParamCodeString("output", OUTPUT_FILE);
+      await editor.setParamCodeString("Output File", OUTPUT_FILE);
       await editor.submitParams();
 
-      await editor.connectFromPort(shapefileReader, bufferer, "default");
+      await editor.connectFromPort(shapefileReader, bufferer, "features");
       await editor.connectFromPort(
         bufferer,
         spatialFilter,
-        "default",
+        "features",
         "filter",
       );
       await editor.connectFromPort(
         geoJsonReader,
         spatialFilter,
-        "default",
+        "features",
         "candidate",
       );
       await editor.connectFromPort(
         spatialFilter,
         geoJsonWriter,
         "passed",
-        "default",
+        "features",
       );
       await expect(editor.edges).toHaveCount(4);
     });

--- a/ui/e2e/tests/ui-csv-to-geojson-built-workflow.spec.ts
+++ b/ui/e2e/tests/ui-csv-to-geojson-built-workflow.spec.ts
@@ -57,27 +57,27 @@ test.describe.serial(
       expect(await editor.isInEditor()).toBe(true);
     });
 
-    test("builds CsvReader → AttributeManager → GeoJsonWriter and configures each node", async () => {
+    test("builds CSV Reader → Attribute Manager → GeoJSON Writer and configures each node", async () => {
       await editor.addSpecificActionNode(
         "reader",
-        "CsvReader",
+        "CSV Reader",
         await editor.canvasPoint(0.25, 0.4),
       );
       await editor.addSpecificActionNode(
         "transformer",
-        "AttributeManager",
+        "Attribute Manager",
         await editor.canvasPoint(0.5, 0.4),
       );
       await editor.addSpecificActionNode(
         "writer",
-        "GeoJsonWriter",
+        "GeoJSON Writer",
         await editor.canvasPoint(0.75, 0.4),
       );
       await expect(editor.nodes).toHaveCount(3);
 
-      const readerNode = editor.nodeByName("CsvReader");
-      const managerNode = editor.nodeByName("AttributeManager");
-      const writerNode = editor.nodeByName("GeoJsonWriter");
+      const readerNode = editor.nodeByName("CSV Reader");
+      const managerNode = editor.nodeByName("Attribute Manager");
+      const writerNode = editor.nodeByName("GeoJSON Writer");
 
       await editor.connectNodes(readerNode, managerNode);
       await editor.connectNodes(managerNode, writerNode);
@@ -95,11 +95,11 @@ test.describe.serial(
       await editor.openNodeParamsForm(managerNode);
       await editor.addParamArrayItem();
       await editor.setParamText("root_operations_0_attribute", "dailyRiders");
-      await editor.setParamSelect("Operation to perform", "create");
+      await editor.setParamSelect("Method", "Create");
       await editor.setParamFlowExpr("Value", 'int(attributes["daily_riders"])');
       await editor.submitParams();
       await editor.openNodeParamsForm(writerNode);
-      await editor.setParamCodeString("output", "stations.geojson");
+      await editor.setParamCodeString("Output File", "stations.geojson");
       await editor.submitParams();
     });
 


### PR DESCRIPTION
## Overview

The scheduled **Reearth Flow - E2E UI Tests** workflow has been failing nightly (8 failed tests per run). The suite had drifted behind three engine/UI refactors:

## What's changed

- **Fixtures** (`sample-workflow.json`, `workflows/*.yml`): renamed actions; `fromPort`/`toPort`/`outputPort` `default` → `features`.
- **Specs** (5 UI-built specs): renamed actions in `addSpecificActionNode`/`nodeByName`, updated form labels and the Method select option (`create` → `Create`), port args `default` → `features`.
- **`pages/editorPage.ts`**:
  - `connectFromPort` default target port → `features`
  - `setParamCheckbox` clicks the Base UI `span[role=checkbox]` adjacent to the hidden input
  - `fillFlowExprDialog` scopes to the visible textarea

All parameter keys/labels were verified against `engine/schema/actions.json`.

## Verification

Full suite run locally against the dev environment (same entrypoint as the scheduled workflow, `npm test`):

```
48 passed, 2 skipped, 0 failed (6.5m)
```

including real engine jobs that now produce their expected artifacts (`stations.geojson`, `park-areas.geojson`, cafe GeoJSON/CSV exports, school-parks output).