### PR TITLE
fix(api): stop the documented dbmigrate seed recipe from silently doing nothing

### DIFF
--- a/server/api/cmd/dbmigrate/main.go
+++ b/server/api/cmd/dbmigrate/main.go
@@ -91,6 +91,19 @@ func main() {
 	applySchema := flag.Bool("apply-schema", false, "apply the embedded Atlas migrations to the target before replicating (fresh instance only)")
 	flag.Parse()
 
+	// -verify returns before the ETL, so pairing it with a seeding flag silently
+	// skips the replication and still exits 0. Reject the combination rather than
+	// leaving an empty database that looks successfully seeded.
+	if *verify {
+		passed := map[string]bool{}
+		flag.Visit(func(f *flag.Flag) { passed[f.Name] = true })
+		for _, name := range []string{"apply-schema", "db"} {
+			if passed[name] {
+				log.Fatalf("-verify only reads the target and cannot be combined with -%s; run the steps separately", name)
+			}
+		}
+	}
+
 	pgURI := os.Getenv("REEARTH_FLOW_DB_PG")
 	if pgURI == "" {
 		log.Fatal("set REEARTH_FLOW_DB_PG (target Postgres URI)")

--- a/server/api/internal/infrastructure/postgres/README.md
+++ b/server/api/internal/infrastructure/postgres/README.md
@@ -68,24 +68,60 @@ For a private-IP Cloud SQL instance, run `dbmigrate` from an ephemeral, in-VPC
 Cloud Run job on the flow-api image (which now ships the `dbmigrate` binary)
 so the job can reach the private instance without a bastion:
 
+`-verify` is a **separate mode**, not an add-on: it reads the target back and
+returns without replicating anything. Combining it with the seed in one
+invocation applies the schema, verifies an empty database and exits `0` — a
+silent no-op that looks like a successful seed. Run the three steps separately.
+
 ```sh
+# Pin the image by digest. The :nightly tag can lag the commit that added
+# dbmigrate, and an image without the binary fails only at execution time.
+IMAGE=$(gcloud artifacts docker images list \
+  us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-flow-api \
+  --project reearth-oss --include-tags --filter='tags:nightly' \
+  --format='value(version)' --limit 1)
+
 gcloud run jobs create reearth-flow-dbmigrate \
   --project reearth-oss \
   --region us-central1 \
-  --image us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-flow-api:nightly \
+  --image "us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-flow-api@${IMAGE}" \
   --network default \
   --subnet default \
   --vpc-egress private-ranges-only \
   --service-account reearth-flow-migration@reearth-oss.iam.gserviceaccount.com \
   --set-secrets REEARTH_FLOW_DB=reearth-flow-db:latest,REEARTH_FLOW_DB_PG=reearth-flow-db-postgres:latest \
   --command /reearth-flow/dbmigrate \
-  --args=-apply-schema,-db=reearth-flow,-verify
+  --args=-apply-schema \
+  --max-retries 0 \
+  --task-timeout 3600s
 
-gcloud run jobs execute reearth-flow-dbmigrate \
-  --project reearth-oss \
-  --region us-central1 \
-  --wait
+run() {
+  gcloud run jobs execute reearth-flow-dbmigrate \
+    --project reearth-oss --region us-central1 --wait
+}
+set_args() {
+  gcloud run jobs update reearth-flow-dbmigrate \
+    --project reearth-oss --region us-central1 --args="$1"
+}
+
+# 1. schema (one-shot; see above)
+run
+
+# 2. replicate the data
+set_args -db=reearth-flow
+run
+
+# 3. read every replicated row back through the Postgres adapters
+set_args -verify
+run
 ```
+
+`--max-retries 0` matters: `-apply-schema` is one-shot, so a retried task fails
+on the already-created tables and buries the original error.
+
+Step 2 exits non-zero if any document failed to decode, while still migrating
+the rest — check the per-collection `migrated=`/`failed=` tallies in the log
+rather than the exit code alone.
 
 The service account needs `roles/secretmanager.secretAccessor` on both
 `reearth-flow-db` (source Mongo) and `reearth-flow-db-postgres` (target). Clean


### PR DESCRIPTION
## The documented golden path cannot seed anything

The Cloud Run recipe added in #2252 combines all three flags:

```sh
--args=-apply-schema,-db=reearth-flow,-verify
```

But `-verify` is a separate mode, not an add-on — it returns before the ETL:

```go
if *verify {
    runVerify(ctx, pool, c)
    return          // <- the replication below never runs
}
```

So that command applies the schema, verifies an **empty** database (every table trivially `rows=0 ok`), and exits **0**. Anyone following the golden path gets an empty Postgres and a green check.

Found while actually seeding `reearth-oss`. The first run looked like this:

```
VERIFY: all rows read back and decoded cleanly
  projects   rows=0  decoded=0  ok
  jobs       rows=0  decoded=0  ok
  ...
Container called exit(0).
```

Re-running the steps separately then produced the real result — `migrated=16420 failed=2` — so this is purely a recipe/UX bug, not a defect in the ETL itself.

## Changes

**README** — split into the three executions it always had to be: schema, then data, then read-back.

**`cmd/dbmigrate`** — reject `-verify` combined with `-db` or `-apply-schema`, using `flag.Visit` so only *explicitly passed* flags count (`-db` has a default, so checking its value would misfire). Failing loudly beats leaving an empty database that looks seeded.

The guard is separable from the docs fix if you'd rather keep this documentation-only — happy to drop it.

## Also carried over from running this for real

- **Pin the image by digest.** `:nightly` was ~15h stale when I seeded, and an image without the `dbmigrate` binary only fails at execution time.
- **`--max-retries 0`.** `-apply-schema` is one-shot with bare `CREATE TABLE`; the default 3 retries means a retried task fails on already-created tables and buries the original error.
- **Note on exit codes.** The ETL exits non-zero if any document fails to decode while still migrating the rest, so the per-collection `migrated=`/`failed=` tallies matter more than the exit code. (Our seed hit 2 pre-existing malformed legacy triggers.)

## Verification

`go build` and `go vet` clean. Guard behaviour, with the broken recipe as row 3:

```
-verify -apply-schema                  -> error: cannot be combined with -apply-schema
-verify -db=reearth-flow               -> error: cannot be combined with -db
-apply-schema -db=reearth-flow -verify -> error: cannot be combined with -apply-schema
-verify                                -> proceeds
-apply-schema                          -> proceeds
-db=reearth-flow                       -> proceeds
```

The corrected three-step recipe is what actually seeded `reearth-oss`: schema applied (14 migrations), `migrated=16420 failed=2`, then verify returned `projects rows=1519`, `jobs rows=6362`, `parameters rows=489`, `assets rows=185`, `deployments rows=113`, `triggers rows=28`, all decoded cleanly.