### PR TITLE
feat(engine): support Hole Counter and Hole Extractor in new-geometry

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.97"
+version = "0.2.98"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "Inflector",
  "approx",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4959,7 +4959,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5008,7 +5008,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5019,7 +5019,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "bytes",
  "clap",
@@ -5059,7 +5059,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5102,7 +5102,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "approx",
  "bvh",
@@ -5179,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5214,7 +5214,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5223,7 +5223,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5252,7 +5252,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5288,7 +5288,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "bytes",
  "futures",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "bytes",
  "futures",
@@ -5355,7 +5355,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5369,7 +5369,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5403,7 +5403,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "ahash",
  "bytes",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.468"
+version = "0.0.469"
 dependencies = [
  "async-trait",
  "axum",
@@ -8205,7 +8205,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.287"
+version = "0.1.288"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.468"
+version = "0.0.469"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/action-processor/src/geometry/hole_counter.rs
+++ b/engine/runtime/action-processor/src/geometry/hole_counter.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
+#[cfg(not(feature = "new-geometry"))]
 use reearth_flow_geometry::algorithm::hole::HoleCounter as HoleCounterAlgorithm;
+#[cfg(feature = "new-geometry")]
+use reearth_flow_geometry::ops::CountHoles;
 use reearth_flow_runtime::{
     errors::BoxedError,
     event::EventHub,
@@ -8,7 +11,9 @@ use reearth_flow_runtime::{
     forwarder::ProcessorChannelForwarder,
     node::{Port, Processor, ProcessorFactory, FEATURES_PORT},
 };
-use reearth_flow_types::{Attribute, AttributeValue, GeometryValue};
+#[cfg(not(feature = "new-geometry"))]
+use reearth_flow_types::GeometryValue;
+use reearth_flow_types::{Attribute, AttributeValue};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -132,7 +137,26 @@ impl Processor for HoleCounter {
         Ok(())
     }
 
-    #[cfg(not(feature = "new-geometry"))]
+    /// Attach the number of interior rings the geometry's faces carry to the
+    /// feature. Counting is total: a geometry that cannot hold a hole — and an
+    /// absent one — yields zero rather than being rejected, so every feature
+    /// leaves with the attribute set.
+    #[cfg(feature = "new-geometry")]
+    fn process(
+        &mut self,
+        ctx: ExecutorContext,
+        fw: &ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        let count = ctx.feature.geometry.count_holes();
+        let mut feature = ctx.feature.clone();
+        feature.attributes_mut().insert(
+            self.output_attribute.clone(),
+            AttributeValue::Number(count.into()),
+        );
+        fw.send(ctx.new_with_feature_and_port(feature, FEATURES_PORT.clone()));
+        Ok(())
+    }
+
     fn finish(
         &mut self,
         _ctx: NodeContext,
@@ -143,5 +167,133 @@ impl Processor for HoleCounter {
 
     fn name(&self) -> &str {
         "Hole Counter"
+    }
+}
+
+#[cfg(all(test, feature = "new-geometry"))]
+mod tests {
+    use super::*;
+    use crate::tests::utils::create_default_execute_context;
+    use pretty_assertions::assert_eq;
+    use reearth_flow_geometry::coordinate::CoordinateFrame;
+    use reearth_flow_geometry::point::Point3D;
+    use reearth_flow_geometry::polygon::Polygon3D;
+    use reearth_flow_geometry::{Euclidean3DGeometry, Geometry};
+    use reearth_flow_runtime::forwarder::NoopChannelForwarder;
+    use reearth_flow_types::Feature;
+
+    const SQUARE: [[f64; 3]; 5] = [
+        [0.0, 0.0, 0.0],
+        [4.0, 0.0, 0.0],
+        [4.0, 4.0, 0.0],
+        [0.0, 4.0, 0.0],
+        [0.0, 0.0, 0.0],
+    ];
+
+    /// A square face carrying `n` holes.
+    fn face_with_holes(n: usize) -> Geometry {
+        let holes: Vec<_> = (0..n)
+            .map(|i| {
+                let x = 1.0 + i as f64 * 1.5;
+                vec![
+                    [x, 1.0, 0.0],
+                    [x + 1.0, 1.0, 0.0],
+                    [x + 1.0, 2.0, 0.0],
+                    [x, 2.0, 0.0],
+                    [x, 1.0, 0.0],
+                ]
+            })
+            .collect();
+        Geometry::Euclidean3D(Euclidean3DGeometry::Polygon(Box::new(
+            Polygon3D::from_rings(CoordinateFrame::Euclidean, SQUARE, holes),
+        )))
+    }
+
+    /// Run the processor over `feature`, returning the single feature it forwards.
+    fn count(feature: Feature) -> Feature {
+        let fw = ProcessorChannelForwarder::Noop(NoopChannelForwarder::default());
+        let ctx = create_default_execute_context(&feature);
+        HoleCounter {
+            output_attribute: Attribute::new("holeCount"),
+        }
+        .process(ctx, &fw)
+        .unwrap();
+
+        let ProcessorChannelForwarder::Noop(noop) = fw else {
+            unreachable!("the forwarder is the one built above");
+        };
+        let ports = noop.send_ports.lock().unwrap();
+        assert_eq!(ports.len(), 1);
+        assert_eq!(ports[0], *FEATURES_PORT);
+        let features = noop.send_features.lock().unwrap();
+        assert_eq!(features.len(), 1);
+        features[0].clone()
+    }
+
+    fn hole_count(feature: &Feature) -> Option<&AttributeValue> {
+        feature.attributes.get(&Attribute::new("holeCount"))
+    }
+
+    #[test]
+    fn a_face_with_holes_reports_their_number() {
+        let feature = count(Feature::from(face_with_holes(2)));
+        assert_eq!(
+            hole_count(&feature),
+            Some(&AttributeValue::Number(2.into()))
+        );
+    }
+
+    #[test]
+    fn a_face_without_holes_reports_zero() {
+        let feature = count(Feature::from(face_with_holes(0)));
+        assert_eq!(
+            hole_count(&feature),
+            Some(&AttributeValue::Number(0.into()))
+        );
+    }
+
+    #[test]
+    fn a_geometry_that_cannot_carry_a_hole_reports_zero() {
+        let point = Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
+            CoordinateFrame::Euclidean,
+            [1.0, 2.0, 3.0],
+        )));
+        let feature = count(Feature::from(point));
+        assert_eq!(
+            hole_count(&feature),
+            Some(&AttributeValue::Number(0.into()))
+        );
+    }
+
+    /// Unlike the legacy processor, which passes a feature with no geometry
+    /// through untouched, the attribute is always set — matching FME, where every
+    /// other kind of geometry receives a hole count of zero.
+    #[test]
+    fn a_feature_without_geometry_reports_zero() {
+        let feature = count(Feature::from(Geometry::None));
+        assert_eq!(
+            hole_count(&feature),
+            Some(&AttributeValue::Number(0.into()))
+        );
+    }
+
+    #[test]
+    fn existing_attributes_and_the_feature_id_are_preserved() {
+        let mut input = Feature::from(face_with_holes(1));
+        input
+            .attributes_mut()
+            .insert(Attribute::new("gmlId"), AttributeValue::String("x".into()));
+        let id = input.id;
+
+        let feature = count(input);
+        assert_eq!(feature.id, id);
+        assert_eq!(
+            feature.attributes.get(&Attribute::new("gmlId")),
+            Some(&AttributeValue::String("x".into()))
+        );
+        assert_eq!(
+            hole_count(&feature),
+            Some(&AttributeValue::Number(1.into()))
+        );
     }
 }

--- a/engine/runtime/action-processor/src/geometry/hole_counter.rs
+++ b/engine/runtime/action-processor/src/geometry/hole_counter.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 #[cfg(not(feature = "new-geometry"))]
-use reearth_flow_geometry::algorithm::hole::HoleCounter as HoleCounterAlgorithm;
+use reearth_flow_geometry::algorithm::hole::HoleCounter as _;
 #[cfg(feature = "new-geometry")]
 use reearth_flow_geometry::ops::CountHoles;
 use reearth_flow_runtime::{

--- a/engine/runtime/action-processor/src/geometry/hole_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/hole_extractor.rs
@@ -1,6 +1,12 @@
-use std::{collections::HashMap, sync::Arc, vec};
+use std::{collections::HashMap, vec};
+
+#[cfg(not(feature = "new-geometry"))]
+use std::sync::Arc;
 
 use once_cell::sync::Lazy;
+#[cfg(feature = "new-geometry")]
+use reearth_flow_geometry::ops::{ExtractHoles, ExtractedPart};
+#[cfg(not(feature = "new-geometry"))]
 use reearth_flow_geometry::types::{
     geometry::{Geometry2D, Geometry3D},
     polygon::{Polygon2D, Polygon3D},
@@ -12,6 +18,7 @@ use reearth_flow_runtime::{
     forwarder::ProcessorChannelForwarder,
     node::{Port, Processor, ProcessorFactory, FEATURES_PORT, REJECTED_PORT},
 };
+#[cfg(not(feature = "new-geometry"))]
 use reearth_flow_types::{Feature, GeometryValue};
 use serde_json::Value;
 
@@ -64,6 +71,49 @@ impl ProcessorFactory for HoleExtractorFactory {
 pub struct HoleExtractor;
 
 impl Processor for HoleExtractor {
+    /// Take every face of the geometry apart, sending its outer boundary (holes
+    /// removed) to `outershell` and each hole, as an area of its own, to `hole`.
+    /// A face without holes still leaves via `outershell`.
+    ///
+    /// Geometry that bounds no area has nothing to take apart and leaves via
+    /// `rejected`, as does a feature with no geometry. A multi-part geometry is
+    /// deaggregated, so a member that bounds no area is rejected on its own
+    /// rather than discarding the areas beside it.
+    #[cfg(feature = "new-geometry")]
+    fn process(
+        &mut self,
+        ctx: ExecutorContext,
+        fw: &ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        let context = ctx.as_context();
+        // Parts stream out as they are produced, so a large surface is never
+        // decomposed into memory all at once.
+        let result = ctx.feature.geometry.extract_holes(&mut |geometry, part| {
+            let port = match part {
+                ExtractedPart::Outershell => OUTERSHELL_PORT.clone(),
+                ExtractedPart::Hole => HOLE_PORT.clone(),
+                ExtractedPart::Rejected => REJECTED_PORT.clone(),
+            };
+            let mut feature = ctx.feature.clone();
+            // One input yields many features, so each needs an id of its own.
+            feature.refresh_id();
+            feature.set_geometry(geometry);
+            fw.send(ExecutorContext::new_with_context_feature_and_port(
+                &context, feature, port,
+            ));
+        });
+        if let Err(e) = result {
+            // Rejecting geometry that bounds no area is this port's normal
+            // business, so it is not worth a warning per feature.
+            ctx.event_hub.debug_log(
+                Some(ctx.error_span()),
+                format!("hole extraction rejected: {e}"),
+            );
+            fw.send(ctx.new_with_feature_and_port(ctx.feature.clone(), REJECTED_PORT.clone()));
+        }
+        Ok(())
+    }
+
     #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
@@ -117,7 +167,6 @@ impl Processor for HoleExtractor {
         Ok(())
     }
 
-    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,
@@ -128,6 +177,155 @@ impl Processor for HoleExtractor {
 
     fn name(&self) -> &str {
         "Hole Extractor"
+    }
+}
+
+#[cfg(all(test, feature = "new-geometry"))]
+mod tests {
+    use super::*;
+    use crate::tests::utils::create_default_execute_context;
+    use pretty_assertions::assert_eq;
+    use reearth_flow_geometry::collection::Collection3D;
+    use reearth_flow_geometry::coordinate::CoordinateFrame;
+    use reearth_flow_geometry::point::Point3D;
+    use reearth_flow_geometry::polygon::Polygon3D;
+    use reearth_flow_geometry::{Euclidean3DGeometry, Geometry};
+    use reearth_flow_runtime::forwarder::NoopChannelForwarder;
+    use reearth_flow_types::{Attribute, AttributeValue, Feature};
+
+    /// A closed 4x4 square, as an exterior ring.
+    const SQUARE: [[f64; 3]; 5] = [
+        [0.0, 0.0, 0.0],
+        [4.0, 0.0, 0.0],
+        [4.0, 4.0, 0.0],
+        [0.0, 4.0, 0.0],
+        [0.0, 0.0, 0.0],
+    ];
+
+    /// A closed square hole ring of side 1, with its lower-left corner at `(x, y)`.
+    fn hole_ring(x: f64, y: f64) -> Vec<[f64; 3]> {
+        vec![
+            [x, y, 0.0],
+            [x, y + 1.0, 0.0],
+            [x + 1.0, y + 1.0, 0.0],
+            [x + 1.0, y, 0.0],
+            [x, y, 0.0],
+        ]
+    }
+
+    fn face_with_holes(n: usize) -> Geometry {
+        let holes: Vec<_> = (0..n)
+            .map(|i| hole_ring(1.0 + i as f64 * 1.5, 1.0))
+            .collect();
+        Geometry::Euclidean3D(Euclidean3DGeometry::Polygon(Box::new(
+            Polygon3D::from_rings(CoordinateFrame::Euclidean, SQUARE, holes),
+        )))
+    }
+
+    fn point() -> Euclidean3DGeometry {
+        Euclidean3DGeometry::Point(Point3D::new(CoordinateFrame::Euclidean, [1.0, 2.0, 3.0]))
+    }
+
+    /// A feature carrying `geometry` and one attribute to trace through.
+    fn feature(geometry: Geometry) -> Feature {
+        let mut feature = Feature::from(geometry);
+        feature.insert("surfaceId", AttributeValue::Number(7.into()));
+        feature
+    }
+
+    /// Run the processor over `feature`, returning what it sent, port by port.
+    fn extract(feature: &Feature) -> Vec<(Port, Feature)> {
+        let fw = ProcessorChannelForwarder::Noop(NoopChannelForwarder::default());
+        HoleExtractor
+            .process(create_default_execute_context(feature), &fw)
+            .unwrap();
+        let ProcessorChannelForwarder::Noop(noop) = fw else {
+            unreachable!("built as a noop forwarder");
+        };
+        let ports = noop.send_ports.lock().unwrap().clone();
+        let features = noop.send_features.lock().unwrap().clone();
+        ports.into_iter().zip(features).collect()
+    }
+
+    fn ports(sent: &[(Port, Feature)]) -> Vec<String> {
+        sent.iter().map(|(port, _)| port.to_string()).collect()
+    }
+
+    fn exterior(feature: &Feature) -> Vec<[f64; 3]> {
+        match &*feature.geometry {
+            Geometry::Euclidean3D(Euclidean3DGeometry::Polygon(p)) => p.exterior().to_vec(),
+            other => panic!("expected a 3D polygon, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_donut_leaves_as_an_outer_shell_and_one_feature_per_hole() {
+        let input = feature(face_with_holes(2));
+        let sent = extract(&input);
+
+        assert_eq!(ports(&sent), ["outershell", "hole", "hole"]);
+        assert_eq!(exterior(&sent[0].1), SQUARE);
+        assert_eq!(exterior(&sent[1].1), hole_ring(1.0, 1.0));
+        assert_eq!(exterior(&sent[2].1), hole_ring(2.5, 1.0));
+    }
+
+    #[test]
+    fn a_non_donut_area_leaves_untouched_via_the_outer_shell() {
+        let sent = extract(&feature(face_with_holes(0)));
+        assert_eq!(ports(&sent), ["outershell"]);
+        assert_eq!(exterior(&sent[0].1), SQUARE);
+    }
+
+    #[test]
+    fn every_part_keeps_the_attributes_and_takes_an_id_of_its_own() {
+        let input = feature(face_with_holes(1));
+        let sent = extract(&input);
+
+        for (_, part) in &sent {
+            assert_eq!(
+                part.attributes.get(&Attribute::new("surfaceId")),
+                Some(&AttributeValue::Number(7.into()))
+            );
+            assert_ne!(part.id, input.id, "a part needs an id of its own");
+        }
+        assert_ne!(sent[0].1.id, sent[1].1.id);
+    }
+
+    #[test]
+    fn geometry_that_bounds_no_area_is_rejected_whole() {
+        let input = feature(Geometry::Euclidean3D(point()));
+        let sent = extract(&input);
+        assert_eq!(ports(&sent), ["rejected"]);
+        // One in, one out: the feature is passed through as it arrived.
+        assert_eq!(sent[0].1.id, input.id);
+        assert_eq!(&*sent[0].1.geometry, &*input.geometry);
+    }
+
+    #[test]
+    fn a_feature_without_geometry_is_rejected() {
+        let sent = extract(&feature(Geometry::None));
+        assert_eq!(ports(&sent), ["rejected"]);
+    }
+
+    // Deaggregating must not let one point discard the area beside it.
+    #[test]
+    fn a_multi_part_geometry_rejects_only_the_parts_that_bound_no_area() {
+        let Geometry::Euclidean3D(area) = face_with_holes(1) else {
+            unreachable!("built as a 3D polygon");
+        };
+        let collection =
+            Geometry::Euclidean3D(Euclidean3DGeometry::Collection(Collection3D::new([
+                area,
+                point(),
+            ])));
+        let sent = extract(&feature(collection));
+
+        assert_eq!(ports(&sent), ["outershell", "hole", "rejected"]);
+        assert_eq!(
+            &*sent[2].1.geometry,
+            &Geometry::Euclidean3D(point()),
+            "the rejected part carries the member that was rejected"
+        );
     }
 }
 

--- a/engine/runtime/action-processor/src/geometry/hole_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/hole_extractor.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, vec};
+use std::collections::HashMap;
 
 #[cfg(not(feature = "new-geometry"))]
 use std::sync::Arc;

--- a/engine/runtime/geometry/src/collection.rs
+++ b/engine/runtime/geometry/src/collection.rs
@@ -317,6 +317,43 @@ impl crate::ops::CountHoles for Collection3D {
     }
 }
 
+// Deaggregate: a member that is not area geometry is handed back as `Rejected`
+// rather than failing the whole collection, so one curve among the surfaces does
+// not discard the surfaces.
+impl crate::ops::ExtractHoles for Collection2D {
+    fn extract_holes(
+        &self,
+        emit: &mut dyn FnMut(crate::Geometry, crate::ops::ExtractedPart),
+    ) -> Result<(), crate::ops::UnsupportedOperation> {
+        for member in self.members() {
+            if member.extract_holes(emit).is_err() {
+                emit(
+                    crate::Geometry::Euclidean2D(member.clone()),
+                    crate::ops::ExtractedPart::Rejected,
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+impl crate::ops::ExtractHoles for Collection3D {
+    fn extract_holes(
+        &self,
+        emit: &mut dyn FnMut(crate::Geometry, crate::ops::ExtractedPart),
+    ) -> Result<(), crate::ops::UnsupportedOperation> {
+        for member in self.members() {
+            if member.extract_holes(emit).is_err() {
+                emit(
+                    crate::Geometry::Euclidean3D(member.clone()),
+                    crate::ops::ExtractedPart::Rejected,
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
 impl crate::ops::Split for Collection2D {
     fn split(
         &mut self,

--- a/engine/runtime/geometry/src/collection.rs
+++ b/engine/runtime/geometry/src/collection.rs
@@ -299,6 +299,24 @@ impl crate::ops::RemoveAppearance for Collection3D {
     }
 }
 
+impl crate::ops::CountHoles for Collection2D {
+    fn count_holes(&self) -> usize {
+        self.members()
+            .iter()
+            .map(Euclidean2DGeometry::count_holes)
+            .sum()
+    }
+}
+
+impl crate::ops::CountHoles for Collection3D {
+    fn count_holes(&self) -> usize {
+        self.members()
+            .iter()
+            .map(Euclidean3DGeometry::count_holes)
+            .sum()
+    }
+}
+
 impl crate::ops::Split for Collection2D {
     fn split(
         &mut self,

--- a/engine/runtime/geometry/src/csg/mod.rs
+++ b/engine/runtime/geometry/src/csg/mod.rs
@@ -39,5 +39,9 @@ crate::unsupported!(Csg: Triangulate, Reproject, ConvertFrame, ForceTwoDimension
 // operands would describe a surface the tree does not yet have.
 crate::unsupported!(Csg: CountHoles);
 
+// The boolean tree is unevaluated, so its operands' faces are not this geometry's
+// boundary and taking them apart would not describe it.
+crate::unsupported!(Csg: ExtractHoles);
+
 // A boolean tree is one logical solid, not a multi-part container.
 crate::unsupported!(Csg: Split);

--- a/engine/runtime/geometry/src/csg/mod.rs
+++ b/engine/runtime/geometry/src/csg/mod.rs
@@ -35,5 +35,9 @@ pub enum Csg {
 // Tessellation is defined only for `Polygon` / `PolygonMesh`.
 crate::unsupported!(Csg: Triangulate, Reproject, ConvertFrame, ForceTwoDimension);
 
+// An unevaluated boolean tree has no faces of its own; counting the rings of its
+// operands would describe a surface the tree does not yet have.
+crate::unsupported!(Csg: CountHoles);
+
 // A boolean tree is one logical solid, not a multi-part container.
 crate::unsupported!(Csg: Split);

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -53,8 +53,8 @@ use serde::{Deserialize, Serialize};
 
 use ops::triangulation::Cache;
 use ops::{
-    Aabb, BoundingBox, ConvertFrame, ForceTwoDimension, ForceTwoDimensionError, RemoveAppearance,
-    Reproject, ReprojectionCache, Translate, Triangulate, UnsupportedOperation,
+    Aabb, BoundingBox, ConvertFrame, CountHoles, ForceTwoDimension, ForceTwoDimensionError,
+    RemoveAppearance, Reproject, ReprojectionCache, Translate, Triangulate, UnsupportedOperation,
 };
 // `ValidationParams` / `ValidationType` / `ValidationReport` are named by the
 // `enum_dispatch`-generated `Validate` impls on the geometry enums, so they must
@@ -167,7 +167,8 @@ impl GeometryCollection {
         Translate,
         Split,
         ForceTwoDimension,
-        RemoveAppearance
+        RemoveAppearance,
+        CountHoles
     )
 )]
 #[cfg_attr(
@@ -181,7 +182,8 @@ impl GeometryCollection {
         Translate,
         Split,
         ForceTwoDimension,
-        RemoveAppearance
+        RemoveAppearance,
+        CountHoles
     )
 )]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -215,7 +217,8 @@ pub enum Euclidean2DGeometry {
         Translate,
         Split,
         ForceTwoDimension,
-        RemoveAppearance
+        RemoveAppearance,
+        CountHoles
     )
 )]
 #[cfg_attr(
@@ -229,7 +232,8 @@ pub enum Euclidean2DGeometry {
         Translate,
         Split,
         ForceTwoDimension,
-        RemoveAppearance
+        RemoveAppearance,
+        CountHoles
     )
 )]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -450,6 +454,24 @@ impl RemoveAppearance for GeometryCollection {
         for member in self.members_mut() {
             member.remove_appearance();
         }
+    }
+}
+
+impl CountHoles for Geometry {
+    fn count_holes(&self) -> usize {
+        match self {
+            // An absent geometry has no faces, so no holes.
+            Geometry::None => 0,
+            Geometry::Euclidean2D(g) => g.count_holes(),
+            Geometry::Euclidean3D(g) => g.count_holes(),
+            Geometry::GeometryCollection(c) => c.count_holes(),
+        }
+    }
+}
+
+impl CountHoles for GeometryCollection {
+    fn count_holes(&self) -> usize {
+        self.members.iter().map(Geometry::count_holes).sum()
     }
 }
 
@@ -1206,5 +1228,203 @@ mod remove_appearance_tests {
         let mut none = Geometry::None;
         none.remove_appearance();
         assert_eq!(none, Geometry::None);
+    }
+}
+
+#[cfg(test)]
+mod count_holes_tests {
+    use super::*;
+    use coordinate::CoordinateFrame;
+    use line_string::LineString3D;
+    use point::Point3D;
+    use point_cloud::PointCloud;
+    use polygon::{Polygon2D, Polygon3D};
+    use polygon_mesh::{PolygonMesh2D, PolygonMesh3D, PolygonMesh3DData};
+    use solid::{Shell, Solid};
+    use triangular_mesh::TriangularMesh3D;
+
+    /// A unit square, as an exterior ring.
+    const SQUARE: [[f64; 3]; 5] = [
+        [0.0, 0.0, 0.0],
+        [4.0, 0.0, 0.0],
+        [4.0, 4.0, 0.0],
+        [0.0, 4.0, 0.0],
+        [0.0, 0.0, 0.0],
+    ];
+
+    /// A closed square hole ring of side 1, with its lower-left corner at `(x, y)`.
+    fn hole(x: f64, y: f64) -> Vec<[f64; 3]> {
+        vec![
+            [x, y, 0.0],
+            [x + 1.0, y, 0.0],
+            [x + 1.0, y + 1.0, 0.0],
+            [x, y + 1.0, 0.0],
+            [x, y, 0.0],
+        ]
+    }
+
+    /// A square face carrying `n` holes.
+    fn face_with_holes(n: usize) -> Polygon3D {
+        let holes: Vec<_> = (0..n).map(|i| hole(1.0 + i as f64 * 1.5, 1.0)).collect();
+        Polygon3D::from_rings(CoordinateFrame::Euclidean, SQUARE, holes)
+    }
+
+    /// A one-quad shell mesh whose single face carries `n` holes.
+    fn shell_with_holes(n: usize) -> PolygonMesh3DData {
+        PolygonMesh3DData::from_polygons([&face_with_holes(n)])
+    }
+
+    fn geometry_3d(g: Euclidean3DGeometry) -> Geometry {
+        Geometry::Euclidean3D(g)
+    }
+
+    #[test]
+    fn a_polygon_counts_its_interior_rings() {
+        assert_eq!(face_with_holes(0).count_holes(), 0);
+        assert_eq!(face_with_holes(2).count_holes(), 2);
+    }
+
+    #[test]
+    fn a_2d_polygon_counts_its_interior_rings() {
+        let square = [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]];
+        let hole = vec![[1.0, 1.0], [2.0, 1.0], [2.0, 2.0], [1.0, 2.0], [1.0, 1.0]];
+        let p = Polygon2D::from_rings_at_elevation(
+            CoordinateFrame::Euclidean,
+            square,
+            vec![hole],
+            10.0,
+        );
+        assert_eq!(p.count_holes(), 1);
+    }
+
+    #[test]
+    fn a_mesh_counts_the_holes_of_every_face() {
+        // Two faces, one with two holes and one with none: three rings in the
+        // shared `interior_offsets`, counted once each.
+        let mesh = PolygonMesh3D::from_polygons(
+            CoordinateFrame::Euclidean,
+            [&face_with_holes(2), &face_with_holes(0)],
+        )
+        .unwrap();
+        assert_eq!(mesh.num_faces(), 2);
+        assert_eq!(mesh.count_holes(), 2);
+    }
+
+    #[test]
+    fn a_mesh_without_holes_counts_zero() {
+        let mesh = PolygonMesh2D::from_parts(
+            CoordinateFrame::Euclidean,
+            vec![[0.0, 0.0], [3.0, 0.0], [3.0, 2.0]],
+            vec![vec![0u32, 1, 2]],
+        )
+        .unwrap();
+        assert_eq!(mesh.count_holes(), 0);
+    }
+
+    #[test]
+    fn a_2d_mesh_counts_the_holes_of_every_face() {
+        // One quad face (corners 0..4) with one hole ring (corners 4..8).
+        let mesh = PolygonMesh2D::from_raw_parts(
+            CoordinateFrame::Euclidean,
+            vec![
+                [0.0, 0.0],
+                [4.0, 0.0],
+                [4.0, 4.0],
+                [0.0, 4.0],
+                [1.0, 1.0],
+                [2.0, 1.0],
+                [2.0, 2.0],
+                [1.0, 2.0],
+            ],
+            vec![0, 1, 2, 3, 4, 5, 6, 7],
+            Vec::new(),
+            vec![4],
+        )
+        .unwrap();
+        assert_eq!(mesh.count_holes(), 1);
+    }
+
+    #[test]
+    fn a_solid_counts_the_holes_in_the_faces_of_every_shell() {
+        // Exterior face has two holes, the void shell's face has one: three in
+        // all. The void shell itself is not a hole and adds nothing.
+        let solid = Solid::new(
+            CoordinateFrame::Euclidean,
+            shell_with_holes(2),
+            vec![Shell::from(shell_with_holes(1))],
+        );
+        assert_eq!(solid.interiors().len(), 1);
+        assert_eq!(solid.count_holes(), 3);
+    }
+
+    #[test]
+    fn a_solid_bounded_by_triangles_counts_zero() {
+        let mesh = triangular_mesh::TriangularMesh3DData::from_parts(
+            vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            [0u32, 1, 2],
+        )
+        .unwrap();
+        let solid = Solid::from_exterior(CoordinateFrame::Euclidean, mesh);
+        assert_eq!(solid.count_holes(), 0);
+    }
+
+    #[test]
+    fn a_type_that_cannot_carry_a_hole_counts_zero() {
+        let tris = TriangularMesh3D::from_parts(
+            CoordinateFrame::Euclidean,
+            vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            [0u32, 1, 2],
+        )
+        .unwrap();
+        let cloud = PointCloud::from_positions(CoordinateFrame::Euclidean, [[0.0, 0.0, 0.0]]);
+        let csg = csg::Csg::union(
+            Solid::from_exterior(CoordinateFrame::Euclidean, shell_with_holes(2)),
+            Solid::from_exterior(CoordinateFrame::Euclidean, shell_with_holes(1)),
+        );
+
+        for g in [
+            Euclidean3DGeometry::Point(Point3D::new(CoordinateFrame::Euclidean, [1.0, 2.0, 3.0])),
+            Euclidean3DGeometry::LineString(LineString3D::from_coords(
+                CoordinateFrame::Euclidean,
+                [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
+            )),
+            Euclidean3DGeometry::TriangularMesh(Box::new(tris)),
+            Euclidean3DGeometry::PointCloud(Box::new(cloud)),
+            // An unevaluated tree has no faces of its own, so its operands'
+            // holes do not surface.
+            Euclidean3DGeometry::Csg(csg),
+        ] {
+            assert_eq!(geometry_3d(g).count_holes(), 0);
+        }
+    }
+
+    #[test]
+    fn an_absent_geometry_counts_zero() {
+        assert_eq!(Geometry::None.count_holes(), 0);
+    }
+
+    #[test]
+    fn a_collection_sums_its_members() {
+        let c = collection::Collection3D::new([
+            Euclidean3DGeometry::Polygon(Box::new(face_with_holes(2))),
+            Euclidean3DGeometry::Point(Point3D::new(CoordinateFrame::Euclidean, [0.0, 0.0, 0.0])),
+        ]);
+        assert_eq!(
+            geometry_3d(Euclidean3DGeometry::Collection(c)).count_holes(),
+            2
+        );
+    }
+
+    #[test]
+    fn counting_reaches_through_nested_collections() {
+        let inner = Geometry::GeometryCollection(GeometryCollection::new([geometry_3d(
+            Euclidean3DGeometry::Polygon(Box::new(face_with_holes(1))),
+        )]));
+        let outer = Geometry::GeometryCollection(GeometryCollection::new([
+            inner,
+            geometry_3d(Euclidean3DGeometry::Polygon(Box::new(face_with_holes(3)))),
+            Geometry::None,
+        ]));
+        assert_eq!(outer.count_holes(), 4);
     }
 }

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -1243,7 +1243,7 @@ mod count_holes_tests {
     use solid::{Shell, Solid};
     use triangular_mesh::TriangularMesh3D;
 
-    /// A unit square, as an exterior ring.
+    /// A 4x4 square, as an exterior ring.
     const SQUARE: [[f64; 3]; 5] = [
         [0.0, 0.0, 0.0],
         [4.0, 0.0, 0.0],
@@ -1299,8 +1299,9 @@ mod count_holes_tests {
 
     #[test]
     fn a_mesh_counts_the_holes_of_every_face() {
-        // Two faces, one with two holes and one with none: three rings in the
-        // shared `interior_offsets`, counted once each.
+        // Two faces, one with two holes and one with none: the shared
+        // `interior_offsets` holds one entry per interior ring, so the mesh-wide
+        // count needs no per-face walk and cannot count a ring twice.
         let mesh = PolygonMesh3D::from_polygons(
             CoordinateFrame::Euclidean,
             [&face_with_holes(2), &face_with_holes(0)],

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -53,8 +53,9 @@ use serde::{Deserialize, Serialize};
 
 use ops::triangulation::Cache;
 use ops::{
-    Aabb, BoundingBox, ConvertFrame, CountHoles, ForceTwoDimension, ForceTwoDimensionError,
-    RemoveAppearance, Reproject, ReprojectionCache, Translate, Triangulate, UnsupportedOperation,
+    Aabb, BoundingBox, ConvertFrame, CountHoles, ExtractHoles, ExtractedPart, ForceTwoDimension,
+    ForceTwoDimensionError, RemoveAppearance, Reproject, ReprojectionCache, Translate, Triangulate,
+    UnsupportedOperation,
 };
 // `ValidationParams` / `ValidationType` / `ValidationReport` are named by the
 // `enum_dispatch`-generated `Validate` impls on the geometry enums, so they must
@@ -168,7 +169,8 @@ impl GeometryCollection {
         Split,
         ForceTwoDimension,
         RemoveAppearance,
-        CountHoles
+        CountHoles,
+        ExtractHoles
     )
 )]
 #[cfg_attr(
@@ -183,7 +185,8 @@ impl GeometryCollection {
         Split,
         ForceTwoDimension,
         RemoveAppearance,
-        CountHoles
+        CountHoles,
+        ExtractHoles
     )
 )]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -218,7 +221,8 @@ pub enum Euclidean2DGeometry {
         Split,
         ForceTwoDimension,
         RemoveAppearance,
-        CountHoles
+        CountHoles,
+        ExtractHoles
     )
 )]
 #[cfg_attr(
@@ -233,7 +237,8 @@ pub enum Euclidean2DGeometry {
         Split,
         ForceTwoDimension,
         RemoveAppearance,
-        CountHoles
+        CountHoles,
+        ExtractHoles
     )
 )]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -472,6 +477,41 @@ impl CountHoles for Geometry {
 impl CountHoles for GeometryCollection {
     fn count_holes(&self) -> usize {
         self.members.iter().map(Geometry::count_holes).sum()
+    }
+}
+
+impl ExtractHoles for Geometry {
+    fn extract_holes(
+        &self,
+        emit: &mut dyn FnMut(Geometry, ExtractedPart),
+    ) -> Result<(), UnsupportedOperation> {
+        match self {
+            // An absent geometry has no faces to take apart.
+            Geometry::None => Err(UnsupportedOperation {
+                geometry: "Geometry::None",
+                operation: "extract_holes",
+            }),
+            Geometry::Euclidean2D(g) => g.extract_holes(emit),
+            Geometry::Euclidean3D(g) => g.extract_holes(emit),
+            Geometry::GeometryCollection(c) => c.extract_holes(emit),
+        }
+    }
+}
+
+impl ExtractHoles for GeometryCollection {
+    /// Deaggregate: each member is taken apart on its own, and one that is not
+    /// area geometry is emitted as [`ExtractedPart::Rejected`] rather than failing
+    /// the whole collection.
+    fn extract_holes(
+        &self,
+        emit: &mut dyn FnMut(Geometry, ExtractedPart),
+    ) -> Result<(), UnsupportedOperation> {
+        for member in &self.members {
+            if member.extract_holes(emit).is_err() {
+                emit(member.clone(), ExtractedPart::Rejected);
+            }
+        }
+        Ok(())
     }
 }
 
@@ -1228,204 +1268,5 @@ mod remove_appearance_tests {
         let mut none = Geometry::None;
         none.remove_appearance();
         assert_eq!(none, Geometry::None);
-    }
-}
-
-#[cfg(test)]
-mod count_holes_tests {
-    use super::*;
-    use coordinate::CoordinateFrame;
-    use line_string::LineString3D;
-    use point::Point3D;
-    use point_cloud::PointCloud;
-    use polygon::{Polygon2D, Polygon3D};
-    use polygon_mesh::{PolygonMesh2D, PolygonMesh3D, PolygonMesh3DData};
-    use solid::{Shell, Solid};
-    use triangular_mesh::TriangularMesh3D;
-
-    /// A 4x4 square, as an exterior ring.
-    const SQUARE: [[f64; 3]; 5] = [
-        [0.0, 0.0, 0.0],
-        [4.0, 0.0, 0.0],
-        [4.0, 4.0, 0.0],
-        [0.0, 4.0, 0.0],
-        [0.0, 0.0, 0.0],
-    ];
-
-    /// A closed square hole ring of side 1, with its lower-left corner at `(x, y)`.
-    fn hole(x: f64, y: f64) -> Vec<[f64; 3]> {
-        vec![
-            [x, y, 0.0],
-            [x + 1.0, y, 0.0],
-            [x + 1.0, y + 1.0, 0.0],
-            [x, y + 1.0, 0.0],
-            [x, y, 0.0],
-        ]
-    }
-
-    /// A square face carrying `n` holes.
-    fn face_with_holes(n: usize) -> Polygon3D {
-        let holes: Vec<_> = (0..n).map(|i| hole(1.0 + i as f64 * 1.5, 1.0)).collect();
-        Polygon3D::from_rings(CoordinateFrame::Euclidean, SQUARE, holes)
-    }
-
-    /// A one-quad shell mesh whose single face carries `n` holes.
-    fn shell_with_holes(n: usize) -> PolygonMesh3DData {
-        PolygonMesh3DData::from_polygons([&face_with_holes(n)])
-    }
-
-    fn geometry_3d(g: Euclidean3DGeometry) -> Geometry {
-        Geometry::Euclidean3D(g)
-    }
-
-    #[test]
-    fn a_polygon_counts_its_interior_rings() {
-        assert_eq!(face_with_holes(0).count_holes(), 0);
-        assert_eq!(face_with_holes(2).count_holes(), 2);
-    }
-
-    #[test]
-    fn a_2d_polygon_counts_its_interior_rings() {
-        let square = [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]];
-        let hole = vec![[1.0, 1.0], [2.0, 1.0], [2.0, 2.0], [1.0, 2.0], [1.0, 1.0]];
-        let p = Polygon2D::from_rings_at_elevation(
-            CoordinateFrame::Euclidean,
-            square,
-            vec![hole],
-            10.0,
-        );
-        assert_eq!(p.count_holes(), 1);
-    }
-
-    #[test]
-    fn a_mesh_counts_the_holes_of_every_face() {
-        // Two faces, one with two holes and one with none: the shared
-        // `interior_offsets` holds one entry per interior ring, so the mesh-wide
-        // count needs no per-face walk and cannot count a ring twice.
-        let mesh = PolygonMesh3D::from_polygons(
-            CoordinateFrame::Euclidean,
-            [&face_with_holes(2), &face_with_holes(0)],
-        )
-        .unwrap();
-        assert_eq!(mesh.num_faces(), 2);
-        assert_eq!(mesh.count_holes(), 2);
-    }
-
-    #[test]
-    fn a_mesh_without_holes_counts_zero() {
-        let mesh = PolygonMesh2D::from_parts(
-            CoordinateFrame::Euclidean,
-            vec![[0.0, 0.0], [3.0, 0.0], [3.0, 2.0]],
-            vec![vec![0u32, 1, 2]],
-        )
-        .unwrap();
-        assert_eq!(mesh.count_holes(), 0);
-    }
-
-    #[test]
-    fn a_2d_mesh_counts_the_holes_of_every_face() {
-        // One quad face (corners 0..4) with one hole ring (corners 4..8).
-        let mesh = PolygonMesh2D::from_raw_parts(
-            CoordinateFrame::Euclidean,
-            vec![
-                [0.0, 0.0],
-                [4.0, 0.0],
-                [4.0, 4.0],
-                [0.0, 4.0],
-                [1.0, 1.0],
-                [2.0, 1.0],
-                [2.0, 2.0],
-                [1.0, 2.0],
-            ],
-            vec![0, 1, 2, 3, 4, 5, 6, 7],
-            Vec::new(),
-            vec![4],
-        )
-        .unwrap();
-        assert_eq!(mesh.count_holes(), 1);
-    }
-
-    #[test]
-    fn a_solid_counts_the_holes_in_the_faces_of_every_shell() {
-        // Exterior face has two holes, the void shell's face has one: three in
-        // all. The void shell itself is not a hole and adds nothing.
-        let solid = Solid::new(
-            CoordinateFrame::Euclidean,
-            shell_with_holes(2),
-            vec![Shell::from(shell_with_holes(1))],
-        );
-        assert_eq!(solid.interiors().len(), 1);
-        assert_eq!(solid.count_holes(), 3);
-    }
-
-    #[test]
-    fn a_solid_bounded_by_triangles_counts_zero() {
-        let mesh = triangular_mesh::TriangularMesh3DData::from_parts(
-            vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
-            [0u32, 1, 2],
-        )
-        .unwrap();
-        let solid = Solid::from_exterior(CoordinateFrame::Euclidean, mesh);
-        assert_eq!(solid.count_holes(), 0);
-    }
-
-    #[test]
-    fn a_type_that_cannot_carry_a_hole_counts_zero() {
-        let tris = TriangularMesh3D::from_parts(
-            CoordinateFrame::Euclidean,
-            vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
-            [0u32, 1, 2],
-        )
-        .unwrap();
-        let cloud = PointCloud::from_positions(CoordinateFrame::Euclidean, [[0.0, 0.0, 0.0]]);
-        let csg = csg::Csg::union(
-            Solid::from_exterior(CoordinateFrame::Euclidean, shell_with_holes(2)),
-            Solid::from_exterior(CoordinateFrame::Euclidean, shell_with_holes(1)),
-        );
-
-        for g in [
-            Euclidean3DGeometry::Point(Point3D::new(CoordinateFrame::Euclidean, [1.0, 2.0, 3.0])),
-            Euclidean3DGeometry::LineString(LineString3D::from_coords(
-                CoordinateFrame::Euclidean,
-                [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
-            )),
-            Euclidean3DGeometry::TriangularMesh(Box::new(tris)),
-            Euclidean3DGeometry::PointCloud(Box::new(cloud)),
-            // An unevaluated tree has no faces of its own, so its operands'
-            // holes do not surface.
-            Euclidean3DGeometry::Csg(csg),
-        ] {
-            assert_eq!(geometry_3d(g).count_holes(), 0);
-        }
-    }
-
-    #[test]
-    fn an_absent_geometry_counts_zero() {
-        assert_eq!(Geometry::None.count_holes(), 0);
-    }
-
-    #[test]
-    fn a_collection_sums_its_members() {
-        let c = collection::Collection3D::new([
-            Euclidean3DGeometry::Polygon(Box::new(face_with_holes(2))),
-            Euclidean3DGeometry::Point(Point3D::new(CoordinateFrame::Euclidean, [0.0, 0.0, 0.0])),
-        ]);
-        assert_eq!(
-            geometry_3d(Euclidean3DGeometry::Collection(c)).count_holes(),
-            2
-        );
-    }
-
-    #[test]
-    fn counting_reaches_through_nested_collections() {
-        let inner = Geometry::GeometryCollection(GeometryCollection::new([geometry_3d(
-            Euclidean3DGeometry::Polygon(Box::new(face_with_holes(1))),
-        )]));
-        let outer = Geometry::GeometryCollection(GeometryCollection::new([
-            inner,
-            geometry_3d(Euclidean3DGeometry::Polygon(Box::new(face_with_holes(3)))),
-            Geometry::None,
-        ]));
-        assert_eq!(outer.count_holes(), 4);
     }
 }

--- a/engine/runtime/geometry/src/line_string/mod.rs
+++ b/engine/runtime/geometry/src/line_string/mod.rs
@@ -75,3 +75,6 @@ crate::unsupported!(LineString3D: Split);
 
 crate::unsupported!(LineString2D: RemoveAppearance);
 crate::unsupported!(LineString3D: RemoveAppearance);
+
+crate::unsupported!(LineString2D: CountHoles);
+crate::unsupported!(LineString3D: CountHoles);

--- a/engine/runtime/geometry/src/line_string/mod.rs
+++ b/engine/runtime/geometry/src/line_string/mod.rs
@@ -78,3 +78,7 @@ crate::unsupported!(LineString3D: RemoveAppearance);
 
 crate::unsupported!(LineString2D: CountHoles);
 crate::unsupported!(LineString3D: CountHoles);
+
+// A curve bounds no area, so there is nothing to take apart.
+crate::unsupported!(LineString2D: ExtractHoles);
+crate::unsupported!(LineString3D: ExtractHoles);

--- a/engine/runtime/geometry/src/ops/hole.rs
+++ b/engine/runtime/geometry/src/ops/hole.rs
@@ -1,0 +1,781 @@
+//! Interior-ring (hole) operations.
+//!
+//! A face's holes are its interior rings. [`CountHoles`] reports how many rings a
+//! geometry carries; [`ExtractHoles`] takes them apart, handing back each ring as
+//! an area of its own alongside the outer boundary it was cut from.
+//!
+//! Both share one notion of a hole, so a geometry counted as having `n` holes
+//! extracts to `n` [`ExtractedPart::Hole`] parts. In particular a
+//! [`Solid`](crate::solid::Solid)'s void shells are not holes in either — a void
+//! is a hollow volume rather than the boundary of a face — while the holes in the
+//! faces of those shells are.
+
+use crate::coordinate::CoordinateFrame;
+use crate::ops::UnsupportedOperation;
+use crate::polygon::{Polygon2D, Polygon3D};
+use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
+
+/// Count the interior (hole) rings a geometry's faces carry.
+///
+/// Total over the hierarchy: a type that cannot carry a hole inherits the `0`
+/// default, so counting never fails and a caller cannot tell "has no holes" from
+/// "cannot have holes". The unit counted is the ring, not the face: a face with
+/// two holes contributes two, matching the inner boundaries a donut reports.
+///
+/// A [`Solid`](crate::solid::Solid)'s void shells are not holes in this sense —
+/// they are hollow volumes, not boundaries of a face — so they are not counted;
+/// the holes in the faces of those shells are.
+#[enum_dispatch::enum_dispatch]
+pub trait CountHoles {
+    /// The number of interior rings across this geometry, recursing into
+    /// collections.
+    fn count_holes(&self) -> usize {
+        0
+    }
+}
+
+impl<T: CountHoles + ?Sized> CountHoles for Box<T> {
+    fn count_holes(&self) -> usize {
+        (**self).count_holes()
+    }
+}
+
+/// Which boundary of a face an extracted part came from.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExtractedPart {
+    /// A face's outer boundary, with its holes removed. A face that had none is
+    /// still reported here, unchanged.
+    Outershell,
+    /// One interior ring, as an area of its own.
+    Hole,
+    /// A container member that is not area geometry, handed back untouched
+    /// instead of failing the whole container. Never produced by a leaf.
+    Rejected,
+}
+
+/// Take every face of a geometry apart into its boundaries: the outer boundary
+/// with the holes removed, and each interior ring as an area of its own.
+///
+/// `emit` is invoked once per part, in `Outershell`-then-holes order per face,
+/// and faces stream rather than being collected. Every emitted area is a bare
+/// [`Polygon`](crate::polygon) in the source's frame and embedding:
+///
+/// * Rings are copied **verbatim** — neither re-wound nor closed. An interior
+///   ring keeps the winding it had inside its face, since whether that winding is
+///   correct is itself something a caller may want to inspect.
+/// * A 2D face's elevation carries onto every part it produces.
+/// * Appearance is dropped: a part has fewer corners than the face it came from,
+///   so the face's per-corner UV no longer applies.
+///
+/// A leaf that is not area geometry (a point, a curve, a point cloud, an
+/// unevaluated CSG tree) returns [`UnsupportedOperation`] via the default body
+/// and emits nothing. A container deaggregates instead: it recurses into its
+/// members, and a member that is not area geometry is emitted as
+/// [`ExtractedPart::Rejected`] rather than failing the container, so one curve
+/// among the surfaces does not discard the surfaces.
+#[enum_dispatch::enum_dispatch]
+pub trait ExtractHoles {
+    /// Emit this geometry's boundaries. The default body reports the type as
+    /// unsupported, emitting nothing.
+    fn extract_holes(
+        &self,
+        emit: &mut dyn FnMut(Geometry, ExtractedPart),
+    ) -> Result<(), UnsupportedOperation> {
+        let _ = emit;
+        Err(UnsupportedOperation {
+            geometry: core::any::type_name::<Self>(),
+            operation: "extract_holes",
+        })
+    }
+}
+
+// The boxed enum variants (`Box<Polygon2D>`, `Box<Solid>`, …) need the trait on
+// the `Box` itself: `enum_dispatch` forwards by UFCS, not auto-deref.
+impl<T: ExtractHoles + ?Sized> ExtractHoles for Box<T> {
+    fn extract_holes(
+        &self,
+        emit: &mut dyn FnMut(Geometry, ExtractedPart),
+    ) -> Result<(), UnsupportedOperation> {
+        (**self).extract_holes(emit)
+    }
+}
+
+/// One ring as a bare, hole-less 2D area at `elevation`.
+pub(crate) fn area_2d(
+    frame: &CoordinateFrame,
+    ring: impl IntoIterator<Item = [f64; 2]>,
+    elevation: Option<f64>,
+) -> Geometry {
+    let no_holes = Vec::<Vec<[f64; 2]>>::new();
+    let polygon = match elevation {
+        None => Polygon2D::from_rings(frame.clone(), ring, no_holes),
+        Some(elevation) => {
+            Polygon2D::from_rings_at_elevation(frame.clone(), ring, no_holes, elevation)
+        }
+    };
+    Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(Box::new(polygon)))
+}
+
+/// One ring as a bare, hole-less 3D area.
+pub(crate) fn area_3d(
+    frame: &CoordinateFrame,
+    ring: impl IntoIterator<Item = [f64; 3]>,
+) -> Geometry {
+    let polygon = Polygon3D::from_rings(frame.clone(), ring, Vec::<Vec<[f64; 3]>>::new());
+    Geometry::Euclidean3D(Euclidean3DGeometry::Polygon(Box::new(polygon)))
+}
+
+/// Emit one 2D face's boundaries, returning whether it yielded anything. A face
+/// with no exterior ring carries no area and yields nothing.
+pub(crate) fn emit_face_2d(
+    face: &Polygon2D,
+    emit: &mut dyn FnMut(Geometry, ExtractedPart),
+) -> bool {
+    let exterior = face.exterior();
+    if exterior.is_empty() {
+        return false;
+    }
+    let frame = face.frame();
+    let elevation = face.elevation();
+    emit(
+        area_2d(frame, exterior.iter().copied(), elevation),
+        ExtractedPart::Outershell,
+    );
+    for hole in face.interiors() {
+        emit(
+            area_2d(frame, hole.iter().copied(), elevation),
+            ExtractedPart::Hole,
+        );
+    }
+    true
+}
+
+/// Emit one 3D face's boundaries, returning whether it yielded anything.
+pub(crate) fn emit_face_3d(
+    face: &Polygon3D,
+    emit: &mut dyn FnMut(Geometry, ExtractedPart),
+) -> bool {
+    let exterior = face.exterior();
+    if exterior.is_empty() {
+        return false;
+    }
+    let frame = face.frame();
+    emit(
+        area_3d(frame, exterior.iter().copied()),
+        ExtractedPart::Outershell,
+    );
+    for hole in face.interiors() {
+        emit(area_3d(frame, hole.iter().copied()), ExtractedPart::Hole);
+    }
+    true
+}
+
+/// Emit one triangle-mesh shell's triangles as outer shells; a triangle carries
+/// no interior ring, so none is a hole. The ring is closed, as when splitting a
+/// triangle mesh into faces.
+pub(crate) fn emit_triangles_3d(
+    frame: &CoordinateFrame,
+    vertices: &[[f64; 3]],
+    triangles: impl Iterator<Item = [u32; 3]>,
+    emit: &mut dyn FnMut(Geometry, ExtractedPart),
+) {
+    for [i, j, k] in triangles {
+        let ring = [
+            vertices[i as usize],
+            vertices[j as usize],
+            vertices[k as usize],
+            vertices[i as usize],
+        ];
+        emit(area_3d(frame, ring), ExtractedPart::Outershell);
+    }
+}
+
+/// Fixtures shared by the two operations, so counting and extraction see the
+/// same geometry and cannot drift apart in what they call a hole.
+#[cfg(test)]
+mod fixtures {
+    use super::*;
+    use crate::csg::Csg;
+    use crate::line_string::LineString3D;
+    use crate::point::Point3D;
+    use crate::point_cloud::PointCloud;
+    use crate::polygon_mesh::PolygonMesh3DData;
+    use crate::solid::Solid;
+    use crate::triangular_mesh::TriangularMesh3DData;
+
+    /// A closed 4x4 square, as an exterior ring.
+    pub(super) const SQUARE: [[f64; 3]; 5] = [
+        [0.0, 0.0, 0.0],
+        [4.0, 0.0, 0.0],
+        [4.0, 4.0, 0.0],
+        [0.0, 4.0, 0.0],
+        [0.0, 0.0, 0.0],
+    ];
+
+    /// [`SQUARE`] without its z, for the 2D faces.
+    pub(super) const SQUARE_2D: [[f64; 2]; 5] =
+        [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]];
+
+    /// A closed square hole ring of side 1, with its lower-left corner at `(x, y)`.
+    /// Wound the opposite way from [`SQUARE`], as a hole should be.
+    pub(super) fn hole_ring(x: f64, y: f64) -> Vec<[f64; 3]> {
+        vec![
+            [x, y, 0.0],
+            [x, y + 1.0, 0.0],
+            [x + 1.0, y + 1.0, 0.0],
+            [x + 1.0, y, 0.0],
+            [x, y, 0.0],
+        ]
+    }
+
+    /// [`hole_ring`] without its z.
+    pub(super) fn hole_ring_2d(x: f64, y: f64) -> Vec<[f64; 2]> {
+        vec![
+            [x, y],
+            [x, y + 1.0],
+            [x + 1.0, y + 1.0],
+            [x + 1.0, y],
+            [x, y],
+        ]
+    }
+
+    /// A square face carrying `n` holes.
+    pub(super) fn face_with_holes(n: usize) -> Polygon3D {
+        let holes: Vec<_> = (0..n)
+            .map(|i| hole_ring(1.0 + i as f64 * 1.5, 1.0))
+            .collect();
+        Polygon3D::from_rings(CoordinateFrame::Euclidean, SQUARE, holes)
+    }
+
+    /// A square 2D face at `elevation`, carrying `n` holes.
+    pub(super) fn face_2d_with_holes(n: usize, elevation: f64) -> Polygon2D {
+        let holes: Vec<_> = (0..n)
+            .map(|i| hole_ring_2d(1.0 + i as f64 * 1.5, 1.0))
+            .collect();
+        Polygon2D::from_rings_at_elevation(CoordinateFrame::Euclidean, SQUARE_2D, holes, elevation)
+    }
+
+    /// A one-quad shell mesh whose single face carries `n` holes.
+    pub(super) fn shell_with_holes(n: usize) -> PolygonMesh3DData {
+        PolygonMesh3DData::from_polygons([&face_with_holes(n)])
+    }
+
+    /// A shell bounded by triangles: a unit square tiled by two of them. A
+    /// triangle carries no interior ring, so this shell can hold no hole.
+    pub(super) fn triangle_shell() -> TriangularMesh3DData {
+        TriangularMesh3DData::from_parts(
+            vec![
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [1.0, 1.0, 0.0],
+            ],
+            [0u32, 1, 2, 1, 3, 2],
+        )
+        .unwrap()
+    }
+
+    /// The 3D leaves that bound no area: a point, a curve, a point cloud, and an
+    /// unevaluated CSG tree. The tree's operands are holed solids, whose holes
+    /// must not surface through a tree that has no faces of its own.
+    pub(super) fn non_area_3d_leaves() -> Vec<Euclidean3DGeometry> {
+        let cloud = PointCloud::from_positions(CoordinateFrame::Euclidean, [[0.0, 0.0, 0.0]]);
+        let csg = Csg::union(
+            Solid::from_exterior(CoordinateFrame::Euclidean, shell_with_holes(2)),
+            Solid::from_exterior(CoordinateFrame::Euclidean, shell_with_holes(1)),
+        );
+        vec![
+            Euclidean3DGeometry::Point(Point3D::new(CoordinateFrame::Euclidean, [1.0, 2.0, 3.0])),
+            Euclidean3DGeometry::LineString(LineString3D::from_coords(
+                CoordinateFrame::Euclidean,
+                [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
+            )),
+            Euclidean3DGeometry::PointCloud(Box::new(cloud)),
+            Euclidean3DGeometry::Csg(csg),
+        ]
+    }
+
+    /// A 3D leaf as a whole geometry.
+    pub(super) fn geometry_3d(g: Euclidean3DGeometry) -> Geometry {
+        Geometry::Euclidean3D(g)
+    }
+}
+
+#[cfg(test)]
+mod count_holes_tests {
+    use super::fixtures::*;
+    use super::*;
+    use crate::collection::Collection3D;
+    use crate::point::Point3D;
+    use crate::polygon_mesh::{PolygonMesh2D, PolygonMesh3D};
+    use crate::solid::{Shell, Solid};
+    use crate::triangular_mesh::TriangularMesh3D;
+    use crate::GeometryCollection;
+
+    #[test]
+    fn a_polygon_counts_its_interior_rings() {
+        assert_eq!(face_with_holes(0).count_holes(), 0);
+        assert_eq!(face_with_holes(2).count_holes(), 2);
+    }
+
+    #[test]
+    fn a_2d_polygon_counts_its_interior_rings() {
+        assert_eq!(face_2d_with_holes(1, 10.0).count_holes(), 1);
+    }
+
+    #[test]
+    fn a_mesh_counts_the_holes_of_every_face() {
+        // Two faces, one with two holes and one with none: the shared
+        // `interior_offsets` holds one entry per interior ring, so the mesh-wide
+        // count needs no per-face walk and cannot count a ring twice.
+        let mesh = PolygonMesh3D::from_polygons(
+            CoordinateFrame::Euclidean,
+            [&face_with_holes(2), &face_with_holes(0)],
+        )
+        .unwrap();
+        assert_eq!(mesh.num_faces(), 2);
+        assert_eq!(mesh.count_holes(), 2);
+    }
+
+    #[test]
+    fn a_mesh_without_holes_counts_zero() {
+        let mesh = PolygonMesh2D::from_parts(
+            CoordinateFrame::Euclidean,
+            vec![[0.0, 0.0], [3.0, 0.0], [3.0, 2.0]],
+            vec![vec![0u32, 1, 2]],
+        )
+        .unwrap();
+        assert_eq!(mesh.count_holes(), 0);
+    }
+
+    #[test]
+    fn a_2d_mesh_counts_the_holes_of_every_face() {
+        // One quad face (corners 0..4) with one hole ring (corners 4..8).
+        let mesh = PolygonMesh2D::from_raw_parts(
+            CoordinateFrame::Euclidean,
+            vec![
+                [0.0, 0.0],
+                [4.0, 0.0],
+                [4.0, 4.0],
+                [0.0, 4.0],
+                [1.0, 1.0],
+                [2.0, 1.0],
+                [2.0, 2.0],
+                [1.0, 2.0],
+            ],
+            vec![0, 1, 2, 3, 4, 5, 6, 7],
+            Vec::new(),
+            vec![4],
+        )
+        .unwrap();
+        assert_eq!(mesh.count_holes(), 1);
+    }
+
+    #[test]
+    fn a_solid_counts_the_holes_in_the_faces_of_every_shell() {
+        // Exterior face has two holes, the void shell's face has one: three in
+        // all. The void shell itself is not a hole and adds nothing.
+        let solid = Solid::new(
+            CoordinateFrame::Euclidean,
+            shell_with_holes(2),
+            vec![Shell::from(shell_with_holes(1))],
+        );
+        assert_eq!(solid.interiors().len(), 1);
+        assert_eq!(solid.count_holes(), 3);
+    }
+
+    #[test]
+    fn a_solid_bounded_by_triangles_counts_zero() {
+        let solid = Solid::from_exterior(CoordinateFrame::Euclidean, triangle_shell());
+        assert_eq!(solid.count_holes(), 0);
+    }
+
+    #[test]
+    fn a_type_that_cannot_carry_a_hole_counts_zero() {
+        // A triangle mesh does bound area, unlike the rest, but a triangle has no
+        // interior ring to count.
+        let tris = TriangularMesh3D::from_parts(
+            CoordinateFrame::Euclidean,
+            vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            [0u32, 1, 2],
+        )
+        .unwrap();
+        let mut cannot = non_area_3d_leaves();
+        cannot.push(Euclidean3DGeometry::TriangularMesh(Box::new(tris)));
+
+        for g in cannot {
+            assert_eq!(geometry_3d(g).count_holes(), 0);
+        }
+    }
+
+    #[test]
+    fn an_absent_geometry_counts_zero() {
+        assert_eq!(Geometry::None.count_holes(), 0);
+    }
+
+    #[test]
+    fn a_collection_sums_its_members() {
+        let c = Collection3D::new([
+            Euclidean3DGeometry::Polygon(Box::new(face_with_holes(2))),
+            Euclidean3DGeometry::Point(Point3D::new(CoordinateFrame::Euclidean, [0.0, 0.0, 0.0])),
+        ]);
+        assert_eq!(
+            geometry_3d(Euclidean3DGeometry::Collection(c)).count_holes(),
+            2
+        );
+    }
+
+    #[test]
+    fn counting_reaches_through_nested_collections() {
+        let inner = Geometry::GeometryCollection(GeometryCollection::new([geometry_3d(
+            Euclidean3DGeometry::Polygon(Box::new(face_with_holes(1))),
+        )]));
+        let outer = Geometry::GeometryCollection(GeometryCollection::new([
+            inner,
+            geometry_3d(Euclidean3DGeometry::Polygon(Box::new(face_with_holes(3)))),
+            Geometry::None,
+        ]));
+        assert_eq!(outer.count_holes(), 4);
+    }
+}
+
+#[cfg(test)]
+mod extract_holes_tests {
+    use super::fixtures::*;
+    use super::*;
+    use crate::collection::Collection3D;
+    use crate::point::Point3D;
+    use crate::polygon_mesh::{PolygonMesh2D, PolygonMesh3D};
+    use crate::solid::{Shell, Solid};
+    use crate::test_support::{bare, theme};
+    use crate::triangular_mesh::{TriangularMesh2D, TriangularMesh3D};
+    use crate::GeometryCollection;
+
+    /// The parts a geometry extracts to, in emission order.
+    fn parts(
+        geometry: &impl ExtractHoles,
+    ) -> Result<Vec<(Geometry, ExtractedPart)>, UnsupportedOperation> {
+        let mut out = Vec::new();
+        geometry.extract_holes(&mut |geometry, part| out.push((geometry, part)))?;
+        Ok(out)
+    }
+
+    fn roles(parts: &[(Geometry, ExtractedPart)]) -> Vec<ExtractedPart> {
+        parts.iter().map(|(_, part)| *part).collect()
+    }
+
+    fn count(parts: &[(Geometry, ExtractedPart)], role: ExtractedPart) -> usize {
+        parts.iter().filter(|(_, part)| *part == role).count()
+    }
+
+    fn face_3d(geometry: &Geometry) -> &Polygon3D {
+        match geometry {
+            Geometry::Euclidean3D(Euclidean3DGeometry::Polygon(p)) => p,
+            other => panic!("expected a 3D polygon, got {other:?}"),
+        }
+    }
+
+    fn face_2d(geometry: &Geometry) -> &Polygon2D {
+        match geometry {
+            Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(p)) => p,
+            other => panic!("expected a 2D polygon, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_face_yields_its_outer_boundary_then_each_hole() {
+        let out = parts(&face_with_holes(2)).unwrap();
+        assert_eq!(
+            roles(&out),
+            [
+                ExtractedPart::Outershell,
+                ExtractedPart::Hole,
+                ExtractedPart::Hole
+            ]
+        );
+        // The outer shell keeps the exterior verbatim and carries no hole itself.
+        assert_eq!(face_3d(&out[0].0).exterior(), SQUARE);
+        assert_eq!(face_3d(&out[0].0).interiors().count(), 0);
+        // Each hole becomes an area of its own, also hole-less.
+        assert_eq!(face_3d(&out[1].0).exterior(), hole_ring(1.0, 1.0));
+        assert_eq!(face_3d(&out[1].0).interiors().count(), 0);
+        assert_eq!(face_3d(&out[2].0).exterior(), hole_ring(2.5, 1.0));
+    }
+
+    #[test]
+    fn a_face_without_holes_yields_only_its_outer_boundary() {
+        let out = parts(&face_with_holes(0)).unwrap();
+        assert_eq!(roles(&out), [ExtractedPart::Outershell]);
+        assert_eq!(face_3d(&out[0].0).exterior(), SQUARE);
+    }
+
+    // A hole's winding is what tells a validator whether the hole is oriented
+    // correctly, so extraction must not re-wind it to match an outer boundary.
+    #[test]
+    fn a_hole_keeps_the_winding_it_had_inside_its_face() {
+        let ring = hole_ring(1.0, 1.0);
+        let out = parts(&face_with_holes(1)).unwrap();
+        assert_eq!(face_3d(&out[1].0).exterior(), ring.as_slice());
+        // Not the reversed ring: the two differ, so the assertion above is real.
+        let mut reversed = ring;
+        reversed.reverse();
+        assert_ne!(face_3d(&out[1].0).exterior(), reversed.as_slice());
+    }
+
+    #[test]
+    fn a_2d_face_carries_its_elevation_onto_every_part() {
+        let out = parts(&face_2d_with_holes(1, 7.5)).unwrap();
+        assert_eq!(
+            roles(&out),
+            [ExtractedPart::Outershell, ExtractedPart::Hole]
+        );
+        for (geometry, _) in &out {
+            assert_eq!(face_2d(geometry).elevation(), Some(7.5));
+        }
+    }
+
+    // A part has fewer corners than the face it came from, so the face's
+    // per-corner UV no longer applies and the appearance cannot come along.
+    #[test]
+    fn parts_come_out_bare() {
+        let mut face = face_with_holes(1);
+        face.set_appearance(theme("rgb"), bare(), None).unwrap();
+        assert!(face.appearance().is_some());
+
+        for (geometry, _) in parts(&face).unwrap() {
+            assert!(face_3d(&geometry).appearance().is_none());
+        }
+    }
+
+    #[test]
+    fn a_face_with_no_exterior_ring_is_rejected() {
+        let empty = Polygon3D::from_rings(
+            CoordinateFrame::Euclidean,
+            Vec::<[f64; 3]>::new(),
+            Vec::<Vec<[f64; 3]>>::new(),
+        );
+        assert!(parts(&empty).is_err());
+    }
+
+    #[test]
+    fn a_mesh_deaggregates_into_its_faces() {
+        let mesh = PolygonMesh3D::from_polygons(
+            CoordinateFrame::Euclidean,
+            [&face_with_holes(2), &face_with_holes(0)],
+        )
+        .unwrap();
+        let out = parts(&mesh).unwrap();
+        // One outer shell per face, and the holes of the face that has them.
+        assert_eq!(count(&out, ExtractedPart::Outershell), 2);
+        assert_eq!(count(&out, ExtractedPart::Hole), 2);
+        assert_eq!(count(&out, ExtractedPart::Rejected), 0);
+    }
+
+    #[test]
+    fn a_2d_mesh_takes_apart_a_holed_face() {
+        // One quad face (corners 0..4) with one hole ring (corners 4..7).
+        let mesh = PolygonMesh2D::from_raw_parts(
+            CoordinateFrame::Euclidean,
+            vec![
+                [0.0, 0.0],
+                [4.0, 0.0],
+                [4.0, 4.0],
+                [0.0, 4.0],
+                [1.0, 1.0],
+                [1.0, 2.0],
+                [2.0, 2.0],
+            ],
+            vec![0, 1, 2, 3, 4, 5, 6],
+            Vec::new(),
+            vec![4],
+        )
+        .unwrap();
+        let out = parts(&mesh).unwrap();
+        assert_eq!(
+            roles(&out),
+            [ExtractedPart::Outershell, ExtractedPart::Hole]
+        );
+        assert_eq!(face_2d(&out[1].0).exterior().len(), 3);
+    }
+
+    #[test]
+    fn a_2d_mesh_carries_its_elevation() {
+        let mesh = PolygonMesh2D::from_parts_at_elevation(
+            CoordinateFrame::Euclidean,
+            vec![[0.0, 0.0], [2.0, 0.0], [2.0, 2.0]],
+            vec![vec![0u32, 1, 2]],
+            3.0,
+        )
+        .unwrap();
+        let out = parts(&mesh).unwrap();
+        assert_eq!(roles(&out), [ExtractedPart::Outershell]);
+        assert_eq!(face_2d(&out[0].0).elevation(), Some(3.0));
+    }
+
+    #[test]
+    fn an_empty_mesh_yields_nothing() {
+        let mesh =
+            PolygonMesh3D::from_parts(CoordinateFrame::Euclidean, vec![], Vec::<Vec<u32>>::new())
+                .unwrap();
+        assert!(parts(&mesh).unwrap().is_empty());
+    }
+
+    #[test]
+    fn a_solid_takes_apart_the_faces_of_every_shell() {
+        // Exterior face has two holes, the void shell's face has one.
+        let solid = Solid::new(
+            CoordinateFrame::Euclidean,
+            shell_with_holes(2),
+            vec![Shell::from(shell_with_holes(1))],
+        );
+        let out = parts(&solid).unwrap();
+        // One outer shell per boundary face — the void shell itself is a hollow
+        // volume, not a hole, so it is never emitted as one.
+        assert_eq!(count(&out, ExtractedPart::Outershell), 2);
+        assert_eq!(count(&out, ExtractedPart::Hole), 3);
+    }
+
+    #[test]
+    fn a_solid_bounded_by_triangles_yields_no_holes() {
+        let solid = Solid::from_exterior(CoordinateFrame::Euclidean, triangle_shell());
+        let out = parts(&solid).unwrap();
+        assert_eq!(count(&out, ExtractedPart::Outershell), 2);
+        assert_eq!(count(&out, ExtractedPart::Hole), 0);
+    }
+
+    #[test]
+    fn a_triangle_mesh_deaggregates_into_closed_triangles() {
+        let mesh = TriangularMesh3D::from_parts(
+            CoordinateFrame::Euclidean,
+            vec![
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [1.0, 1.0, 0.0],
+            ],
+            [0u32, 1, 2, 1, 3, 2],
+        )
+        .unwrap();
+        let out = parts(&mesh).unwrap();
+        assert_eq!(
+            roles(&out),
+            [ExtractedPart::Outershell, ExtractedPart::Outershell]
+        );
+        let first = face_3d(&out[0].0).exterior();
+        assert_eq!(
+            first,
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0]
+            ]
+        );
+    }
+
+    #[test]
+    fn a_2d_triangle_mesh_carries_its_elevation() {
+        let mesh = TriangularMesh2D::from_parts_at_elevation(
+            CoordinateFrame::Euclidean,
+            vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
+            [0u32, 1, 2],
+            2.5,
+        )
+        .unwrap();
+        let out = parts(&mesh).unwrap();
+        assert_eq!(roles(&out), [ExtractedPart::Outershell]);
+        assert_eq!(face_2d(&out[0].0).elevation(), Some(2.5));
+    }
+
+    #[test]
+    fn a_type_that_bounds_no_area_is_rejected() {
+        for g in non_area_3d_leaves() {
+            assert!(parts(&geometry_3d(g)).is_err());
+        }
+    }
+
+    #[test]
+    fn an_absent_geometry_is_rejected() {
+        assert!(parts(&Geometry::None).is_err());
+    }
+
+    // Deaggregating a container must not let one curve discard the surfaces
+    // beside it, so a member that bounds no area comes back as `Rejected`.
+    #[test]
+    fn a_collection_hands_back_its_non_area_members() {
+        let point = Point3D::new(CoordinateFrame::Euclidean, [0.0, 0.0, 0.0]);
+        let c = Collection3D::new([
+            Euclidean3DGeometry::Polygon(Box::new(face_with_holes(2))),
+            Euclidean3DGeometry::Point(point.clone()),
+        ]);
+        let out = parts(&geometry_3d(Euclidean3DGeometry::Collection(c))).unwrap();
+        assert_eq!(
+            roles(&out),
+            [
+                ExtractedPart::Outershell,
+                ExtractedPart::Hole,
+                ExtractedPart::Hole,
+                ExtractedPart::Rejected
+            ]
+        );
+        assert_eq!(
+            out[3].0,
+            geometry_3d(Euclidean3DGeometry::Point(point)),
+            "the rejected member comes back untouched"
+        );
+    }
+
+    #[test]
+    fn extraction_reaches_through_nested_collections() {
+        let inner = Geometry::GeometryCollection(GeometryCollection::new([geometry_3d(
+            Euclidean3DGeometry::Polygon(Box::new(face_with_holes(1))),
+        )]));
+        let outer = Geometry::GeometryCollection(GeometryCollection::new([
+            inner,
+            geometry_3d(Euclidean3DGeometry::Polygon(Box::new(face_with_holes(3)))),
+            Geometry::None,
+        ]));
+        let out = parts(&outer).unwrap();
+        assert_eq!(count(&out, ExtractedPart::Outershell), 2);
+        assert_eq!(count(&out, ExtractedPart::Hole), 4);
+        // The absent member bounds no area, so it comes back rejected.
+        assert_eq!(count(&out, ExtractedPart::Rejected), 1);
+    }
+
+    #[test]
+    fn an_empty_collection_yields_nothing() {
+        let c = Collection3D::new(Vec::new());
+        let out = parts(&geometry_3d(Euclidean3DGeometry::Collection(c))).unwrap();
+        assert!(out.is_empty());
+    }
+
+    // The two operations share one notion of a hole, so the workflows that filter
+    // on a hole count and then extract cannot disagree about what they will get.
+    #[test]
+    fn the_hole_count_matches_the_holes_extracted() {
+        let mesh = PolygonMesh3D::from_polygons(
+            CoordinateFrame::Euclidean,
+            [&face_with_holes(2), &face_with_holes(1)],
+        )
+        .unwrap();
+        let solid = Solid::new(
+            CoordinateFrame::Euclidean,
+            shell_with_holes(2),
+            vec![Shell::from(shell_with_holes(1))],
+        );
+        let collection = Geometry::GeometryCollection(GeometryCollection::new([
+            geometry_3d(Euclidean3DGeometry::Polygon(Box::new(face_with_holes(3)))),
+            geometry_3d(Euclidean3DGeometry::PolygonMesh(Box::new(mesh.clone()))),
+        ]));
+
+        for geometry in [
+            geometry_3d(Euclidean3DGeometry::Polygon(Box::new(face_with_holes(2)))),
+            geometry_3d(Euclidean3DGeometry::PolygonMesh(Box::new(mesh))),
+            geometry_3d(Euclidean3DGeometry::Solid(Box::new(solid))),
+            collection,
+        ] {
+            let extracted = count(&parts(&geometry).unwrap(), ExtractedPart::Hole);
+            assert_eq!(geometry.count_holes(), extracted);
+        }
+    }
+}

--- a/engine/runtime/geometry/src/ops/mod.rs
+++ b/engine/runtime/geometry/src/ops/mod.rs
@@ -8,10 +8,13 @@
 //! chains through to the concrete leaf. `GeometryCollection` and the per-frame
 //! `Collection`s recurse by hand over their children.
 
+pub mod hole;
 pub mod reproject;
 pub mod split;
 pub mod triangulation;
 
+pub(crate) use hole::{area_2d, emit_face_2d, emit_face_3d, emit_triangles_3d};
+pub use hole::{CountHoles, ExtractHoles, ExtractedPart};
 pub(crate) use reproject::{
     axis_order_sign, crs_demote_to_2d, crs_is_linear, lift_coords, TwoDimensionalCrs,
 };
@@ -265,31 +268,6 @@ pub trait RemoveAppearance {
 impl<T: RemoveAppearance + ?Sized> RemoveAppearance for Box<T> {
     fn remove_appearance(&mut self) {
         (**self).remove_appearance()
-    }
-}
-
-/// Count the interior (hole) rings a geometry's faces carry.
-///
-/// Total over the hierarchy: a type that cannot carry a hole inherits the `0`
-/// default, so counting never fails and a caller cannot tell "has no holes" from
-/// "cannot have holes". The unit counted is the ring, not the face: a face with
-/// two holes contributes two, matching the inner boundaries a donut reports.
-///
-/// A [`Solid`](crate::solid::Solid)'s void shells are not holes in this sense —
-/// they are hollow volumes, not boundaries of a face — so they are not counted;
-/// the holes in the faces of those shells are.
-#[enum_dispatch::enum_dispatch]
-pub trait CountHoles {
-    /// The number of interior rings across this geometry, recursing into
-    /// collections.
-    fn count_holes(&self) -> usize {
-        0
-    }
-}
-
-impl<T: CountHoles + ?Sized> CountHoles for Box<T> {
-    fn count_holes(&self) -> usize {
-        (**self).count_holes()
     }
 }
 

--- a/engine/runtime/geometry/src/ops/mod.rs
+++ b/engine/runtime/geometry/src/ops/mod.rs
@@ -268,6 +268,31 @@ impl<T: RemoveAppearance + ?Sized> RemoveAppearance for Box<T> {
     }
 }
 
+/// Count the interior (hole) rings a geometry's faces carry.
+///
+/// Total over the hierarchy: a type that cannot carry a hole inherits the `0`
+/// default, so counting never fails and a caller cannot tell "has no holes" from
+/// "cannot have holes". The unit counted is the ring, not the face: a face with
+/// two holes contributes two, matching the inner boundaries a donut reports.
+///
+/// A [`Solid`](crate::solid::Solid)'s void shells are not holes in this sense —
+/// they are hollow volumes, not boundaries of a face — so they are not counted;
+/// the holes in the faces of those shells are.
+#[enum_dispatch::enum_dispatch]
+pub trait CountHoles {
+    /// The number of interior rings across this geometry, recursing into
+    /// collections.
+    fn count_holes(&self) -> usize {
+        0
+    }
+}
+
+impl<T: CountHoles + ?Sized> CountHoles for Box<T> {
+    fn count_holes(&self) -> usize {
+        (**self).count_holes()
+    }
+}
+
 /// Why a geometry could not be re-represented in a pure 2D embedding.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ForceTwoDimensionError {

--- a/engine/runtime/geometry/src/point/mod.rs
+++ b/engine/runtime/geometry/src/point/mod.rs
@@ -63,3 +63,6 @@ crate::unsupported!(Point3D: Split);
 
 crate::unsupported!(Point2D: RemoveAppearance);
 crate::unsupported!(Point3D: RemoveAppearance);
+
+crate::unsupported!(Point2D: CountHoles);
+crate::unsupported!(Point3D: CountHoles);

--- a/engine/runtime/geometry/src/point/mod.rs
+++ b/engine/runtime/geometry/src/point/mod.rs
@@ -66,3 +66,7 @@ crate::unsupported!(Point3D: RemoveAppearance);
 
 crate::unsupported!(Point2D: CountHoles);
 crate::unsupported!(Point3D: CountHoles);
+
+// A point bounds no area, so there is nothing to take apart.
+crate::unsupported!(Point2D: ExtractHoles);
+crate::unsupported!(Point3D: ExtractHoles);

--- a/engine/runtime/geometry/src/point_cloud/mod.rs
+++ b/engine/runtime/geometry/src/point_cloud/mod.rs
@@ -156,5 +156,6 @@ crate::unsupported!(
     ConvertFrame,
     ForceTwoDimension,
     RemoveAppearance,
-    CountHoles
+    CountHoles,
+    ExtractHoles
 );

--- a/engine/runtime/geometry/src/point_cloud/mod.rs
+++ b/engine/runtime/geometry/src/point_cloud/mod.rs
@@ -155,5 +155,6 @@ crate::unsupported!(
     Reproject,
     ConvertFrame,
     ForceTwoDimension,
-    RemoveAppearance
+    RemoveAppearance,
+    CountHoles
 );

--- a/engine/runtime/geometry/src/polygon/ops.rs
+++ b/engine/runtime/geometry/src/polygon/ops.rs
@@ -356,7 +356,20 @@ impl Polygon2D {
     }
 }
 
-use crate::ops::RemoveAppearance;
+use crate::ops::{CountHoles, RemoveAppearance};
+
+// One offset per interior ring, so the count is the offsets' length.
+impl CountHoles for Polygon2D {
+    fn count_holes(&self) -> usize {
+        self.interior_offsets.len()
+    }
+}
+
+impl CountHoles for Polygon3D {
+    fn count_holes(&self) -> usize {
+        self.interior_offsets.len()
+    }
+}
 
 impl RemoveAppearance for Polygon2D {
     fn remove_appearance(&mut self) {

--- a/engine/runtime/geometry/src/polygon/ops.rs
+++ b/engine/runtime/geometry/src/polygon/ops.rs
@@ -356,7 +356,9 @@ impl Polygon2D {
     }
 }
 
-use crate::ops::{CountHoles, RemoveAppearance};
+use crate::ops::{
+    emit_face_2d, emit_face_3d, CountHoles, ExtractHoles, ExtractedPart, RemoveAppearance,
+};
 
 // One offset per interior ring, so the count is the offsets' length.
 impl CountHoles for Polygon2D {
@@ -368,6 +370,40 @@ impl CountHoles for Polygon2D {
 impl CountHoles for Polygon3D {
     fn count_holes(&self) -> usize {
         self.interior_offsets.len()
+    }
+}
+
+// A face with no exterior ring bounds no area, so it is not area geometry to
+// take apart — the one case where a polygon itself is rejected.
+impl ExtractHoles for Polygon2D {
+    fn extract_holes(
+        &self,
+        emit: &mut dyn FnMut(Geometry, ExtractedPart),
+    ) -> Result<(), UnsupportedOperation> {
+        if emit_face_2d(self, emit) {
+            Ok(())
+        } else {
+            Err(UnsupportedOperation {
+                geometry: "Polygon2D",
+                operation: "extract_holes",
+            })
+        }
+    }
+}
+
+impl ExtractHoles for Polygon3D {
+    fn extract_holes(
+        &self,
+        emit: &mut dyn FnMut(Geometry, ExtractedPart),
+    ) -> Result<(), UnsupportedOperation> {
+        if emit_face_3d(self, emit) {
+            Ok(())
+        } else {
+            Err(UnsupportedOperation {
+                geometry: "Polygon3D",
+                operation: "extract_holes",
+            })
+        }
     }
 }
 

--- a/engine/runtime/geometry/src/polygon_mesh/faces.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/faces.rs
@@ -117,12 +117,23 @@ impl PolygonMesh3D {
     /// Invoke `f` once per face with that face rebuilt as a standalone bare
     /// [`Polygon3D`] in the mesh's frame. Faces are streamed rather than
     /// collected. Appearance is not carried onto them.
-    pub(crate) fn for_each_face_polygon(&self, mut f: impl FnMut(Polygon3D)) {
-        let data = self.data();
-        let (face_indices, face_offsets, interior_offsets) = data.csr_buffers();
-        let frame = self.frame();
+    pub(crate) fn for_each_face_polygon(&self, f: impl FnMut(Polygon3D)) {
+        self.data().for_each_face_polygon(self.frame(), f);
+    }
+}
+
+impl super::PolygonMesh3DData {
+    /// As [`PolygonMesh3D::for_each_face_polygon`], but with the frame supplied
+    /// by the caller — the form a [`Solid`](crate::solid::Solid) shell needs,
+    /// since a shell holds mesh data and takes its frame from the solid.
+    pub(crate) fn for_each_face_polygon(
+        &self,
+        frame: &CoordinateFrame,
+        mut f: impl FnMut(Polygon3D),
+    ) {
+        let (face_indices, face_offsets, interior_offsets) = self.csr_buffers();
         for_each_face_coords(
-            data.vertices(),
+            self.vertices(),
             face_indices,
             face_offsets,
             interior_offsets,

--- a/engine/runtime/geometry/src/polygon_mesh/mod.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/mod.rs
@@ -234,6 +234,13 @@ impl PolygonMesh3DData {
 }
 
 impl PolygonMesh3DData {
+    /// The number of hole rings across every face. Crate-internal: lets a
+    /// [`Solid`](crate::solid::Solid) shell count its own holes.
+    #[inline]
+    pub(crate) fn num_holes(&self) -> usize {
+        self.interior_offsets.len()
+    }
+
     /// Drop the appearance.
     pub(crate) fn remove_appearance(&mut self) {
         self.appearance = None;

--- a/engine/runtime/geometry/src/polygon_mesh/ops.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/ops.rs
@@ -553,7 +553,9 @@ impl PolygonMesh2D {
     }
 }
 
-use crate::ops::{CountHoles, RemoveAppearance};
+use crate::ops::{
+    emit_face_2d, emit_face_3d, CountHoles, ExtractHoles, ExtractedPart, RemoveAppearance,
+};
 
 // `interior_offsets` already spans every face, so the mesh-wide count is its
 // length — no per-face walk, and no risk of counting a ring twice.
@@ -566,6 +568,32 @@ impl CountHoles for PolygonMesh2D {
 impl CountHoles for PolygonMesh3D {
     fn count_holes(&self) -> usize {
         self.data().num_holes()
+    }
+}
+
+// A mesh is an aggregate of faces, so it deaggregates: every face contributes its
+// own outer shell, and its holes come out alongside.
+impl ExtractHoles for PolygonMesh2D {
+    fn extract_holes(
+        &self,
+        emit: &mut dyn FnMut(Geometry, ExtractedPart),
+    ) -> Result<(), UnsupportedOperation> {
+        self.for_each_face_polygon(|face| {
+            emit_face_2d(&face, emit);
+        });
+        Ok(())
+    }
+}
+
+impl ExtractHoles for PolygonMesh3D {
+    fn extract_holes(
+        &self,
+        emit: &mut dyn FnMut(Geometry, ExtractedPart),
+    ) -> Result<(), UnsupportedOperation> {
+        self.for_each_face_polygon(|face| {
+            emit_face_3d(&face, emit);
+        });
+        Ok(())
     }
 }
 

--- a/engine/runtime/geometry/src/polygon_mesh/ops.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/ops.rs
@@ -553,7 +553,21 @@ impl PolygonMesh2D {
     }
 }
 
-use crate::ops::RemoveAppearance;
+use crate::ops::{CountHoles, RemoveAppearance};
+
+// `interior_offsets` already spans every face, so the mesh-wide count is its
+// length — no per-face walk, and no risk of counting a ring twice.
+impl CountHoles for PolygonMesh2D {
+    fn count_holes(&self) -> usize {
+        self.interior_offsets.len()
+    }
+}
+
+impl CountHoles for PolygonMesh3D {
+    fn count_holes(&self) -> usize {
+        self.data().num_holes()
+    }
+}
 
 impl RemoveAppearance for PolygonMesh2D {
     fn remove_appearance(&mut self) {

--- a/engine/runtime/geometry/src/solid/ops.rs
+++ b/engine/runtime/geometry/src/solid/ops.rs
@@ -143,7 +143,23 @@ impl ConvertFrame for Solid {
 // result, so it has no 2D counterpart.
 crate::unsupported!(Solid: ForceTwoDimension);
 
-use crate::ops::RemoveAppearance;
+use crate::ops::{CountHoles, RemoveAppearance};
+
+impl CountHoles for Solid {
+    /// The holes in the boundary faces of every shell. The void shells
+    /// themselves are hollow volumes rather than face boundaries, so they are
+    /// not counted; only the rings inside their faces are. A triangle-mesh shell
+    /// carries no rings and contributes nothing.
+    fn count_holes(&self) -> usize {
+        std::iter::once(&self.exterior)
+            .chain(self.interiors.iter())
+            .map(|shell| match shell {
+                Shell::PolygonMesh(data) => data.num_holes(),
+                Shell::TriangularMesh(_) => 0,
+            })
+            .sum()
+    }
+}
 
 impl RemoveAppearance for Solid {
     fn remove_appearance(&mut self) {

--- a/engine/runtime/geometry/src/solid/ops.rs
+++ b/engine/runtime/geometry/src/solid/ops.rs
@@ -143,7 +143,9 @@ impl ConvertFrame for Solid {
 // result, so it has no 2D counterpart.
 crate::unsupported!(Solid: ForceTwoDimension);
 
-use crate::ops::{CountHoles, RemoveAppearance};
+use crate::ops::{
+    emit_face_3d, emit_triangles_3d, CountHoles, ExtractHoles, ExtractedPart, RemoveAppearance,
+};
 
 impl CountHoles for Solid {
     /// The holes in the boundary faces of every shell. The void shells
@@ -158,6 +160,29 @@ impl CountHoles for Solid {
                 Shell::TriangularMesh(_) => 0,
             })
             .sum()
+    }
+}
+
+impl ExtractHoles for Solid {
+    /// Take apart the boundary faces of every shell. Matching [`CountHoles`], a
+    /// void shell is not itself a hole — it is a hollow volume — so it is not
+    /// emitted as one; its faces are taken apart like the exterior's.
+    fn extract_holes(
+        &self,
+        emit: &mut dyn FnMut(Geometry, ExtractedPart),
+    ) -> Result<(), UnsupportedOperation> {
+        let frame = self.frame();
+        for shell in std::iter::once(&self.exterior).chain(self.interiors.iter()) {
+            match shell {
+                Shell::PolygonMesh(data) => data.for_each_face_polygon(frame, |face| {
+                    emit_face_3d(&face, emit);
+                }),
+                Shell::TriangularMesh(data) => {
+                    emit_triangles_3d(frame, data.vertices(), data.triangles(), emit)
+                }
+            }
+        }
+        Ok(())
     }
 }
 

--- a/engine/runtime/geometry/src/triangular_mesh/mod.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/mod.rs
@@ -212,6 +212,10 @@ impl TriangularMesh3DData {
 crate::unsupported!(TriangularMesh2D: Triangulate);
 crate::unsupported!(TriangularMesh3D: Triangulate);
 
+// Triangles carry no interior rings, so the hole count is always zero.
+crate::unsupported!(TriangularMesh2D: CountHoles);
+crate::unsupported!(TriangularMesh3D: CountHoles);
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;

--- a/engine/runtime/geometry/src/triangular_mesh/ops.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/ops.rs
@@ -160,6 +160,41 @@ impl ConvertFrame for TriangularMesh3D {
     }
 }
 
+use crate::ops::{area_2d, emit_triangles_3d, ExtractHoles, ExtractedPart};
+
+// A triangle mesh is an aggregate of faces, so it deaggregates like a polygon
+// mesh. A triangle carries no interior ring, so every part is an outer shell.
+impl ExtractHoles for TriangularMesh2D {
+    fn extract_holes(
+        &self,
+        emit: &mut dyn FnMut(Geometry, ExtractedPart),
+    ) -> Result<(), UnsupportedOperation> {
+        let vertices = self.vertices();
+        let frame = self.frame();
+        let elevation = self.elevation();
+        for [i, j, k] in self.triangles() {
+            let ring = [
+                vertices[i as usize],
+                vertices[j as usize],
+                vertices[k as usize],
+                vertices[i as usize],
+            ];
+            emit(area_2d(frame, ring, elevation), ExtractedPart::Outershell);
+        }
+        Ok(())
+    }
+}
+
+impl ExtractHoles for TriangularMesh3D {
+    fn extract_holes(
+        &self,
+        emit: &mut dyn FnMut(Geometry, ExtractedPart),
+    ) -> Result<(), UnsupportedOperation> {
+        emit_triangles_3d(self.frame(), self.vertices(), self.triangles(), emit);
+        Ok(())
+    }
+}
+
 impl Split for TriangularMesh2D {
     fn split(
         &mut self,

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.97"
+version = "0.2.98"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.287"
+version = "0.1.288"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
# Overview

Make `Hole Counter` and `Hole Extractor` work under the `new-geometry` feature, backed by a new pair of geometry operations (`CountHoles` / `ExtractHoles`) that share one definition of "hole".

## What I've done

### Hole Counter

- Writes the number of interior rings to `outputAttribute`; every feature leaves via `features`.
- Counting is total: geometry that cannot carry a hole — point, curve, point cloud, triangle mesh, absent geometry — yields `0`.
- A `Solid` counts the holes in the faces of every shell. A void shell is a hollow volume, not a face boundary, so it is not itself a hole.

### Hole Extractor

- Each face is taken apart: outer boundary with holes removed to `outershell`, each interior ring to `hole` as an area of its own. A face without holes still leaves via `outershell`, unchanged.
- Meshes, solids, and collections deaggregate — one feature in, many out — each part keeping the input's attributes and taking a fresh id.
- Rings are emitted verbatim, neither re-wound nor re-closed: a hole's winding is exactly what the surface validation workflows inspect.
- Geometry bounding no area goes to `rejected`, member-by-member inside a container.

### Differences from FME

Matches FME on the behavior that matters (zero for non-area geometry; outershell passthrough, deaggregation, non-area rejection). Not replicated: FME emits a hole containing a smaller hole via both ports (nested donuts) — here each ring is emitted once. FME's `Aggregate Handling` parameter is not exposed; deaggregation is fixed, as in the existing action.

### Differences from the legacy implementation

| | legacy | new-geometry |
| --- | --- | --- |
| Counter, no geometry | forwarded without the attribute | attribute set to `0` |
| Counter, triangle mesh | panics (`unimplemented!()` in `runtime/geometry/src/algorithm/hole.rs`) | `0` |
| Extractor, input types | polygon / multi-polygon / CityGML only, else rejected whole | any area geometry, meshes and solids included |
| Extractor, mixed container | one non-area member rejected the whole feature | only that member is rejected |

## What I haven't done

- No new end-to-end workflow test; covered by unit tests at the geometry-op and processor level.
- No schema / i18n regeneration — parameters and ports are unchanged.

## How I tested

- Geometry-op unit tests in `runtime/geometry/src/ops/hole.rs`, with counting and extraction driven from shared fixtures plus a cross-check that the reported count equals the number of extracted `hole` parts.
- Processor unit tests asserting the exact port-and-feature sequence, attribute preservation, and fresh part ids.
- `cargo make format`, `cargo make clippy`, `cargo make test`, with and without `new-geometry`.

## Screenshot

## Which point I want you to review particularly

- Impact on the consumers: `runtime/examples/fixture/graphs/surface_validator.yml` and the 10 `quality-check/plateau4/*.yml` workflows, where the count feeds a `Feature Filter` on `attributes["holeCount"] > 0` and the extractor feeds the interior orientation / intersection checks.
- Whether a `Solid`'s void shells should be counted as holes (currently not — only the rings inside their faces).

## Memo