### PR TITLE
feat(engine): generating 3D views for intermediate data

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5150,6 +5150,7 @@ dependencies = [
  "bytes",
  "reearth-flow-action-sink",
  "reearth-flow-common",
+ "reearth-flow-expr",
  "reearth-flow-geometry",
  "reearth-flow-storage",
  "reearth-flow-types",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.102"
+version = "0.2.103"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "Inflector",
  "approx",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4959,7 +4959,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5008,7 +5008,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5019,7 +5019,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "bytes",
  "clap",
@@ -5061,7 +5061,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5145,7 +5145,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.465"
+version = "0.0.473"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "approx",
  "bvh",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5243,7 +5243,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5272,7 +5272,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5308,7 +5308,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "bytes",
  "futures",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "bytes",
  "futures",
@@ -5375,7 +5375,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "ahash",
  "bytes",
@@ -5459,7 +5459,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.472"
+version = "0.0.473"
 dependencies = [
  "async-trait",
  "axum",
@@ -8225,7 +8225,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.292"
+version = "0.1.293"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5039,6 +5039,7 @@ dependencies = [
  "reearth-flow-action-sink",
  "reearth-flow-action-source",
  "reearth-flow-common",
+ "reearth-flow-feature-view",
  "reearth-flow-geometry",
  "reearth-flow-runner",
  "reearth-flow-runtime",
@@ -5140,6 +5141,22 @@ dependencies = [
  "regex",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reearth-flow-feature-view"
+version = "0.0.465"
+dependencies = [
+ "bytes",
+ "reearth-flow-action-sink",
+ "reearth-flow-common",
+ "reearth-flow-geometry",
+ "reearth-flow-storage",
+ "reearth-flow-types",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "zstd",
 ]
 
 [[package]]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -56,9 +56,9 @@ reearth-flow-action-source = { path = "runtime/action-source" }
 reearth-flow-atlas = { path = "runtime/atlas" }
 reearth-flow-common = { path = "runtime/common" }
 reearth-flow-expr = { path = "runtime/expr" }
+reearth-flow-feature-view = { path = "runtime/feature-view" }
 reearth-flow-geometry = { path = "runtime/geometry" }
 reearth-flow-gltf = { path = "runtime/gltf" }
-reearth-flow-feature-view = { path = "runtime/feature-view" }
 reearth-flow-macros = { path = "runtime/macros" }
 reearth-flow-runner = { path = "runtime/runner" }
 reearth-flow-runtime = { path = "runtime/runtime" }

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -58,6 +58,7 @@ reearth-flow-common = { path = "runtime/common" }
 reearth-flow-expr = { path = "runtime/expr" }
 reearth-flow-geometry = { path = "runtime/geometry" }
 reearth-flow-gltf = { path = "runtime/gltf" }
+reearth-flow-feature-view = { path = "runtime/feature-view" }
 reearth-flow-macros = { path = "runtime/macros" }
 reearth-flow-runner = { path = "runtime/runner" }
 reearth-flow-runtime = { path = "runtime/runtime" }

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.472"
+version = "0.0.473"
 
 [profile.dev]
 opt-level = 0

--- a/engine/cli/Cargo.toml
+++ b/engine/cli/Cargo.toml
@@ -23,6 +23,7 @@ memory-stats = [
 # Temporary migration flag for the new-geometry migration.
 # TODO: Remove after migration.
 new-geometry = [
+  "reearth-flow-feature-view/new-geometry",
   "reearth-flow-action-plateau-processor/new-geometry",
   "reearth-flow-action-processor/new-geometry",
   "reearth-flow-action-python-processor/new-geometry",

--- a/engine/cli/Cargo.toml
+++ b/engine/cli/Cargo.toml
@@ -23,12 +23,12 @@ memory-stats = [
 # Temporary migration flag for the new-geometry migration.
 # TODO: Remove after migration.
 new-geometry = [
-  "reearth-flow-feature-view/new-geometry",
   "reearth-flow-action-plateau-processor/new-geometry",
   "reearth-flow-action-processor/new-geometry",
   "reearth-flow-action-python-processor/new-geometry",
   "reearth-flow-action-sink/new-geometry",
   "reearth-flow-action-source/new-geometry",
+  "reearth-flow-feature-view/new-geometry",
   "reearth-flow-types/new-geometry",
 ]
 
@@ -46,8 +46,8 @@ reearth-flow-action-python-processor.workspace = true
 reearth-flow-action-sink.workspace = true
 reearth-flow-action-source.workspace = true
 reearth-flow-common.workspace = true
-reearth-flow-geometry.workspace = true
 reearth-flow-feature-view.workspace = true
+reearth-flow-geometry.workspace = true
 reearth-flow-runner.workspace = true
 reearth-flow-runtime.workspace = true
 reearth-flow-state.workspace = true

--- a/engine/cli/Cargo.toml
+++ b/engine/cli/Cargo.toml
@@ -46,6 +46,7 @@ reearth-flow-action-sink.workspace = true
 reearth-flow-action-source.workspace = true
 reearth-flow-common.workspace = true
 reearth-flow-geometry.workspace = true
+reearth-flow-feature-view.workspace = true
 reearth-flow-runner.workspace = true
 reearth-flow-runtime.workspace = true
 reearth-flow-state.workspace = true

--- a/engine/cli/src/cli.rs
+++ b/engine/cli/src/cli.rs
@@ -10,10 +10,11 @@ use crate::scaffold_i18n::{build_scaffold_i18n_command, ScaffoldI18nCliCommand};
 use crate::schema_action::{build_schema_action_command, SchemaActionCliCommand};
 use crate::schema_feature::{build_schema_feature_command, SchemaFeatureCliCommand};
 use crate::schema_workflow::{build_schema_workflow_command, SchemaWorkflowCliCommand};
+#[cfg(feature = "new-geometry")]
 use crate::view::{build_view_command, ViewCliCommand};
 
 pub fn build_cli() -> Command {
-    Command::new("Re:Earth Flow CLI")
+    let command = Command::new("Re:Earth Flow CLI")
         .version(env!("CARGO_PKG_VERSION"))
         .subcommand(build_run_command().display_order(1))
         .subcommand(build_dot_command().display_order(2))
@@ -22,8 +23,10 @@ pub fn build_cli() -> Command {
         .subcommand(build_doc_action_command().display_order(5))
         .subcommand(build_scaffold_i18n_command().display_order(6))
         .subcommand(build_probe_schema_command().display_order(7))
-        .subcommand(build_schema_feature_command().display_order(8))
-        .subcommand(build_view_command().display_order(9))
+        .subcommand(build_schema_feature_command().display_order(8));
+    #[cfg(feature = "new-geometry")]
+    let command = command.subcommand(build_view_command().display_order(9));
+    command
         .arg_required_else_help(true)
         .disable_help_subcommand(true)
         .subcommand_required(true)
@@ -39,6 +42,7 @@ pub enum CliCommand {
     ScaffoldI18n(ScaffoldI18nCliCommand),
     ProbeSchema(ProbeSchemaCliCommand),
     SchemaFeature(SchemaFeatureCliCommand),
+    #[cfg(feature = "new-geometry")]
     View(ViewCliCommand),
 }
 
@@ -64,6 +68,7 @@ impl CliCommand {
             "schema-feature" => Ok(CliCommand::SchemaFeature(
                 SchemaFeatureCliCommand::parse_cli_args(submatches)?,
             )),
+            #[cfg(feature = "new-geometry")]
             "view" => ViewCliCommand::parse_cli_args(submatches).map(CliCommand::View),
             _ => Err(crate::errors::Error::unknown_command(subcommand)),
         }
@@ -79,6 +84,7 @@ impl CliCommand {
             CliCommand::ScaffoldI18n(subcommand) => subcommand.execute(),
             CliCommand::ProbeSchema(subcommand) => subcommand.execute(),
             CliCommand::SchemaFeature(subcommand) => subcommand.execute(),
+            #[cfg(feature = "new-geometry")]
             CliCommand::View(subcommand) => subcommand.execute(),
         }
     }

--- a/engine/cli/src/cli.rs
+++ b/engine/cli/src/cli.rs
@@ -10,6 +10,7 @@ use crate::scaffold_i18n::{build_scaffold_i18n_command, ScaffoldI18nCliCommand};
 use crate::schema_action::{build_schema_action_command, SchemaActionCliCommand};
 use crate::schema_feature::{build_schema_feature_command, SchemaFeatureCliCommand};
 use crate::schema_workflow::{build_schema_workflow_command, SchemaWorkflowCliCommand};
+use crate::view::{build_view_command, ViewCliCommand};
 
 pub fn build_cli() -> Command {
     Command::new("Re:Earth Flow CLI")
@@ -22,6 +23,7 @@ pub fn build_cli() -> Command {
         .subcommand(build_scaffold_i18n_command().display_order(6))
         .subcommand(build_probe_schema_command().display_order(7))
         .subcommand(build_schema_feature_command().display_order(8))
+        .subcommand(build_view_command().display_order(9))
         .arg_required_else_help(true)
         .disable_help_subcommand(true)
         .subcommand_required(true)
@@ -37,6 +39,7 @@ pub enum CliCommand {
     ScaffoldI18n(ScaffoldI18nCliCommand),
     ProbeSchema(ProbeSchemaCliCommand),
     SchemaFeature(SchemaFeatureCliCommand),
+    View(ViewCliCommand),
 }
 
 impl CliCommand {
@@ -61,6 +64,7 @@ impl CliCommand {
             "schema-feature" => Ok(CliCommand::SchemaFeature(
                 SchemaFeatureCliCommand::parse_cli_args(submatches)?,
             )),
+            "view" => ViewCliCommand::parse_cli_args(submatches).map(CliCommand::View),
             _ => Err(crate::errors::Error::unknown_command(subcommand)),
         }
     }
@@ -75,6 +79,7 @@ impl CliCommand {
             CliCommand::ScaffoldI18n(subcommand) => subcommand.execute(),
             CliCommand::ProbeSchema(subcommand) => subcommand.execute(),
             CliCommand::SchemaFeature(subcommand) => subcommand.execute(),
+            CliCommand::View(subcommand) => subcommand.execute(),
         }
     }
 }

--- a/engine/cli/src/main.rs
+++ b/engine/cli/src/main.rs
@@ -12,6 +12,7 @@ mod schema_action;
 mod schema_feature;
 mod schema_workflow;
 mod utils;
+mod view;
 
 use std::env;
 

--- a/engine/cli/src/main.rs
+++ b/engine/cli/src/main.rs
@@ -12,6 +12,7 @@ mod schema_action;
 mod schema_feature;
 mod schema_workflow;
 mod utils;
+#[cfg(feature = "new-geometry")]
 mod view;
 
 use std::env;

--- a/engine/cli/src/view.rs
+++ b/engine/cli/src/view.rs
@@ -1,0 +1,254 @@
+use clap::{Arg, ArgAction, ArgMatches, Command};
+
+/// The `view` subcommand.
+pub fn build_view_command() -> Command {
+    Command::new("view")
+        .about("Render intermediate data into a viewable 3D form.")
+        .long_about(
+            "Read the intermediate-data JSONL a run left on an edge, keep the features a Flow \
+             expression selects, and render them for a 3D viewer. The default is a single glb \
+             holding the whole selection, which suits one feature or a handful; --format 3dtiles \
+             renders a tiled 3D Tiles tileset instead, for looking at an entire edge at once.",
+        )
+        .arg(
+            Arg::new("input")
+                .long("input")
+                .help(
+                    "Intermediate-data file location, e.g. \
+                     .../feature-store/<node-id>.<port>.jsonl.zst.",
+                )
+                .required(true)
+                .display_order(1),
+        )
+        .arg(
+            Arg::new("output")
+                .long("output")
+                .help("Directory the view is written under.")
+                .required(true)
+                .display_order(2),
+        )
+        .arg(
+            Arg::new("name")
+                .long("name")
+                .help(
+                    "Base name for the output. A glTF view writes <name>.glb; a tileset writes \
+                     <name>/tileset.json. Defaults to the input file's name.",
+                )
+                .display_order(3),
+        )
+        .arg(
+            Arg::new("row")
+                .long("row")
+                .help(
+                    "Row to render, 0-based, as numbered in the intermediate-data table. \
+                     Repeatable. This is the path behind clicking a table row: only the named \
+                     lines are parsed, so it does not pay to decode the whole edge. Cannot be \
+                     combined with --filter.",
+                )
+                .value_parser(clap::value_parser!(usize))
+                .action(ArgAction::Append)
+                .conflicts_with("filter")
+                .display_order(4),
+        )
+        .arg(
+            Arg::new("filter")
+                .long("filter")
+                .help(
+                    "Flow expression evaluated against each feature; only features it returns \
+                     true for are rendered. Omit to render every feature.",
+                )
+                .display_order(4),
+        )
+        .arg(
+            Arg::new("format")
+                .long("format")
+                .help("View to render.")
+                .value_parser(["gltf", "3dtiles"])
+                .default_value("gltf")
+                .display_order(5),
+        )
+        .arg(
+            Arg::new("max-zoom")
+                .long("max-zoom")
+                .help("Deepest quadtree level a feature may be placed at. 3D Tiles only.")
+                .value_parser(clap::value_parser!(u8))
+                .default_value("18")
+                .display_order(6),
+        )
+        .arg(
+            Arg::new("no-draco")
+                .long("no-draco")
+                .help(
+                    "Skip Draco mesh compression. On by default; turn it off for a viewer that \
+                     does not support KHR_draco_mesh_compression.",
+                )
+                .action(ArgAction::SetTrue)
+                .display_order(7),
+        )
+        .arg(
+            Arg::new("texel-size")
+                .long("texel-size")
+                .help("Target texel size in metres per pixel. 0 keeps full texture detail.")
+                .value_parser(clap::value_parser!(f64))
+                .default_value("0")
+                .display_order(8),
+        )
+        .arg(
+            Arg::new("texture-codec")
+                .long("texture-codec")
+                .help(
+                    "Image codec for textures. JPEG is the default: it encodes far faster than \
+                     the KTX2 forms at a comparable file size, which is what a view built on \
+                     demand wants. KTX2 is GPU-compressed and cheaper to serve repeatedly, but \
+                     its encode dominates render time. 'untextured' skips texturing entirely \
+                     and renders geometry in its neutral colour.",
+                )
+                .value_parser(["jpeg", "png", "ktx2-etc1s", "ktx2-uastc", "untextured"])
+                .default_value("jpeg")
+                .display_order(9),
+        )
+}
+
+#[derive(Debug, PartialEq)]
+pub struct ViewCliCommand {
+    input: String,
+    output: String,
+    name: Option<String>,
+    rows: Vec<usize>,
+    filter: Option<String>,
+    format: String,
+    max_zoom: u8,
+    draco: bool,
+    texel_size: f64,
+    texture_codec: String,
+}
+
+impl ViewCliCommand {
+    pub fn parse_cli_args(mut matches: ArgMatches) -> crate::Result<Self> {
+        let input = matches
+            .remove_one::<String>("input")
+            .ok_or(crate::errors::Error::init("No input uri provided"))?;
+        let output = matches
+            .remove_one::<String>("output")
+            .ok_or(crate::errors::Error::init("No output uri provided"))?;
+        Ok(ViewCliCommand {
+            input,
+            output,
+            name: matches.remove_one::<String>("name"),
+            rows: matches
+                .remove_many::<usize>("row")
+                .map(|rows| rows.collect())
+                .unwrap_or_default(),
+            filter: matches.remove_one::<String>("filter"),
+            format: matches
+                .remove_one::<String>("format")
+                .unwrap_or_else(|| "gltf".to_string()),
+            max_zoom: matches.remove_one::<u8>("max-zoom").unwrap_or(18),
+            draco: !matches.get_flag("no-draco"),
+            texel_size: matches.remove_one::<f64>("texel-size").unwrap_or(0.0),
+            texture_codec: matches
+                .remove_one::<String>("texture-codec")
+                .unwrap_or_else(|| "jpeg".to_string()),
+        })
+    }
+
+    pub fn execute(&self) -> crate::Result<()> {
+        use std::sync::Arc;
+
+        use reearth_flow_common::uri::Uri;
+        use reearth_flow_feature_view::{
+            load_selected, render, Destination, Selection, TextureCodec, ViewFormat, ViewOptions,
+        };
+        use reearth_flow_storage::resolve::StorageResolver;
+
+        let storage_resolver = StorageResolver::new();
+        let input = Uri::for_test(self.input.as_str());
+        let output = Uri::for_test(self.output.as_str());
+
+        // One streaming read either way: naming rows parses only those lines, a
+        // filter runs against each feature as it is parsed, and neither holds a
+        // feature the view will not render.
+        let selection = if !self.rows.is_empty() {
+            Selection::Rows(&self.rows)
+        } else if let Some(expr) = self.filter.as_deref() {
+            Selection::Filter {
+                expr,
+                env_vars: Arc::new(serde_json::Map::new()),
+            }
+        } else {
+            Selection::All
+        };
+        let scan_stopped_early = !self.rows.is_empty();
+        let loaded = load_selected(&input, selection, &storage_resolver)
+            .map_err(crate::errors::Error::run)?;
+        let selection = loaded.selection;
+        let total = if scan_stopped_early {
+            "requested".to_string()
+        } else {
+            loaded.scanned.to_string()
+        };
+
+        let options = ViewOptions {
+            format: if self.format == "3dtiles" {
+                ViewFormat::Cesium3DTiles {
+                    max_zoom: self.max_zoom,
+                }
+            } else {
+                ViewFormat::Gltf
+            },
+            draco: self.draco,
+            texel_size: self.texel_size,
+            texture_codec: match self.texture_codec.as_str() {
+                "ktx2-etc1s" => TextureCodec::Ktx2Etc1s,
+                "ktx2-uastc" => TextureCodec::Ktx2Uastc,
+                "png" => TextureCodec::Png,
+                "untextured" => TextureCodec::Untextured,
+                _ => TextureCodec::Jpeg,
+            },
+            ..ViewOptions::default()
+        };
+
+        let name = self.default_name(&input)?;
+        let destination = Destination {
+            root: &output,
+            prefix: name.as_str(),
+            storage_resolver: &storage_resolver,
+        };
+
+        let view = render(&selection, &options, &destination).map_err(crate::errors::Error::run)?;
+
+        match view.entry_point {
+            Some(entry_point) => println!(
+                "Rendered {} of {total} features into {} ({} file(s))",
+                selection.len(),
+                entry_point.as_str(),
+                view.written.len()
+            ),
+            None => println!(
+                "None of the {} selected features (of {total}) carried renderable geometry; \
+                 nothing was written",
+                selection.len()
+            ),
+        }
+        Ok(())
+    }
+
+    /// The output base name: what `--name` says, else the input file's name
+    /// with its intermediate-data extension dropped.
+    fn default_name(&self, input: &reearth_flow_common::uri::Uri) -> crate::Result<String> {
+        if let Some(name) = &self.name {
+            return Ok(name.clone());
+        }
+        let name = input
+            .file_name()
+            .and_then(|name| name.to_str().map(str::to_string))
+            .ok_or_else(|| {
+                crate::errors::Error::init(format!("{} has no file name", self.input))
+            })?;
+        let stem = name
+            .strip_suffix(".jsonl.zst")
+            .or_else(|| name.strip_suffix(".jsonl"))
+            .unwrap_or(name.as_str());
+        Ok(stem.to_string())
+    }
+}

--- a/engine/cli/src/view.rs
+++ b/engine/cli/src/view.rs
@@ -1,15 +1,76 @@
+use std::str::FromStr;
+use std::sync::Arc;
+
 use clap::{Arg, ArgAction, ArgMatches, Command};
+use reearth_flow_common::uri::Uri;
+use reearth_flow_feature_view::{
+    default_name, load_selected, render, Destination, Selection, TextureCodec, ViewFormat,
+    ViewOptions,
+};
+use reearth_flow_storage::resolve::StorageResolver;
 
 /// The `view` subcommand.
+///
+/// Each shape takes only the selection it can act on: rows pick features out of
+/// the table for a glb, a filter narrows a whole edge for a tileset. They are
+/// separate subcommands so the other pairing cannot be spelled at all.
 pub fn build_view_command() -> Command {
     Command::new("view")
         .about("Render intermediate data into a viewable 3D form.")
         .long_about(
-            "Read the intermediate-data JSONL a run left on an edge, keep the features a Flow \
-             expression selects, and render them for a 3D viewer. The default is a single glb \
-             holding the whole selection, which suits one feature or a handful; --format 3dtiles \
-             renders a tiled 3D Tiles tileset instead, for looking at an entire edge at once.",
+            "Read the intermediate-data JSONL a run left on an edge and render its features for \
+             a 3D viewer. `gltf` renders named rows into one glb, which is what showing a single \
+             feature or a handful wants; `3dtiles` renders a whole edge into a tiled tileset for \
+             looking at all of it at once.",
         )
+        .subcommand_required(true)
+        .arg_required_else_help(true)
+        .subcommand(
+            shared_args(Command::new("gltf"))
+                .about("Render the named rows into a single glb.")
+                .arg(
+                    Arg::new("row")
+                        .long("row")
+                        .help(
+                            "Row to render, 0-based, as numbered in the intermediate-data table. \
+                             Repeatable. This is the path behind clicking a table row: the scan \
+                             stops at the highest row named, and no other line is parsed.",
+                        )
+                        .value_parser(clap::value_parser!(usize))
+                        .action(ArgAction::Append)
+                        .required(true)
+                        .display_order(4),
+                )
+                .display_order(1),
+        )
+        .subcommand(
+            shared_args(Command::new("3dtiles"))
+                .about("Render a whole edge into a tiled 3D Tiles tileset.")
+                .arg(
+                    Arg::new("filter")
+                        .long("filter")
+                        .help(
+                            "Flow expression evaluated against each feature; only features it \
+                             returns true for are rendered. Omit to render every feature. The \
+                             expression sees the feature alone, not workflow variables.",
+                        )
+                        .display_order(4),
+                )
+                .arg(
+                    Arg::new("max-zoom")
+                        .long("max-zoom")
+                        .help("Deepest quadtree level a feature may be placed at.")
+                        .value_parser(clap::value_parser!(u8))
+                        .default_value("18")
+                        .display_order(5),
+                )
+                .display_order(2),
+        )
+}
+
+/// The arguments both shapes take.
+fn shared_args(command: Command) -> Command {
+    command
         .arg(
             Arg::new("input")
                 .long("input")
@@ -35,45 +96,6 @@ pub fn build_view_command() -> Command {
                      <name>/tileset.json. Defaults to the input file's name.",
                 )
                 .display_order(3),
-        )
-        .arg(
-            Arg::new("row")
-                .long("row")
-                .help(
-                    "Row to render, 0-based, as numbered in the intermediate-data table. \
-                     Repeatable. This is the path behind clicking a table row: only the named \
-                     lines are parsed, so it does not pay to decode the whole edge. Cannot be \
-                     combined with --filter.",
-                )
-                .value_parser(clap::value_parser!(usize))
-                .action(ArgAction::Append)
-                .conflicts_with("filter")
-                .display_order(4),
-        )
-        .arg(
-            Arg::new("filter")
-                .long("filter")
-                .help(
-                    "Flow expression evaluated against each feature; only features it returns \
-                     true for are rendered. Omit to render every feature.",
-                )
-                .display_order(4),
-        )
-        .arg(
-            Arg::new("format")
-                .long("format")
-                .help("View to render.")
-                .value_parser(["gltf", "3dtiles"])
-                .default_value("gltf")
-                .display_order(5),
-        )
-        .arg(
-            Arg::new("max-zoom")
-                .long("max-zoom")
-                .help("Deepest quadtree level a feature may be placed at. 3D Tiles only.")
-                .value_parser(clap::value_parser!(u8))
-                .default_value("18")
-                .display_order(6),
         )
         .arg(
             Arg::new("no-draco")
@@ -114,120 +136,132 @@ pub struct ViewCliCommand {
     input: String,
     output: String,
     name: Option<String>,
-    rows: Vec<usize>,
-    filter: Option<String>,
-    format: String,
-    max_zoom: u8,
     draco: bool,
     texel_size: f64,
-    texture_codec: String,
+    texture_codec: TextureCodec,
+    shape: Shape,
+}
+
+/// The view shape, holding the selection only that shape accepts.
+#[derive(Debug, PartialEq)]
+enum Shape {
+    Gltf {
+        rows: Vec<usize>,
+    },
+    Cesium3DTiles {
+        filter: Option<String>,
+        max_zoom: u8,
+    },
 }
 
 impl ViewCliCommand {
     pub fn parse_cli_args(mut matches: ArgMatches) -> crate::Result<Self> {
+        let (shape, mut matches) = matches
+            .remove_subcommand()
+            .ok_or(crate::errors::Error::init("No view shape provided"))?;
+        let shape = match shape.as_str() {
+            "gltf" => Shape::Gltf {
+                rows: matches
+                    .remove_many::<usize>("row")
+                    .map(|rows| rows.collect())
+                    .unwrap_or_default(),
+            },
+            "3dtiles" => Shape::Cesium3DTiles {
+                filter: matches.remove_one::<String>("filter"),
+                max_zoom: matches.remove_one::<u8>("max-zoom").unwrap_or(18),
+            },
+            other => return Err(crate::errors::Error::unknown_command(other)),
+        };
         let input = matches
             .remove_one::<String>("input")
             .ok_or(crate::errors::Error::init("No input uri provided"))?;
         let output = matches
             .remove_one::<String>("output")
             .ok_or(crate::errors::Error::init("No output uri provided"))?;
+        let texture_codec = match matches.remove_one::<String>("texture-codec").as_deref() {
+            Some("ktx2-etc1s") => TextureCodec::Ktx2Etc1s,
+            Some("ktx2-uastc") => TextureCodec::Ktx2Uastc,
+            Some("png") => TextureCodec::Png,
+            Some("untextured") => TextureCodec::Untextured,
+            Some("jpeg") | None => TextureCodec::Jpeg,
+            Some(other) => {
+                return Err(crate::errors::Error::init(format!(
+                    "Unknown texture codec: {other}"
+                )))
+            }
+        };
         Ok(ViewCliCommand {
             input,
             output,
             name: matches.remove_one::<String>("name"),
-            rows: matches
-                .remove_many::<usize>("row")
-                .map(|rows| rows.collect())
-                .unwrap_or_default(),
-            filter: matches.remove_one::<String>("filter"),
-            format: matches
-                .remove_one::<String>("format")
-                .unwrap_or_else(|| "gltf".to_string()),
-            max_zoom: matches.remove_one::<u8>("max-zoom").unwrap_or(18),
             draco: !matches.get_flag("no-draco"),
             texel_size: matches.remove_one::<f64>("texel-size").unwrap_or(0.0),
-            texture_codec: matches
-                .remove_one::<String>("texture-codec")
-                .unwrap_or_else(|| "jpeg".to_string()),
+            texture_codec,
+            shape,
         })
     }
 
     pub fn execute(&self) -> crate::Result<()> {
-        use std::sync::Arc;
-
-        use reearth_flow_common::uri::Uri;
-        use reearth_flow_feature_view::{
-            load_selected, render, Destination, Selection, TextureCodec, ViewFormat, ViewOptions,
-        };
-        use reearth_flow_storage::resolve::StorageResolver;
-
         let storage_resolver = StorageResolver::new();
-        let input = Uri::for_test(self.input.as_str());
-        let output = Uri::for_test(self.output.as_str());
+        let input = Uri::from_str(self.input.as_str()).map_err(crate::errors::Error::init)?;
+        let output = Uri::from_str(self.output.as_str()).map_err(crate::errors::Error::init)?;
 
-        // One streaming read either way: naming rows parses only those lines, a
-        // filter runs against each feature as it is parsed, and neither holds a
-        // feature the view will not render.
-        let selection = if !self.rows.is_empty() {
-            Selection::Rows(&self.rows)
-        } else if let Some(expr) = self.filter.as_deref() {
-            Selection::Filter {
+        // One streaming read either way: naming rows decodes only as far as the
+        // last of them, a filter runs against each feature as it is parsed, and
+        // neither holds a feature the view will not render.
+        let selection = match &self.shape {
+            Shape::Gltf { rows } => Selection::Rows(rows),
+            Shape::Cesium3DTiles {
+                filter: Some(expr), ..
+            } => Selection::Filter {
                 expr,
                 env_vars: Arc::new(serde_json::Map::new()),
-            }
-        } else {
-            Selection::All
+            },
+            Shape::Cesium3DTiles { filter: None, .. } => Selection::All,
         };
-        let scan_stopped_early = !self.rows.is_empty();
         let loaded = load_selected(&input, selection, &storage_resolver)
             .map_err(crate::errors::Error::run)?;
-        let selection = loaded.selection;
-        let total = if scan_stopped_early {
-            "requested".to_string()
-        } else {
-            loaded.scanned.to_string()
-        };
 
         let options = ViewOptions {
-            format: if self.format == "3dtiles" {
-                ViewFormat::Cesium3DTiles {
-                    max_zoom: self.max_zoom,
-                }
-            } else {
-                ViewFormat::Gltf
+            format: match &self.shape {
+                Shape::Gltf { .. } => ViewFormat::Gltf,
+                Shape::Cesium3DTiles { max_zoom, .. } => ViewFormat::Cesium3DTiles {
+                    max_zoom: *max_zoom,
+                },
             },
             draco: self.draco,
             texel_size: self.texel_size,
-            texture_codec: match self.texture_codec.as_str() {
-                "ktx2-etc1s" => TextureCodec::Ktx2Etc1s,
-                "ktx2-uastc" => TextureCodec::Ktx2Uastc,
-                "png" => TextureCodec::Png,
-                "untextured" => TextureCodec::Untextured,
-                _ => TextureCodec::Jpeg,
-            },
+            texture_codec: self.texture_codec,
             ..ViewOptions::default()
         };
 
-        let name = self.default_name(&input)?;
+        let name = self.name(&input)?;
         let destination = Destination {
             root: &output,
             prefix: name.as_str(),
             storage_resolver: &storage_resolver,
         };
 
-        let view = render(&selection, &options, &destination).map_err(crate::errors::Error::run)?;
+        let selected = loaded.selection.len();
+        let view =
+            render(&loaded.selection, &options, &destination).map_err(crate::errors::Error::run)?;
 
+        // A row scan stops at the highest row asked for, so its `scanned` is not
+        // the table's length and reporting it as one would mislead.
+        let out_of = match &self.shape {
+            Shape::Gltf { rows } => format!("{} requested", rows.len()),
+            Shape::Cesium3DTiles { .. } => format!("{} scanned", loaded.scanned),
+        };
         match view.entry_point {
             Some(entry_point) => println!(
-                "Rendered {} of {total} features into {} ({} file(s))",
-                selection.len(),
+                "Rendered {} of {selected} selected features ({out_of}) into {} ({} file(s))",
+                view.rendered_features,
                 entry_point.as_str(),
                 view.written.len()
             ),
             None => println!(
-                "None of the {} selected features (of {total}) carried renderable geometry; \
-                 nothing was written",
-                selection.len()
+                "None of the {selected} selected features ({out_of}) carried renderable \
+                 geometry; nothing was written"
             ),
         }
         Ok(())
@@ -235,20 +269,44 @@ impl ViewCliCommand {
 
     /// The output base name: what `--name` says, else the input file's name
     /// with its intermediate-data extension dropped.
-    fn default_name(&self, input: &reearth_flow_common::uri::Uri) -> crate::Result<String> {
+    fn name(&self, input: &Uri) -> crate::Result<String> {
         if let Some(name) = &self.name {
             return Ok(name.clone());
         }
-        let name = input
-            .file_name()
-            .and_then(|name| name.to_str().map(str::to_string))
-            .ok_or_else(|| {
-                crate::errors::Error::init(format!("{} has no file name", self.input))
-            })?;
-        let stem = name
-            .strip_suffix(".jsonl.zst")
-            .or_else(|| name.strip_suffix(".jsonl"))
-            .unwrap_or(name.as_str());
-        Ok(stem.to_string())
+        default_name(input)
+            .ok_or_else(|| crate::errors::Error::init(format!("{} has no file name", self.input)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(args: &[&str]) -> Result<ArgMatches, clap::Error> {
+        let mut argv = vec!["view", args[0], "--input", "in.jsonl", "--output", "out"];
+        argv.extend_from_slice(&args[1..]);
+        build_view_command().try_get_matches_from(argv)
+    }
+
+    /// Each shape takes its own selection argument and rejects the other's, so
+    /// an invalid pairing cannot reach the renderer.
+    #[test]
+    fn a_shape_takes_only_its_own_selection() {
+        assert!(parse(&["gltf", "--row", "1"]).is_ok());
+        assert!(parse(&["3dtiles", "--filter", "true"]).is_ok());
+        assert!(parse(&["3dtiles"]).is_ok(), "a tileset may take every row");
+
+        assert!(parse(&["gltf", "--filter", "true"]).is_err());
+        assert!(parse(&["3dtiles", "--row", "1"]).is_err());
+        assert!(parse(&["gltf"]).is_err(), "a glb needs the rows to render");
+    }
+
+    #[test]
+    fn rows_and_shape_survive_parsing() {
+        let matches = parse(&["gltf", "--row", "3", "--row", "1"]).expect("parses");
+        let command = ViewCliCommand::parse_cli_args(matches).expect("parses");
+
+        assert_eq!(command.shape, Shape::Gltf { rows: vec![3, 1] });
+        assert_eq!(command.texture_codec, TextureCodec::Jpeg);
     }
 }

--- a/engine/cli/src/view.rs
+++ b/engine/cli/src/view.rs
@@ -4,40 +4,38 @@ use std::sync::Arc;
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use reearth_flow_common::uri::Uri;
 use reearth_flow_feature_view::{
-    default_name, load_selected, render, Destination, Selection, TextureCodec, ViewFormat,
-    ViewOptions,
+    default_name, load_selected, render_feature, render_tileset, Destination, Selection,
+    TextureCodec, ViewOptions,
 };
 use reearth_flow_storage::resolve::StorageResolver;
 
 /// The `view` subcommand.
 ///
-/// Each shape takes only the selection it can act on: rows pick features out of
-/// the table for a glb, a filter narrows a whole edge for a tileset. They are
-/// separate subcommands so the other pairing cannot be spelled at all.
+/// Each shape takes only the selection it can act on: a row picks one feature
+/// out of the table for a glb, a filter narrows a whole edge for a tileset.
 pub fn build_view_command() -> Command {
     Command::new("view")
         .about("Render intermediate data into a viewable 3D form.")
         .long_about(
             "Read the intermediate-data JSONL a run left on an edge and render its features for \
-             a 3D viewer. `gltf` renders named rows into one glb, which is what showing a single \
-             feature or a handful wants; `3dtiles` renders a whole edge into a tiled tileset for \
-             looking at all of it at once.",
+             a 3D viewer. `gltf` renders one row into a glb, which is what showing a single \
+             feature wants; `3dtiles` renders a whole edge into a tiled tileset for looking at \
+             all of it at once.",
         )
         .subcommand_required(true)
         .arg_required_else_help(true)
         .subcommand(
             shared_args(Command::new("gltf"))
-                .about("Render the named rows into a single glb.")
+                .about("Render one row into a glb.")
                 .arg(
                     Arg::new("row")
                         .long("row")
                         .help(
                             "Row to render, 0-based, as numbered in the intermediate-data table. \
-                             Repeatable. This is the path behind clicking a table row: the scan \
-                             stops at the highest row named, and no other line is parsed.",
+                             This is the path behind clicking a table row: the scan stops there, \
+                             and no later line is read.",
                         )
                         .value_parser(clap::value_parser!(usize))
-                        .action(ArgAction::Append)
                         .required(true)
                         .display_order(4),
                 )
@@ -146,7 +144,7 @@ pub struct ViewCliCommand {
 #[derive(Debug, PartialEq)]
 enum Shape {
     Gltf {
-        rows: Vec<usize>,
+        row: usize,
     },
     Cesium3DTiles {
         filter: Option<String>,
@@ -161,10 +159,9 @@ impl ViewCliCommand {
             .ok_or(crate::errors::Error::init("No view shape provided"))?;
         let shape = match shape.as_str() {
             "gltf" => Shape::Gltf {
-                rows: matches
-                    .remove_many::<usize>("row")
-                    .map(|rows| rows.collect())
-                    .unwrap_or_default(),
+                row: matches
+                    .remove_one::<usize>("row")
+                    .ok_or(crate::errors::Error::init("No row provided"))?,
             },
             "3dtiles" => Shape::Cesium3DTiles {
                 filter: matches.remove_one::<String>("filter"),
@@ -206,35 +203,12 @@ impl ViewCliCommand {
         let input = Uri::from_str(self.input.as_str()).map_err(crate::errors::Error::init)?;
         let output = Uri::from_str(self.output.as_str()).map_err(crate::errors::Error::init)?;
 
-        // One streaming read either way: naming rows decodes only as far as the
-        // last of them, a filter runs against each feature as it is parsed, and
-        // neither holds a feature the view will not render.
-        let selection = match &self.shape {
-            Shape::Gltf { rows } => Selection::Rows(rows),
-            Shape::Cesium3DTiles {
-                filter: Some(expr), ..
-            } => Selection::Filter {
-                expr,
-                env_vars: Arc::new(serde_json::Map::new()),
-            },
-            Shape::Cesium3DTiles { filter: None, .. } => Selection::All,
-        };
-        let loaded = load_selected(&input, selection, &storage_resolver)
-            .map_err(crate::errors::Error::run)?;
-
         let options = ViewOptions {
-            format: match &self.shape {
-                Shape::Gltf { .. } => ViewFormat::Gltf,
-                Shape::Cesium3DTiles { max_zoom, .. } => ViewFormat::Cesium3DTiles {
-                    max_zoom: *max_zoom,
-                },
-            },
             draco: self.draco,
             texel_size: self.texel_size,
             texture_codec: self.texture_codec,
             ..ViewOptions::default()
         };
-
         let name = self.name(&input)?;
         let destination = Destination {
             root: &output,
@@ -242,27 +216,57 @@ impl ViewCliCommand {
             storage_resolver: &storage_resolver,
         };
 
-        let selected = loaded.selection.len();
-        let view =
-            render(&loaded.selection, &options, &destination).map_err(crate::errors::Error::run)?;
-
-        // A row scan stops at the highest row asked for, so its `scanned` is not
-        // the table's length and reporting it as one would mislead.
-        let out_of = match &self.shape {
-            Shape::Gltf { rows } => format!("{} requested", rows.len()),
-            Shape::Cesium3DTiles { .. } => format!("{} scanned", loaded.scanned),
-        };
-        match view.entry_point {
-            Some(entry_point) => println!(
-                "Rendered {} of {selected} selected features ({out_of}) into {} ({} file(s))",
-                view.rendered_features,
-                entry_point.as_str(),
-                view.written.len()
-            ),
-            None => println!(
-                "None of the {selected} selected features ({out_of}) carried renderable \
-                 geometry; nothing was written"
-            ),
+        // One streaming read either way: naming a row decodes only as far as
+        // it, a filter runs against each feature as it is parsed, and neither
+        // holds a feature the view will not render.
+        match &self.shape {
+            Shape::Gltf { row } => {
+                let loaded = load_selected(&input, Selection::Row(*row), &storage_resolver)
+                    .map_err(crate::errors::Error::run)?;
+                let Some(selected) = loaded.selection.first() else {
+                    println!("Row {row} is past the end of the table; nothing was written");
+                    return Ok(());
+                };
+                let view = render_feature(selected, &options, &destination)
+                    .map_err(crate::errors::Error::run)?;
+                match view.entry_point {
+                    Some(entry_point) => {
+                        println!("Rendered row {row} into {}", entry_point.as_str())
+                    }
+                    None => {
+                        println!("Row {row} carried no renderable geometry; nothing was written")
+                    }
+                }
+            }
+            Shape::Cesium3DTiles { filter, max_zoom } => {
+                let selection = match filter {
+                    Some(expr) => Selection::Filter {
+                        expr,
+                        env_vars: Arc::new(serde_json::Map::new()),
+                    },
+                    None => Selection::All,
+                };
+                let loaded = load_selected(&input, selection, &storage_resolver)
+                    .map_err(crate::errors::Error::run)?;
+                let selected = loaded.selection.len();
+                let view = render_tileset(&loaded.selection, *max_zoom, &options, &destination)
+                    .map_err(crate::errors::Error::run)?;
+                match view.entry_point {
+                    Some(entry_point) => println!(
+                        "Rendered {} of {selected} selected features ({} scanned) into {} \
+                         ({} file(s))",
+                        view.rendered_features,
+                        loaded.scanned,
+                        entry_point.as_str(),
+                        view.written.len()
+                    ),
+                    None => println!(
+                        "None of the {selected} selected features ({} scanned) carried \
+                         renderable geometry; nothing was written",
+                        loaded.scanned
+                    ),
+                }
+            }
         }
         Ok(())
     }
@@ -302,11 +306,16 @@ mod tests {
     }
 
     #[test]
-    fn rows_and_shape_survive_parsing() {
-        let matches = parse(&["gltf", "--row", "3", "--row", "1"]).expect("parses");
+    fn the_row_and_shape_survive_parsing() {
+        let matches = parse(&["gltf", "--row", "3"]).expect("parses");
         let command = ViewCliCommand::parse_cli_args(matches).expect("parses");
 
-        assert_eq!(command.shape, Shape::Gltf { rows: vec![3, 1] });
+        assert_eq!(command.shape, Shape::Gltf { row: 3 });
         assert_eq!(command.texture_codec, TextureCodec::Jpeg);
+
+        assert!(
+            parse(&["gltf", "--row", "3", "--row", "1"]).is_err(),
+            "a glb holds one row"
+        );
     }
 }

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/mod.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/mod.rs
@@ -273,6 +273,8 @@ pub fn build(
 /// drops into a georeferenced viewer unchanged.
 ///
 /// `Ok(None)` means the feature carried no renderable geometry.
+///
+// TODO: Relocate this after GltfWriter is implemented (for the new geometry)
 pub fn build_glb(
     feature: &Feature,
     options: MetadataOptions,

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/mod.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/mod.rs
@@ -264,44 +264,35 @@ pub fn build(
     })
 }
 
-/// An untiled glb and the count of features that reached it.
-pub struct BuiltGlb {
-    pub glb: Vec<u8>,
-    pub rendered_features: usize,
-}
-
-/// Render every feature into a single glb, untiled. Where [`build`] splits a
-/// whole dataset across a quadtree, this renders a hand-picked selection whole,
-/// which is what a viewer wants for one feature or a few.
+/// Render one feature into a glb, untiled. Where [`build`] splits a whole
+/// dataset across a quadtree, this renders a single picked feature, which is
+/// what a viewer wants when a table row is clicked.
 ///
 /// Positions are local to an origin chosen from the rendered geometry, carried
 /// on the scene node's translation exactly as tile content is, so the result
 /// drops into a georeferenced viewer unchanged.
 ///
-/// `Ok(None)` means no feature carried renderable geometry.
+/// `Ok(None)` means the feature carried no renderable geometry.
 pub fn build_glb(
-    features: &[Feature],
+    feature: &Feature,
     options: MetadataOptions,
     render: RenderOptions,
-) -> crate::errors::Result<Option<BuiltGlb>> {
+) -> crate::errors::Result<Option<Vec<u8>>> {
     let mut caches = mesh::ExtractCaches::default();
-    let extracted: Vec<(&Feature, mesh::ExtractedMesh)> = features
-        .iter()
-        .filter_map(|feature| mesh::extract(&feature.geometry, &mut caches).map(|m| (feature, m)))
-        .collect();
-
-    if extracted.is_empty() {
+    let Some(extracted) = mesh::extract(&feature.geometry, &mut caches) else {
         return Ok(None);
-    }
+    };
 
-    let members: Vec<&(&Feature, mesh::ExtractedMesh)> = extracted.iter().collect();
     let mut textures = TextureCache::default();
     let mut embedded = EmbeddedTextures::new()?;
-    let glb = build_cell_glb(&members, options, render, &mut textures, &mut embedded)?;
-    Ok(Some(BuiltGlb {
-        glb,
-        rendered_features: extracted.len(),
-    }))
+    build_cell_glb(
+        &[&(feature, extracted)],
+        options,
+        render,
+        &mut textures,
+        &mut embedded,
+    )
+    .map(Some)
 }
 
 fn empty_tileset() -> crate::errors::Result<BuiltTileset> {

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/mod.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/mod.rs
@@ -144,6 +144,8 @@ pub struct BuiltTileset {
     pub tileset_json: String,
     pub subtrees: Vec<(String, Vec<u8>)>,
     pub tile_count: usize,
+    /// Features that carried renderable geometry; the rest never reach a tile.
+    pub rendered_features: usize,
 }
 
 /// Rendering knobs shared by every cell of a tileset.
@@ -258,7 +260,14 @@ pub fn build(
         tileset_json: tileset_bytes,
         subtrees,
         tile_count,
+        rendered_features: extracted.len(),
     })
+}
+
+/// An untiled glb and the count of features that reached it.
+pub struct BuiltGlb {
+    pub glb: Vec<u8>,
+    pub rendered_features: usize,
 }
 
 /// Render every feature into a single glb, untiled. Where [`build`] splits a
@@ -274,7 +283,7 @@ pub fn build_glb(
     features: &[Feature],
     options: MetadataOptions,
     render: RenderOptions,
-) -> crate::errors::Result<Option<Vec<u8>>> {
+) -> crate::errors::Result<Option<BuiltGlb>> {
     let mut caches = mesh::ExtractCaches::default();
     let extracted: Vec<(&Feature, mesh::ExtractedMesh)> = features
         .iter()
@@ -288,7 +297,11 @@ pub fn build_glb(
     let members: Vec<&(&Feature, mesh::ExtractedMesh)> = extracted.iter().collect();
     let mut textures = TextureCache::default();
     let mut embedded = EmbeddedTextures::new()?;
-    build_cell_glb(&members, options, render, &mut textures, &mut embedded).map(Some)
+    let glb = build_cell_glb(&members, options, render, &mut textures, &mut embedded)?;
+    Ok(Some(BuiltGlb {
+        glb,
+        rendered_features: extracted.len(),
+    }))
 }
 
 fn empty_tileset() -> crate::errors::Result<BuiltTileset> {
@@ -309,6 +322,7 @@ fn empty_tileset() -> crate::errors::Result<BuiltTileset> {
         tileset_json: tileset_bytes,
         subtrees,
         tile_count: 0,
+        rendered_features: 0,
     })
 }
 

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/mod.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/mod.rs
@@ -261,6 +261,36 @@ pub fn build(
     })
 }
 
+/// Render every feature into a single glb, untiled. Where [`build`] splits a
+/// whole dataset across a quadtree, this renders a hand-picked selection whole,
+/// which is what a viewer wants for one feature or a few.
+///
+/// Positions are local to an origin chosen from the rendered geometry, carried
+/// on the scene node's translation exactly as tile content is, so the result
+/// drops into a georeferenced viewer unchanged.
+///
+/// `Ok(None)` means no feature carried renderable geometry.
+pub fn build_glb(
+    features: &[Feature],
+    options: MetadataOptions,
+    render: RenderOptions,
+) -> crate::errors::Result<Option<Vec<u8>>> {
+    let mut caches = mesh::ExtractCaches::default();
+    let extracted: Vec<(&Feature, mesh::ExtractedMesh)> = features
+        .iter()
+        .filter_map(|feature| mesh::extract(&feature.geometry, &mut caches).map(|m| (feature, m)))
+        .collect();
+
+    if extracted.is_empty() {
+        return Ok(None);
+    }
+
+    let members: Vec<&(&Feature, mesh::ExtractedMesh)> = extracted.iter().collect();
+    let mut textures = TextureCache::default();
+    let mut embedded = EmbeddedTextures::new()?;
+    build_cell_glb(&members, options, render, &mut textures, &mut embedded).map(Some)
+}
+
 fn empty_tileset() -> crate::errors::Result<BuiltTileset> {
     let root = GeoBox {
         west: 0.0,

--- a/engine/runtime/examples/fixture/workflow/examples/citygml3-reader/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/examples/citygml3-reader/workflow.yml
@@ -83,14 +83,15 @@ graphs:
             - tran:TrafficArea
             - frn:CityFurniture
 
-      # A CityGML feature carries every LOD it defines in one geometry
-      # collection. Splitting lifts each member's `lod` onto its own feature,
-      # so a consumer of this edge can select one LOD without re-reading the
-      # collection.
+      # PLATEAU CityGML 3 coordinates are in JGD2011 geographic (lat/lon/ellipsoidal-height).
+      # Shift ellipsoidal height → WGS84 orthometric height before tile output.
+      # Horizontal reprojection is not required: JGD2011 lat/lon ≈ WGS84 lat/lon for 3D tiles.
       - id: b1c2d3e4-f5a6-7890-bcde-f12345678901
-        name: GeometrySplitter
+        name: VerticalReprojector
         type: action
-        action: Geometry Splitter
+        action: Vertical Reprojector
+        with:
+          reprojectorType: jgd2011ToWgs84
 
       - id: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b
         name: Cesium3DTilesWriter

--- a/engine/runtime/examples/fixture/workflow/examples/citygml3-reader/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/examples/citygml3-reader/workflow.yml
@@ -83,15 +83,14 @@ graphs:
             - tran:TrafficArea
             - frn:CityFurniture
 
-      # PLATEAU CityGML 3 coordinates are in JGD2011 geographic (lat/lon/ellipsoidal-height).
-      # Shift ellipsoidal height → WGS84 orthometric height before tile output.
-      # Horizontal reprojection is not required: JGD2011 lat/lon ≈ WGS84 lat/lon for 3D tiles.
+      # A CityGML feature carries every LOD it defines in one geometry
+      # collection. Splitting lifts each member's `lod` onto its own feature,
+      # so a consumer of this edge can select one LOD without re-reading the
+      # collection.
       - id: b1c2d3e4-f5a6-7890-bcde-f12345678901
-        name: VerticalReprojector
+        name: GeometrySplitter
         type: action
-        action: Vertical Reprojector
-        with:
-          reprojectorType: jgd2011ToWgs84
+        action: Geometry Splitter
 
       - id: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b
         name: Cesium3DTilesWriter

--- a/engine/runtime/feature-view/Cargo.toml
+++ b/engine/runtime/feature-view/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+description = "Re:Earth Flow feature view builder"
+name = "reearth-flow-feature-view"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+# The view builders read the geometry these features select, so this crate only
+# exists in that world and turns them on rather than forwarding a flag of its
+# own. Cargo unifies features across a build, so depending on this crate pulls
+# every dependent into the same world; keep it an optional dependency of
+# anything that still builds both.
+reearth-flow-action-sink = { workspace = true, features = ["new-geometry"] }
+reearth-flow-common.workspace = true
+reearth-flow-geometry = { workspace = true, features = ["new-geometry"] }
+reearth-flow-storage.workspace = true
+reearth-flow-types = { workspace = true, features = ["new-geometry"] }
+
+bytes.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+zstd.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/engine/runtime/feature-view/Cargo.toml
+++ b/engine/runtime/feature-view/Cargo.toml
@@ -13,11 +13,6 @@ version.workspace = true
 [features]
 # Temporary migration flag for the new-geometry migration.
 # TODO: Remove after migration.
-#
-# The view builders read the geometry this flag selects, so the crate compiles
-# to nothing without it. It is forwarded rather than turned on unconditionally
-# because Cargo unifies features across a build: enabling it here would flip
-# every crate built alongside this one.
 new-geometry = [
   "reearth-flow-action-sink/new-geometry",
   "reearth-flow-geometry/new-geometry",

--- a/engine/runtime/feature-view/Cargo.toml
+++ b/engine/runtime/feature-view/Cargo.toml
@@ -27,6 +27,7 @@ new-geometry = [
 [dependencies]
 reearth-flow-action-sink.workspace = true
 reearth-flow-common.workspace = true
+reearth-flow-expr.workspace = true
 reearth-flow-geometry.workspace = true
 reearth-flow-storage.workspace = true
 reearth-flow-types.workspace = true

--- a/engine/runtime/feature-view/Cargo.toml
+++ b/engine/runtime/feature-view/Cargo.toml
@@ -10,17 +10,26 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[features]
+# Temporary migration flag for the new-geometry migration.
+# TODO: Remove after migration.
+#
+# The view builders read the geometry this flag selects, so the crate compiles
+# to nothing without it. It is forwarded rather than turned on unconditionally
+# because Cargo unifies features across a build: enabling it here would flip
+# every crate built alongside this one.
+new-geometry = [
+  "reearth-flow-action-sink/new-geometry",
+  "reearth-flow-geometry/new-geometry",
+  "reearth-flow-types/new-geometry",
+]
+
 [dependencies]
-# The view builders read the geometry these features select, so this crate only
-# exists in that world and turns them on rather than forwarding a flag of its
-# own. Cargo unifies features across a build, so depending on this crate pulls
-# every dependent into the same world; keep it an optional dependency of
-# anything that still builds both.
-reearth-flow-action-sink = { workspace = true, features = ["new-geometry"] }
+reearth-flow-action-sink.workspace = true
 reearth-flow-common.workspace = true
-reearth-flow-geometry = { workspace = true, features = ["new-geometry"] }
+reearth-flow-geometry.workspace = true
 reearth-flow-storage.workspace = true
-reearth-flow-types = { workspace = true, features = ["new-geometry"] }
+reearth-flow-types.workspace = true
 
 bytes.workspace = true
 serde_json.workspace = true

--- a/engine/runtime/feature-view/src/lib.rs
+++ b/engine/runtime/feature-view/src/lib.rs
@@ -8,11 +8,12 @@
 // The whole crate is new-geometry only; see Cargo.toml.
 #![cfg(feature = "new-geometry")]
 
-use std::borrow::Cow;
 use std::collections::BTreeSet;
-use std::sync::Arc;
+use std::io::{BufRead, BufReader};
+use std::sync::{Arc, Mutex, PoisonError};
 
 use bytes::Bytes;
+use reearth_flow_action_sink::errors::SinkError;
 use reearth_flow_action_sink::file::cesium3dtiles::next::{
     build, build_glb, MetadataOptions, RenderOptions,
 };
@@ -20,7 +21,9 @@ use reearth_flow_action_sink::SinkOutput;
 use reearth_flow_common::uri::Uri;
 use reearth_flow_geometry::Geometry;
 use reearth_flow_storage::resolve::StorageResolver;
-use reearth_flow_types::{Attribute, AttributeValue, Attributes, Code, CodeType, Feature};
+use reearth_flow_types::{
+    Attribute, AttributeValue, Attributes, Code, CodeType, CompiledCode, Feature,
+};
 use thiserror::Error as ThisError;
 
 pub use reearth_flow_action_sink::file::cesium3dtiles::next::TextureCodec;
@@ -33,6 +36,20 @@ const FEATURE_EXTENSIONS: [&str; 2] = [".jsonl.zst", ".jsonl"];
 /// the table its file came from.
 pub const ROW_INDEX_PROPERTY: &str = "rowIndex";
 
+/// The base name a view takes from its input: the file name with the
+/// intermediate-data extension dropped.
+pub fn default_name(input: &Uri) -> Option<String> {
+    let name = input.file_name()?.to_str()?;
+    Some(strip_feature_extension(name).to_string())
+}
+
+fn strip_feature_extension(name: &str) -> &str {
+    FEATURE_EXTENSIONS
+        .iter()
+        .find_map(|ext| name.strip_suffix(ext))
+        .unwrap_or(name)
+}
+
 #[derive(ThisError, Debug)]
 pub enum Error {
     #[error("Failed to read features from {uri}: {source}")]
@@ -41,16 +58,23 @@ pub enum Error {
         #[source]
         source: std::io::Error,
     },
-    #[error("Filter expression {expr:?} failed to compile: {message}")]
-    FilterCompile { expr: String, message: String },
-    #[error("Filter expression {expr:?} failed on feature {feature_id}: {message}")]
+    #[error("Filter expression {expr:?} failed to compile: {source}")]
+    FilterCompile {
+        expr: String,
+        #[source]
+        source: reearth_flow_expr::Error,
+    },
+    #[error("Filter expression {expr:?} failed on feature {feature_id}: {source}")]
     FilterEval {
         expr: String,
         feature_id: String,
-        message: String,
+        #[source]
+        source: reearth_flow_types::error::Error,
     },
     #[error("Failed to render the view: {0}")]
-    Render(String),
+    Render(#[from] SinkError),
+    #[error("Views of 2D geometry are not supported yet")]
+    TwoDimensional,
     #[error("Failed to write {path}: {source}")]
     Write {
         path: String,
@@ -124,50 +148,12 @@ impl ViewOptions {
         MetadataOptions {
             schema_key: None,
             skip_unexposed_attributes: false,
+            array_map_separator: None,
         }
     }
 }
 
-/// Where a view's files land: every path is `prefix` joined under `root`.
-pub struct Destination<'a> {
-    pub root: &'a Uri,
-    /// A glTF view writes `{prefix}.glb`; a tileset writes
-    /// `{prefix}/tileset.json` alongside its content and subtree files.
-    pub prefix: &'a str,
-    pub storage_resolver: &'a StorageResolver,
-}
-
-impl Destination<'_> {
-    fn write(&self, relative_path: &str, bytes: Vec<u8>) -> Result<Uri> {
-        let out =
-            SinkOutput::new(self.root, relative_path, self.storage_resolver).map_err(|source| {
-                Error::Write {
-                    path: relative_path.to_string(),
-                    source,
-                }
-            })?;
-        let uri = out.uri().clone();
-        out.write(Bytes::from(bytes))
-            .map_err(|source| Error::Write {
-                path: relative_path.to_string(),
-                source,
-            })?;
-        Ok(uri)
-    }
-}
-
-/// What a render produced.
-#[derive(Debug)]
-pub struct RenderedView {
-    pub rendered_features: usize,
-    /// The entry point a viewer opens: the glb, or the tileset's
-    /// `tileset.json`.
-    pub entry_point: Option<Uri>,
-    /// Every file written, the entry point included.
-    pub written: Vec<Uri>,
-}
-
-/// A selected feature and the line it came from.
+/// A selected feature, as it was read, and the line it came from.
 #[derive(Clone, Debug)]
 pub struct Selected {
     /// 0-based line in the file, which is the row a table shows it at. Survives
@@ -196,91 +182,125 @@ pub struct Loaded {
     pub scanned: usize,
 }
 
+/// A [`Selection`] with its per-line work done up front: the filter compiled,
+/// the rows sorted and their last one found. Holding them in the value the loop
+/// matches on leaves no separate state to keep in step with it.
+enum Scan<'a> {
+    All,
+    Rows {
+        wanted: BTreeSet<usize>,
+        last: usize,
+    },
+    Filter {
+        expr: &'a str,
+        code: CompiledCode,
+        env_vars: Arc<serde_json::Map<String, serde_json::Value>>,
+    },
+}
+
+impl<'a> Scan<'a> {
+    /// `None` when the selection can keep nothing, so there is nothing to read.
+    fn prepare(selection: Selection<'a>) -> Result<Option<Self>> {
+        Ok(match selection {
+            Selection::All => Some(Scan::All),
+            Selection::Rows(rows) => {
+                let wanted: BTreeSet<usize> = rows.iter().copied().collect();
+                let last = wanted.iter().next_back().copied();
+                last.map(|last| Scan::Rows { wanted, last })
+            }
+            Selection::Filter { expr, env_vars } => {
+                let code = Code::<{ CodeType::FlowExpr as u32 }> {
+                    ty: CodeType::FlowExpr,
+                    value: expr.to_string(),
+                };
+                Some(Scan::Filter {
+                    code: code.compile().map_err(|source| Error::FilterCompile {
+                        expr: expr.to_string(),
+                        source,
+                    })?,
+                    expr,
+                    env_vars,
+                })
+            }
+        })
+    }
+
+    /// Whether `row` is the last one this scan has any reason to read.
+    fn stops_at(&self, row: usize) -> bool {
+        matches!(self, Scan::Rows { last, .. } if *last == row)
+    }
+}
+
 /// Read a feature file, keeping only what `selection` asks for.
 ///
-/// One line at a time: a line that is not kept is dropped before the next is
-/// read, and a kept one has its attributes swapped for the row index at once,
-/// so peak memory tracks surviving geometry rather than the file. Rows past the
-/// end are ignored, so a stale table selection yields an empty view.
+/// Lines are decompressed and parsed one at a time and dropped unless kept, so
+/// the decompressed file is never held whole, and [`Selection::Rows`] stops at
+/// its highest row rather than decoding the rest. The compressed bytes are read
+/// whole, which is what the storage backends offer. Rows past the end are
+/// ignored, so a stale table selection yields an empty view.
 pub fn load_selected(
     input: &Uri,
     selection: Selection<'_>,
     storage_resolver: &StorageResolver,
 ) -> Result<Loaded> {
-    let compiled = match &selection {
-        Selection::Filter { expr, .. } => {
-            let code = Code::<{ CodeType::FlowExpr as u32 }> {
-                ty: CodeType::FlowExpr,
-                value: expr.to_string(),
-            };
-            Some(code.compile().map_err(|e| Error::FilterCompile {
-                expr: expr.to_string(),
-                message: format!("{e:?}"),
-            })?)
-        }
-        _ => None,
-    };
-
-    let wanted: BTreeSet<usize> = match &selection {
-        Selection::Rows(rows) => rows.iter().copied().collect(),
-        _ => BTreeSet::new(),
-    };
-    if matches!(selection, Selection::Rows(_)) && wanted.is_empty() {
+    let Some(scan) = Scan::prepare(selection)? else {
         return Ok(Loaded {
             selection: Vec::new(),
             scanned: 0,
         });
-    }
-    let last_wanted = wanted.iter().next_back().copied();
-
-    let (uri, raw) = read_raw(input, storage_resolver)?;
-    let data = decode_auto(raw.as_ref()).map_err(|source| Error::Read {
-        uri: uri.as_str().to_string(),
-        source,
-    })?;
-
-    let parse = |line: &[u8], row: usize| -> Result<Feature> {
-        serde_json::from_slice(line).map_err(|e| Error::Read {
-            uri: uri.as_str().to_string(),
-            source: std::io::Error::other(format!("row {row}: {e}")),
-        })
     };
 
+    let (uri, raw) = read_raw(input, storage_resolver)?;
+    let read_error = |source: std::io::Error| Error::Read {
+        uri: uri.as_str().to_string(),
+        source,
+    };
+    let parse = |line: &[u8], row: usize| -> Result<Feature> {
+        serde_json::from_slice(line)
+            .map_err(|e| read_error(std::io::Error::other(format!("row {row}: {e}"))))
+    };
+
+    let mut lines = line_reader(raw.as_ref()).map_err(read_error)?;
     let mut kept = Vec::new();
     let mut row = 0usize;
-    for line in data.split(|&b| b == b'\n') {
-        let line = trim_ascii(line);
+    let mut buffer = Vec::new();
+    loop {
+        buffer.clear();
+        if lines.read_until(b'\n', &mut buffer).map_err(read_error)? == 0 {
+            break;
+        }
+        let line = buffer.trim_ascii();
         if line.is_empty() {
             continue;
         }
-        let keep = match &selection {
-            Selection::All => Some(parse(line, row)?),
-            Selection::Rows(_) => match wanted.contains(&row) {
+        let keep = match &scan {
+            Scan::All => Some(parse(line, row)?),
+            Scan::Rows { wanted, .. } => match wanted.contains(&row) {
                 true => Some(parse(line, row)?),
                 false => None,
             },
-            Selection::Filter { expr, env_vars } => {
+            Scan::Filter {
+                expr,
+                code,
+                env_vars,
+            } => {
                 let feature = parse(line, row)?;
-                let matched = compiled
-                    .as_ref()
-                    .expect("a filter selection compiled its expression")
+                let matched = code
                     .eval_bool(&feature, Arc::clone(env_vars))
-                    .map_err(|e| Error::FilterEval {
+                    .map_err(|source| Error::FilterEval {
                         expr: expr.to_string(),
                         feature_id: feature.id.to_string(),
-                        message: format!("{e:?}"),
+                        source,
                     })?;
                 matched.then_some(feature)
             }
         };
         if let Some(feature) = keep {
-            kept.push(Selected {
-                row,
-                feature: feature.with_attributes(row_index_attributes(row)),
-            });
+            kept.push(Selected { row, feature });
         }
+        let done = scan.stops_at(row);
         row += 1;
-        if Some(row - 1) == last_wanted {
+        if done {
             break;
         }
     }
@@ -293,28 +313,10 @@ pub fn load_selected(
 
 /// Read the named file, or its counterpart in the other feature-file extension.
 fn read_raw(input: &Uri, storage_resolver: &StorageResolver) -> Result<(Uri, Bytes)> {
-    let mut candidates = vec![input.clone()];
-    if let (Some(name), Some(dir)) = (
-        input
-            .file_name()
-            .and_then(|n| n.to_str().map(str::to_string)),
-        input.parent(),
-    ) {
-        let stem = FEATURE_EXTENSIONS
-            .iter()
-            .find_map(|ext| name.strip_suffix(ext))
-            .unwrap_or(name.as_str());
-        for ext in FEATURE_EXTENSIONS {
-            if let Ok(candidate) = dir.join(format!("{stem}{ext}")) {
-                if candidate.as_str() != input.as_str() {
-                    candidates.push(candidate);
-                }
-            }
-        }
-    }
-
-    let mut last: Option<std::io::Error> = None;
-    for candidate in candidates {
+    // Report the failure for the file that was actually asked for; the
+    // counterpart extension is a fallback, and its error only distracts.
+    let mut asked_for: Option<std::io::Error> = None;
+    for candidate in read_candidates(input) {
         let read = storage_resolver
             .resolve(&candidate)
             .map_err(std::io::Error::other)
@@ -325,48 +327,94 @@ fn read_raw(input: &Uri, storage_resolver: &StorageResolver) -> Result<(Uri, Byt
             });
         match read {
             Ok(bytes) => return Ok((candidate, bytes)),
-            Err(e) => last = Some(e),
+            Err(e) => asked_for = asked_for.or(Some(e)),
         }
     }
     Err(Error::Read {
         uri: input.as_str().to_string(),
-        source: last.unwrap_or_else(|| std::io::Error::other("no candidate jsonl found")),
+        source: asked_for.unwrap_or_else(|| std::io::Error::other("no candidate jsonl found")),
     })
 }
 
-/// zstd frame magic is `28 B5 2F FD`; anything else is already plain text.
-fn decode_auto(bytes: &[u8]) -> std::io::Result<Cow<'_, [u8]>> {
+/// `input` itself, then the same stem under every other feature-file extension.
+fn read_candidates(input: &Uri) -> Vec<Uri> {
+    let mut candidates = vec![input.clone()];
+    let (Some(name), Some(dir)) = (
+        input
+            .file_name()
+            .and_then(|n| n.to_str().map(str::to_string)),
+        input.parent(),
+    ) else {
+        return candidates;
+    };
+    let stem = strip_feature_extension(&name);
+    for ext in FEATURE_EXTENSIONS {
+        if let Ok(candidate) = dir.join(format!("{stem}{ext}")) {
+            if candidate.as_str() != input.as_str() {
+                candidates.push(candidate);
+            }
+        }
+    }
+    candidates
+}
+
+/// Lines of `bytes`, decompressing as it goes if they are a zstd frame (magic
+/// `28 B5 2F FD`); anything else is already plain text.
+fn line_reader(bytes: &[u8]) -> std::io::Result<Box<dyn BufRead + '_>> {
     if bytes.starts_with(&[0x28, 0xB5, 0x2F, 0xFD]) {
-        zstd::stream::decode_all(bytes).map(Cow::Owned)
+        Ok(Box::new(BufReader::new(zstd::stream::read::Decoder::new(
+            bytes,
+        )?)))
     } else {
-        Ok(Cow::Borrowed(bytes))
+        Ok(Box::new(bytes))
     }
 }
 
-fn trim_ascii(mut line: &[u8]) -> &[u8] {
-    while let [first, rest @ ..] = line {
-        if !first.is_ascii_whitespace() {
-            break;
-        }
-        line = rest;
-    }
-    while let [rest @ .., last] = line {
-        if !last.is_ascii_whitespace() {
-            break;
-        }
-        line = rest;
-    }
-    line
+/// Where a view's files land: every path is `prefix` joined under `root`.
+pub struct Destination<'a> {
+    pub root: &'a Uri,
+    /// A glTF view writes `{prefix}.glb`; a tileset writes
+    /// `{prefix}/tileset.json` alongside its content and subtree files.
+    pub prefix: &'a str,
+    pub storage_resolver: &'a StorageResolver,
 }
 
-/// The single-entry attribute set a rendered feature carries.
-fn row_index_attributes(row: usize) -> Attributes {
-    let mut attributes = Attributes::new();
-    attributes.insert(
-        Attribute::new(ROW_INDEX_PROPERTY),
-        AttributeValue::Number(row.into()),
-    );
-    attributes
+impl Destination<'_> {
+    /// Write `{prefix}{suffix}`, for a shape whose whole output is one file.
+    fn write_suffixed(&self, suffix: &str, bytes: Vec<u8>) -> Result<Uri> {
+        self.write_path(&format!("{}{suffix}", self.prefix), bytes)
+    }
+
+    /// Write `{prefix}/{relative_path}`, for a shape that writes a directory.
+    fn write_under(&self, relative_path: &str, bytes: Vec<u8>) -> Result<Uri> {
+        self.write_path(&format!("{}/{relative_path}", self.prefix), bytes)
+    }
+
+    fn write_path(&self, path: &str, bytes: Vec<u8>) -> Result<Uri> {
+        let write = || {
+            let out = SinkOutput::new(self.root, path, self.storage_resolver)?;
+            let uri = out.uri().clone();
+            out.write(Bytes::from(bytes))?;
+            Ok::<_, Box<dyn std::error::Error + Send + Sync>>(uri)
+        };
+        write().map_err(|source| Error::Write {
+            path: path.to_string(),
+            source,
+        })
+    }
+}
+
+/// What a render produced.
+#[derive(Debug)]
+pub struct RenderedView {
+    /// Selected features that carried renderable geometry; the rest are absent
+    /// from the output.
+    pub rendered_features: usize,
+    /// The entry point a viewer opens: the glb, or the tileset's
+    /// `tileset.json`.
+    pub entry_point: Option<Uri>,
+    /// Every file written, the entry point included.
+    pub written: Vec<Uri>,
 }
 
 /// Render the selection and write it to `destination`.
@@ -375,11 +423,11 @@ pub fn render(
     options: &ViewOptions,
     destination: &Destination<'_>,
 ) -> Result<RenderedView> {
+    reject_two_dimensional(selection)?;
     let features: Vec<Feature> = selection
         .iter()
         .map(|s| s.feature.with_attributes(row_index_attributes(s.row)))
         .collect();
-    reject_two_dimensional(&features);
 
     match options.format {
         ViewFormat::Gltf => render_gltf(&features, options, destination),
@@ -394,14 +442,12 @@ fn render_gltf(
     options: &ViewOptions,
     destination: &Destination<'_>,
 ) -> Result<RenderedView> {
-    let glb = build_glb(
+    let Some(glb) = build_glb(
         features,
         options.metadata_options(),
         options.render_options(),
-    )
-    .map_err(|e| Error::Render(format!("{e:?}")))?;
-
-    let Some(glb) = glb else {
+    )?
+    else {
         return Ok(RenderedView {
             rendered_features: 0,
             entry_point: None,
@@ -409,9 +455,9 @@ fn render_gltf(
         });
     };
 
-    let uri = destination.write(&format!("{}.glb", destination.prefix), glb)?;
+    let uri = destination.write_suffixed(".glb", glb.glb)?;
     Ok(RenderedView {
-        rendered_features: features.len(),
+        rendered_features: glb.rendered_features,
         entry_point: Some(uri.clone()),
         written: vec![uri],
     })
@@ -425,7 +471,7 @@ fn render_tileset(
 ) -> Result<RenderedView> {
     // Content glbs are handed over as they are built, so peak memory stays at
     // one tile rather than the whole tileset; collect only their paths.
-    let written = std::sync::Mutex::new(Vec::new());
+    let written = Mutex::new(Vec::new());
     let built = build(
         features,
         options.metadata_options(),
@@ -433,41 +479,48 @@ fn render_tileset(
         options.render_options(),
         |relative_path, bytes| {
             let uri = destination
-                .write(&format!("{}/{relative_path}", destination.prefix), bytes)
-                .map_err(|e| {
-                    reearth_flow_action_sink::errors::SinkError::Cesium3DTilesWriter(format!("{e}"))
-                })?;
+                .write_under(&relative_path, bytes)
+                .map_err(|e| SinkError::Cesium3DTilesWriter(format!("{e}")))?;
             written
                 .lock()
-                .expect("write log is never poisoned")
+                .unwrap_or_else(PoisonError::into_inner)
                 .push(uri);
             Ok(())
         },
-    )
-    .map_err(|e| Error::Render(format!("{e:?}")))?;
-
-    let mut written = written.into_inner().expect("write log is never poisoned");
-    for (relative_path, bytes) in built.subtrees {
-        written.push(destination.write(&format!("{}/{relative_path}", destination.prefix), bytes)?);
-    }
-    let entry_point = destination.write(
-        &format!("{}/tileset.json", destination.prefix),
-        built.tileset_json.into_bytes(),
     )?;
+
+    let mut written = written.into_inner().unwrap_or_else(PoisonError::into_inner);
+    for (relative_path, bytes) in built.subtrees {
+        written.push(destination.write_under(&relative_path, bytes)?);
+    }
+    let entry_point = destination.write_under("tileset.json", built.tileset_json.into_bytes())?;
     written.push(entry_point.clone());
 
     Ok(RenderedView {
-        rendered_features: features.len(),
+        rendered_features: built.rendered_features,
         entry_point: Some(entry_point),
         written,
     })
 }
 
-/// 2D has no view yet. Reaching it is a caller error rather than an empty
-/// render, so say so instead of writing a file with nothing in it.
-fn reject_two_dimensional(features: &[Feature]) {
-    if features.iter().any(|f| holds_two_dimensional(&f.geometry)) {
-        unimplemented!("feature views of 2D geometry");
+/// The single-entry attribute set a rendered feature carries.
+fn row_index_attributes(row: usize) -> Attributes {
+    let mut attributes = Attributes::new();
+    attributes.insert(
+        Attribute::new(ROW_INDEX_PROPERTY),
+        AttributeValue::Number(row.into()),
+    );
+    attributes
+}
+
+/// 2D has no view yet, so say so instead of writing a file with nothing in it.
+fn reject_two_dimensional(selection: &[Selected]) -> Result<()> {
+    match selection
+        .iter()
+        .any(|s| holds_two_dimensional(&s.feature.geometry))
+    {
+        true => Err(Error::TwoDimensional),
+        false => Ok(()),
     }
 }
 
@@ -487,8 +540,9 @@ mod tests {
 
     use reearth_flow_geometry::collection::Collection3D;
     use reearth_flow_geometry::coordinate::{CoordinateFrame, EpsgCode};
+    use reearth_flow_geometry::point::Point2D;
     use reearth_flow_geometry::triangular_mesh::TriangularMesh3D;
-    use reearth_flow_geometry::Euclidean3DGeometry;
+    use reearth_flow_geometry::{Euclidean2DGeometry, Euclidean3DGeometry};
 
     use super::*;
 
@@ -549,6 +603,95 @@ mod tests {
     fn glb_json(bytes: &[u8]) -> serde_json::Value {
         let len = u32::from_le_bytes(bytes[12..16].try_into().unwrap()) as usize;
         serde_json::from_slice(&bytes[20..20 + len]).unwrap()
+    }
+
+    /// The compressed form reads like the plain one, is found under either
+    /// extension, and a row selection decodes no further than it must.
+    #[test]
+    fn a_compressed_file_reads_by_row() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let features: Vec<Feature> = (0..4).map(|i| mesh_feature("k", 35.0 + i as f64)).collect();
+        let lines: Vec<String> = features
+            .iter()
+            .map(|f| serde_json::to_string(f).expect("a feature serializes"))
+            .collect();
+        std::fs::write(
+            dir.path().join("node.default.jsonl.zst"),
+            zstd::stream::encode_all(lines.join("\n").as_bytes(), 0).expect("compress"),
+        )
+        .expect("write features");
+        let resolver = StorageResolver::new();
+
+        let compressed = Uri::for_test(&format!(
+            "file://{}/node.default.jsonl.zst",
+            dir.path().display()
+        ));
+        let loaded = load_selected(&compressed, Selection::Rows(&[1]), &resolver).expect("rows");
+        assert_eq!(
+            loaded.selection.iter().map(|s| s.row).collect::<Vec<_>>(),
+            vec![1]
+        );
+        assert_eq!(loaded.selection[0].feature.id, features[1].id);
+        assert_eq!(loaded.scanned, 2, "the scan stops at the row it asked for");
+
+        let plain = Uri::for_test(&format!(
+            "file://{}/node.default.jsonl",
+            dir.path().display()
+        ));
+        let by_plain_name = load_selected(&plain, Selection::Rows(&[1]), &resolver)
+            .expect("the compressed file stands in for the plain name");
+        assert_eq!(by_plain_name.selection[0].feature.id, features[1].id);
+    }
+
+    /// A feature the renderer cannot use is dropped, and the count says so
+    /// rather than reporting everything selected.
+    #[test]
+    fn the_count_is_of_features_that_reached_the_glb() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let selection = [
+            Selected {
+                row: 0,
+                feature: Feature::from(Attributes::new()),
+            },
+            Selected {
+                row: 1,
+                feature: mesh_feature("k", 35.0),
+            },
+        ];
+        let view = render_to(dir.path(), &selection, &ViewOptions::default());
+
+        assert_eq!(view.rendered_features, 1);
+    }
+
+    /// 2D is not renderable yet, and saying so is an error rather than a panic.
+    #[test]
+    fn a_two_dimensional_selection_is_rejected() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let root = Uri::for_test(&format!("file://{}", dir.path().display()));
+        let resolver = StorageResolver::new();
+        let selection = [Selected {
+            row: 0,
+            feature: feature(
+                "k",
+                Geometry::Euclidean2D(Euclidean2DGeometry::Point(Point2D::new(
+                    CoordinateFrame::Euclidean,
+                    [0.0, 0.0],
+                ))),
+            ),
+        }];
+
+        let error = render(
+            &selection,
+            &ViewOptions::default(),
+            &Destination {
+                root: &root,
+                prefix: "out",
+                storage_resolver: &resolver,
+            },
+        )
+        .expect_err("2D has no view");
+
+        assert!(matches!(error, Error::TwoDimensional));
     }
 
     /// Every selection mode must agree on what row N is, and a filter must not

--- a/engine/runtime/feature-view/src/lib.rs
+++ b/engine/runtime/feature-view/src/lib.rs
@@ -5,6 +5,9 @@
 //! features carry no attributes, only [`ROW_INDEX_PROPERTY`], so a click in a
 //! viewer resolves to a row in the table the file came from.
 
+// The whole crate is new-geometry only; see Cargo.toml.
+#![cfg(feature = "new-geometry")]
+
 use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::sync::Arc;

--- a/engine/runtime/feature-view/src/lib.rs
+++ b/engine/runtime/feature-view/src/lib.rs
@@ -1,14 +1,13 @@
 //! Renders a viewable form of the features a run leaves on an edge.
 //!
-//! The input is one JSONL file. The output is either a single glb holding the
-//! whole selection, or a 3D Tiles tileset for streaming a whole edge. Rendered
-//! features carry no attributes, only [`ROW_INDEX_PROPERTY`], so a click in a
-//! viewer resolves to a row in the table the file came from.
+//! The input is one JSONL file. The output is either a glb holding one picked
+//! feature, or a 3D Tiles tileset for streaming a whole edge. Rendered features
+//! carry no attributes, only [`ROW_INDEX_PROPERTY`], so a click in a viewer
+//! resolves to a row in the table the file came from.
 
 // The whole crate is new-geometry only; see Cargo.toml.
 #![cfg(feature = "new-geometry")]
 
-use std::collections::BTreeSet;
 use std::io::{BufRead, BufReader};
 use std::sync::{Arc, Mutex, PoisonError};
 
@@ -85,25 +84,10 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Which of the two view shapes to render.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum ViewFormat {
-    /// One glb holding the whole selection, untiled.
-    #[default]
-    Gltf,
-    /// A 3D Tiles tileset, for streaming a whole edge.
-    Cesium3DTiles {
-        /// Deepest quadtree level a feature may be placed at.
-        max_zoom: u8,
-    },
-}
-
-/// How to render, independent of which shape is being rendered.
+/// How to render, shared by both view shapes.
 #[derive(Clone, Debug)]
 pub struct ViewOptions {
-    pub format: ViewFormat,
-    /// Draco mesh compression. On by default: it costs about 2% of render time
-    /// and cuts a glb several-fold.
+    /// Draco mesh compression. On by default.
     pub draco: bool,
     /// Per-polygon flat normals, so surfaces light rather than read flat.
     pub compute_flat_normal: bool,
@@ -111,15 +95,13 @@ pub struct ViewOptions {
     pub texel_size: f64,
     pub atlas_size: u32,
     pub atlas_extrusion: u32,
-    /// JPEG by default rather than the tile writer's KTX2: a view is built on
-    /// demand, and JPEG encodes several times faster at a comparable size.
+    /// JPEG by default: a view is built on demand, so we need fast encoding.
     pub texture_codec: TextureCodec,
 }
 
 impl Default for ViewOptions {
     fn default() -> Self {
         Self {
-            format: ViewFormat::default(),
             draco: true,
             compute_flat_normal: true,
             texel_size: 0.0,
@@ -165,8 +147,9 @@ pub struct Selected {
 /// Which features a read keeps.
 pub enum Selection<'a> {
     All,
-    /// The scan stops after the highest row, and no other line is parsed.
-    Rows(&'a [usize]),
+    /// One row, for a glTF view. The scan stops there, and no later line is
+    /// read at all.
+    Row(usize),
     /// The features a Flow expression evaluates true for.
     Filter {
         expr: &'a str,
@@ -178,19 +161,16 @@ pub enum Selection<'a> {
 pub struct Loaded {
     pub selection: Vec<Selected>,
     /// Non-empty lines examined; short of the file's total under
-    /// [`Selection::Rows`], which stops early.
+    /// [`Selection::Row`], which stops early.
     pub scanned: usize,
 }
 
-/// A [`Selection`] with its per-line work done up front: the filter compiled,
-/// the rows sorted and their last one found. Holding them in the value the loop
-/// matches on leaves no separate state to keep in step with it.
+/// A [`Selection`] with its per-line work done up front: the filter compiled.
+/// Holding it in the value the loop matches on leaves no separate state to keep
+/// in step with it.
 enum Scan<'a> {
     All,
-    Rows {
-        wanted: BTreeSet<usize>,
-        last: usize,
-    },
+    Row(usize),
     Filter {
         expr: &'a str,
         code: CompiledCode,
@@ -199,56 +179,46 @@ enum Scan<'a> {
 }
 
 impl<'a> Scan<'a> {
-    /// `None` when the selection can keep nothing, so there is nothing to read.
-    fn prepare(selection: Selection<'a>) -> Result<Option<Self>> {
+    fn prepare(selection: Selection<'a>) -> Result<Self> {
         Ok(match selection {
-            Selection::All => Some(Scan::All),
-            Selection::Rows(rows) => {
-                let wanted: BTreeSet<usize> = rows.iter().copied().collect();
-                let last = wanted.iter().next_back().copied();
-                last.map(|last| Scan::Rows { wanted, last })
-            }
+            Selection::All => Scan::All,
+            Selection::Row(row) => Scan::Row(row),
             Selection::Filter { expr, env_vars } => {
                 let code = Code::<{ CodeType::FlowExpr as u32 }> {
                     ty: CodeType::FlowExpr,
                     value: expr.to_string(),
                 };
-                Some(Scan::Filter {
+                Scan::Filter {
                     code: code.compile().map_err(|source| Error::FilterCompile {
                         expr: expr.to_string(),
                         source,
                     })?,
                     expr,
                     env_vars,
-                })
+                }
             }
         })
     }
 
     /// Whether `row` is the last one this scan has any reason to read.
     fn stops_at(&self, row: usize) -> bool {
-        matches!(self, Scan::Rows { last, .. } if *last == row)
+        matches!(self, Scan::Row(wanted) if *wanted == row)
     }
 }
 
 /// Read a feature file, keeping only what `selection` asks for.
 ///
 /// Lines are decompressed and parsed one at a time and dropped unless kept, so
-/// the decompressed file is never held whole, and [`Selection::Rows`] stops at
-/// its highest row rather than decoding the rest. The compressed bytes are read
-/// whole, which is what the storage backends offer. Rows past the end are
-/// ignored, so a stale table selection yields an empty view.
+/// the decompressed file is never held whole, and [`Selection::Row`] stops at
+/// its row rather than decoding the rest. The compressed bytes are read whole,
+/// which is what the storage backends offer. A row past the end is ignored, so
+/// a stale table selection yields an empty view.
 pub fn load_selected(
     input: &Uri,
     selection: Selection<'_>,
     storage_resolver: &StorageResolver,
 ) -> Result<Loaded> {
-    let Some(scan) = Scan::prepare(selection)? else {
-        return Ok(Loaded {
-            selection: Vec::new(),
-            scanned: 0,
-        });
-    };
+    let scan = Scan::prepare(selection)?;
 
     let (uri, raw) = read_raw(input, storage_resolver)?;
     let read_error = |source: std::io::Error| Error::Read {
@@ -275,7 +245,7 @@ pub fn load_selected(
         }
         let keep = match &scan {
             Scan::All => Some(parse(line, row)?),
-            Scan::Rows { wanted, .. } => match wanted.contains(&row) {
+            Scan::Row(wanted) => match *wanted == row {
                 true => Some(parse(line, row)?),
                 false => None,
             },
@@ -417,33 +387,20 @@ pub struct RenderedView {
     pub written: Vec<Uri>,
 }
 
-/// Render the selection and write it to `destination`.
-pub fn render(
-    selection: &[Selected],
+/// Render one feature into `{prefix}.glb`, untiled: the view behind clicking a
+/// table row.
+pub fn render_feature(
+    selected: &Selected,
     options: &ViewOptions,
     destination: &Destination<'_>,
 ) -> Result<RenderedView> {
-    reject_two_dimensional(selection)?;
-    let features: Vec<Feature> = selection
-        .iter()
-        .map(|s| s.feature.with_attributes(row_index_attributes(s.row)))
-        .collect();
+    reject_two_dimensional(std::slice::from_ref(selected))?;
+    let feature = selected
+        .feature
+        .with_attributes(row_index_attributes(selected.row));
 
-    match options.format {
-        ViewFormat::Gltf => render_gltf(&features, options, destination),
-        ViewFormat::Cesium3DTiles { max_zoom } => {
-            render_tileset(&features, options, max_zoom, destination)
-        }
-    }
-}
-
-fn render_gltf(
-    features: &[Feature],
-    options: &ViewOptions,
-    destination: &Destination<'_>,
-) -> Result<RenderedView> {
     let Some(glb) = build_glb(
-        features,
+        &feature,
         options.metadata_options(),
         options.render_options(),
     )?
@@ -455,25 +412,33 @@ fn render_gltf(
         });
     };
 
-    let uri = destination.write_suffixed(".glb", glb.glb)?;
+    let uri = destination.write_suffixed(".glb", glb)?;
     Ok(RenderedView {
-        rendered_features: glb.rendered_features,
+        rendered_features: 1,
         entry_point: Some(uri.clone()),
         written: vec![uri],
     })
 }
 
-fn render_tileset(
-    features: &[Feature],
-    options: &ViewOptions,
+/// Render a whole selection into a tileset under `{prefix}/`: the view of an
+/// entire edge.
+pub fn render_tileset(
+    selection: &[Selected],
     max_zoom: u8,
+    options: &ViewOptions,
     destination: &Destination<'_>,
 ) -> Result<RenderedView> {
+    reject_two_dimensional(selection)?;
+    let features: Vec<Feature> = selection
+        .iter()
+        .map(|s| s.feature.with_attributes(row_index_attributes(s.row)))
+        .collect();
+
     // Content glbs are handed over as they are built, so peak memory stays at
     // one tile rather than the whole tileset; collect only their paths.
     let written = Mutex::new(Vec::new());
     let built = build(
-        features,
+        &features,
         options.metadata_options(),
         max_zoom,
         options.render_options(),
@@ -585,19 +550,24 @@ mod tests {
         Uri::for_test(&format!("file://{}", path.display()))
     }
 
-    fn render_to(dir: &Path, selection: &[Selected], options: &ViewOptions) -> RenderedView {
+    fn feature_to(dir: &Path, selected: &Selected, options: &ViewOptions) -> RenderedView {
         let root = Uri::for_test(&format!("file://{}", dir.display()));
         let resolver = StorageResolver::new();
-        render(
-            selection,
-            options,
-            &Destination {
-                root: &root,
-                prefix: "out",
-                storage_resolver: &resolver,
-            },
-        )
-        .expect("render")
+        render_feature(selected, options, &destination(&root, &resolver)).expect("render")
+    }
+
+    fn tileset_to(dir: &Path, selection: &[Selected], options: &ViewOptions) -> RenderedView {
+        let root = Uri::for_test(&format!("file://{}", dir.display()));
+        let resolver = StorageResolver::new();
+        render_tileset(selection, 18, options, &destination(&root, &resolver)).expect("render")
+    }
+
+    fn destination<'a>(root: &'a Uri, resolver: &'a StorageResolver) -> Destination<'a> {
+        Destination {
+            root,
+            prefix: "out",
+            storage_resolver: resolver,
+        }
     }
 
     fn glb_json(bytes: &[u8]) -> serde_json::Value {
@@ -626,7 +596,7 @@ mod tests {
             "file://{}/node.default.jsonl.zst",
             dir.path().display()
         ));
-        let loaded = load_selected(&compressed, Selection::Rows(&[1]), &resolver).expect("rows");
+        let loaded = load_selected(&compressed, Selection::Row(1), &resolver).expect("rows");
         assert_eq!(
             loaded.selection.iter().map(|s| s.row).collect::<Vec<_>>(),
             vec![1]
@@ -638,7 +608,7 @@ mod tests {
             "file://{}/node.default.jsonl",
             dir.path().display()
         ));
-        let by_plain_name = load_selected(&plain, Selection::Rows(&[1]), &resolver)
+        let by_plain_name = load_selected(&plain, Selection::Row(1), &resolver)
             .expect("the compressed file stands in for the plain name");
         assert_eq!(by_plain_name.selection[0].feature.id, features[1].id);
     }
@@ -646,7 +616,7 @@ mod tests {
     /// A feature the renderer cannot use is dropped, and the count says so
     /// rather than reporting everything selected.
     #[test]
-    fn the_count_is_of_features_that_reached_the_glb() {
+    fn the_count_is_of_features_that_reached_the_tileset() {
         let dir = tempfile::tempdir().expect("temp dir");
         let selection = [
             Selected {
@@ -658,7 +628,7 @@ mod tests {
                 feature: mesh_feature("k", 35.0),
             },
         ];
-        let view = render_to(dir.path(), &selection, &ViewOptions::default());
+        let view = tileset_to(dir.path(), &selection, &ViewOptions::default());
 
         assert_eq!(view.rendered_features, 1);
     }
@@ -669,7 +639,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("temp dir");
         let root = Uri::for_test(&format!("file://{}", dir.path().display()));
         let resolver = StorageResolver::new();
-        let selection = [Selected {
+        let selected = Selected {
             row: 0,
             feature: feature(
                 "k",
@@ -678,16 +648,12 @@ mod tests {
                     [0.0, 0.0],
                 ))),
             ),
-        }];
+        };
 
-        let error = render(
-            &selection,
+        let error = render_feature(
+            &selected,
             &ViewOptions::default(),
-            &Destination {
-                root: &root,
-                prefix: "out",
-                storage_resolver: &resolver,
-            },
+            &destination(&root, &resolver),
         )
         .expect_err("2D has no view");
 
@@ -714,10 +680,10 @@ mod tests {
             vec![0, 1, 2, 3]
         );
 
-        let rows = load_selected(&input, Selection::Rows(&[3, 1]), &resolver).expect("rows");
+        let row = load_selected(&input, Selection::Row(3), &resolver).expect("row");
         assert_eq!(
-            rows.selection.iter().map(|s| s.row).collect::<Vec<_>>(),
-            vec![1, 3]
+            row.selection.iter().map(|s| s.row).collect::<Vec<_>>(),
+            vec![3]
         );
 
         let filtered = load_selected(
@@ -744,11 +710,11 @@ mod tests {
     #[test]
     fn the_view_carries_only_the_row_index() {
         let dir = tempfile::tempdir().expect("temp dir");
-        let selection = [Selected {
+        let selected = Selected {
             row: 4242,
             feature: mesh_feature("keep", 35.0),
-        }];
-        render_to(dir.path(), &selection, &ViewOptions::default());
+        };
+        feature_to(dir.path(), &selected, &ViewOptions::default());
 
         let glb = std::fs::read(dir.path().join("out.glb")).expect("the glb is written");
         let contains = |n: &str| glb.windows(n.len()).any(|w| w == n.as_bytes());
@@ -773,17 +739,17 @@ mod tests {
                 Euclidean3DGeometry::TriangularMesh(Box::new(triangle(35.0))),
                 Euclidean3DGeometry::TriangularMesh(Box::new(triangle(35.5))),
             ])));
-        let selection = [Selected {
+        let selected = Selected {
             row: 0,
             feature: feature("k", collection),
-        }];
+        };
         // Draco packs positions away from the accessor, so read the count off an
         // uncompressed render.
         let options = ViewOptions {
             draco: false,
             ..ViewOptions::default()
         };
-        render_to(dir.path(), &selection, &options);
+        feature_to(dir.path(), &selected, &options);
 
         let json = glb_json(&std::fs::read(dir.path().join("out.glb")).unwrap());
         let accessor = json["meshes"][0]["primitives"][0]["attributes"]["POSITION"]
@@ -812,11 +778,7 @@ mod tests {
                 feature: mesh_feature("k", lat),
             })
             .collect();
-        let options = ViewOptions {
-            format: ViewFormat::Cesium3DTiles { max_zoom: 18 },
-            ..ViewOptions::default()
-        };
-        let view = render_to(dir.path(), &selection, &options);
+        let view = tileset_to(dir.path(), &selection, &ViewOptions::default());
 
         assert!(dir.path().join("out/tileset.json").exists());
         assert!(view
@@ -826,13 +788,13 @@ mod tests {
     }
 
     #[test]
-    fn a_selection_without_geometry_writes_nothing() {
+    fn a_feature_without_geometry_writes_nothing() {
         let dir = tempfile::tempdir().expect("temp dir");
-        let selection = [Selected {
+        let selected = Selected {
             row: 0,
             feature: Feature::from(Attributes::new()),
-        }];
-        let view = render_to(dir.path(), &selection, &ViewOptions::default());
+        };
+        let view = feature_to(dir.path(), &selected, &ViewOptions::default());
 
         assert_eq!(view.rendered_features, 0);
         assert!(view.entry_point.is_none());

--- a/engine/runtime/feature-view/src/lib.rs
+++ b/engine/runtime/feature-view/src/lib.rs
@@ -1,0 +1,695 @@
+//! Renders a viewable form of the features a run leaves on an edge.
+//!
+//! The input is one JSONL file. The output is either a single glb holding the
+//! whole selection, or a 3D Tiles tileset for streaming a whole edge. Rendered
+//! features carry no attributes, only [`ROW_INDEX_PROPERTY`], so a click in a
+//! viewer resolves to a row in the table the file came from.
+
+use std::borrow::Cow;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use reearth_flow_action_sink::file::cesium3dtiles::next::{
+    build, build_glb, MetadataOptions, RenderOptions,
+};
+use reearth_flow_action_sink::SinkOutput;
+use reearth_flow_common::uri::Uri;
+use reearth_flow_geometry::Geometry;
+use reearth_flow_storage::resolve::StorageResolver;
+use reearth_flow_types::{Attribute, AttributeValue, Attributes, Code, CodeType, Feature};
+use thiserror::Error as ThisError;
+
+pub use reearth_flow_action_sink::file::cesium3dtiles::next::TextureCodec;
+
+/// Extensions a feature file carries, longest first so the compressed form is
+/// matched before the plain one it ends with.
+const FEATURE_EXTENSIONS: [&str; 2] = [".jsonl.zst", ".jsonl"];
+
+/// The one property a rendered view carries: the row a picked feature sits at in
+/// the table its file came from.
+pub const ROW_INDEX_PROPERTY: &str = "rowIndex";
+
+#[derive(ThisError, Debug)]
+pub enum Error {
+    #[error("Failed to read features from {uri}: {source}")]
+    Read {
+        uri: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Filter expression {expr:?} failed to compile: {message}")]
+    FilterCompile { expr: String, message: String },
+    #[error("Filter expression {expr:?} failed on feature {feature_id}: {message}")]
+    FilterEval {
+        expr: String,
+        feature_id: String,
+        message: String,
+    },
+    #[error("Failed to render the view: {0}")]
+    Render(String),
+    #[error("Failed to write {path}: {source}")]
+    Write {
+        path: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Which of the two view shapes to render.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ViewFormat {
+    /// One glb holding the whole selection, untiled.
+    #[default]
+    Gltf,
+    /// A 3D Tiles tileset, for streaming a whole edge.
+    Cesium3DTiles {
+        /// Deepest quadtree level a feature may be placed at.
+        max_zoom: u8,
+    },
+}
+
+/// How to render, independent of which shape is being rendered.
+#[derive(Clone, Debug)]
+pub struct ViewOptions {
+    pub format: ViewFormat,
+    /// Draco mesh compression. On by default: it costs about 2% of render time
+    /// and cuts a glb several-fold.
+    pub draco: bool,
+    /// Per-polygon flat normals, so surfaces light rather than read flat.
+    pub compute_flat_normal: bool,
+    /// Target texel size in metres per pixel. `0.0` keeps full texture detail.
+    pub texel_size: f64,
+    pub atlas_size: u32,
+    pub atlas_extrusion: u32,
+    /// JPEG by default rather than the tile writer's KTX2: a view is built on
+    /// demand, and JPEG encodes several times faster at a comparable size.
+    pub texture_codec: TextureCodec,
+}
+
+impl Default for ViewOptions {
+    fn default() -> Self {
+        Self {
+            format: ViewFormat::default(),
+            draco: true,
+            compute_flat_normal: true,
+            texel_size: 0.0,
+            atlas_size: 2048,
+            atlas_extrusion: 0,
+            texture_codec: TextureCodec::Jpeg,
+        }
+    }
+}
+
+impl ViewOptions {
+    fn render_options(&self) -> RenderOptions {
+        RenderOptions {
+            draco: self.draco,
+            compute_flat_normal: self.compute_flat_normal,
+            texel_size: self.texel_size,
+            atlas_size: self.atlas_size,
+            atlas_extrusion: self.atlas_extrusion,
+            texture_codec: self.texture_codec,
+        }
+    }
+
+    /// The property table is the row index and nothing else, so there is no
+    /// attribute exposure left for these to shape.
+    fn metadata_options(&self) -> MetadataOptions<'static> {
+        MetadataOptions {
+            schema_key: None,
+            skip_unexposed_attributes: false,
+        }
+    }
+}
+
+/// Where a view's files land: every path is `prefix` joined under `root`.
+pub struct Destination<'a> {
+    pub root: &'a Uri,
+    /// A glTF view writes `{prefix}.glb`; a tileset writes
+    /// `{prefix}/tileset.json` alongside its content and subtree files.
+    pub prefix: &'a str,
+    pub storage_resolver: &'a StorageResolver,
+}
+
+impl Destination<'_> {
+    fn write(&self, relative_path: &str, bytes: Vec<u8>) -> Result<Uri> {
+        let out =
+            SinkOutput::new(self.root, relative_path, self.storage_resolver).map_err(|source| {
+                Error::Write {
+                    path: relative_path.to_string(),
+                    source,
+                }
+            })?;
+        let uri = out.uri().clone();
+        out.write(Bytes::from(bytes))
+            .map_err(|source| Error::Write {
+                path: relative_path.to_string(),
+                source,
+            })?;
+        Ok(uri)
+    }
+}
+
+/// What a render produced.
+#[derive(Debug)]
+pub struct RenderedView {
+    pub rendered_features: usize,
+    /// The entry point a viewer opens: the glb, or the tileset's
+    /// `tileset.json`.
+    pub entry_point: Option<Uri>,
+    /// Every file written, the entry point included.
+    pub written: Vec<Uri>,
+}
+
+/// A selected feature and the line it came from.
+#[derive(Clone, Debug)]
+pub struct Selected {
+    /// 0-based line in the file, which is the row a table shows it at. Survives
+    /// filtering, so it still addresses the full table.
+    pub row: usize,
+    pub feature: Feature,
+}
+
+/// Which features a read keeps.
+pub enum Selection<'a> {
+    All,
+    /// The scan stops after the highest row, and no other line is parsed.
+    Rows(&'a [usize]),
+    /// The features a Flow expression evaluates true for.
+    Filter {
+        expr: &'a str,
+        env_vars: Arc<serde_json::Map<String, serde_json::Value>>,
+    },
+}
+
+/// What a read produced.
+pub struct Loaded {
+    pub selection: Vec<Selected>,
+    /// Non-empty lines examined; short of the file's total under
+    /// [`Selection::Rows`], which stops early.
+    pub scanned: usize,
+}
+
+/// Read a feature file, keeping only what `selection` asks for.
+///
+/// One line at a time: a line that is not kept is dropped before the next is
+/// read, and a kept one has its attributes swapped for the row index at once,
+/// so peak memory tracks surviving geometry rather than the file. Rows past the
+/// end are ignored, so a stale table selection yields an empty view.
+pub fn load_selected(
+    input: &Uri,
+    selection: Selection<'_>,
+    storage_resolver: &StorageResolver,
+) -> Result<Loaded> {
+    let compiled = match &selection {
+        Selection::Filter { expr, .. } => {
+            let code = Code::<{ CodeType::FlowExpr as u32 }> {
+                ty: CodeType::FlowExpr,
+                value: expr.to_string(),
+            };
+            Some(code.compile().map_err(|e| Error::FilterCompile {
+                expr: expr.to_string(),
+                message: format!("{e:?}"),
+            })?)
+        }
+        _ => None,
+    };
+
+    let wanted: BTreeSet<usize> = match &selection {
+        Selection::Rows(rows) => rows.iter().copied().collect(),
+        _ => BTreeSet::new(),
+    };
+    if matches!(selection, Selection::Rows(_)) && wanted.is_empty() {
+        return Ok(Loaded {
+            selection: Vec::new(),
+            scanned: 0,
+        });
+    }
+    let last_wanted = wanted.iter().next_back().copied();
+
+    let (uri, raw) = read_raw(input, storage_resolver)?;
+    let data = decode_auto(raw.as_ref()).map_err(|source| Error::Read {
+        uri: uri.as_str().to_string(),
+        source,
+    })?;
+
+    let parse = |line: &[u8], row: usize| -> Result<Feature> {
+        serde_json::from_slice(line).map_err(|e| Error::Read {
+            uri: uri.as_str().to_string(),
+            source: std::io::Error::other(format!("row {row}: {e}")),
+        })
+    };
+
+    let mut kept = Vec::new();
+    let mut row = 0usize;
+    for line in data.split(|&b| b == b'\n') {
+        let line = trim_ascii(line);
+        if line.is_empty() {
+            continue;
+        }
+        let keep = match &selection {
+            Selection::All => Some(parse(line, row)?),
+            Selection::Rows(_) => match wanted.contains(&row) {
+                true => Some(parse(line, row)?),
+                false => None,
+            },
+            Selection::Filter { expr, env_vars } => {
+                let feature = parse(line, row)?;
+                let matched = compiled
+                    .as_ref()
+                    .expect("a filter selection compiled its expression")
+                    .eval_bool(&feature, Arc::clone(env_vars))
+                    .map_err(|e| Error::FilterEval {
+                        expr: expr.to_string(),
+                        feature_id: feature.id.to_string(),
+                        message: format!("{e:?}"),
+                    })?;
+                matched.then_some(feature)
+            }
+        };
+        if let Some(feature) = keep {
+            kept.push(Selected {
+                row,
+                feature: feature.with_attributes(row_index_attributes(row)),
+            });
+        }
+        row += 1;
+        if Some(row - 1) == last_wanted {
+            break;
+        }
+    }
+
+    Ok(Loaded {
+        selection: kept,
+        scanned: row,
+    })
+}
+
+/// Read the named file, or its counterpart in the other feature-file extension.
+fn read_raw(input: &Uri, storage_resolver: &StorageResolver) -> Result<(Uri, Bytes)> {
+    let mut candidates = vec![input.clone()];
+    if let (Some(name), Some(dir)) = (
+        input
+            .file_name()
+            .and_then(|n| n.to_str().map(str::to_string)),
+        input.parent(),
+    ) {
+        let stem = FEATURE_EXTENSIONS
+            .iter()
+            .find_map(|ext| name.strip_suffix(ext))
+            .unwrap_or(name.as_str());
+        for ext in FEATURE_EXTENSIONS {
+            if let Ok(candidate) = dir.join(format!("{stem}{ext}")) {
+                if candidate.as_str() != input.as_str() {
+                    candidates.push(candidate);
+                }
+            }
+        }
+    }
+
+    let mut last: Option<std::io::Error> = None;
+    for candidate in candidates {
+        let read = storage_resolver
+            .resolve(&candidate)
+            .map_err(std::io::Error::other)
+            .and_then(|storage| {
+                storage
+                    .get_sync(candidate.path().as_path())
+                    .map_err(std::io::Error::other)
+            });
+        match read {
+            Ok(bytes) => return Ok((candidate, bytes)),
+            Err(e) => last = Some(e),
+        }
+    }
+    Err(Error::Read {
+        uri: input.as_str().to_string(),
+        source: last.unwrap_or_else(|| std::io::Error::other("no candidate jsonl found")),
+    })
+}
+
+/// zstd frame magic is `28 B5 2F FD`; anything else is already plain text.
+fn decode_auto(bytes: &[u8]) -> std::io::Result<Cow<'_, [u8]>> {
+    if bytes.starts_with(&[0x28, 0xB5, 0x2F, 0xFD]) {
+        zstd::stream::decode_all(bytes).map(Cow::Owned)
+    } else {
+        Ok(Cow::Borrowed(bytes))
+    }
+}
+
+fn trim_ascii(mut line: &[u8]) -> &[u8] {
+    while let [first, rest @ ..] = line {
+        if !first.is_ascii_whitespace() {
+            break;
+        }
+        line = rest;
+    }
+    while let [rest @ .., last] = line {
+        if !last.is_ascii_whitespace() {
+            break;
+        }
+        line = rest;
+    }
+    line
+}
+
+/// The single-entry attribute set a rendered feature carries.
+fn row_index_attributes(row: usize) -> Attributes {
+    let mut attributes = Attributes::new();
+    attributes.insert(
+        Attribute::new(ROW_INDEX_PROPERTY),
+        AttributeValue::Number(row.into()),
+    );
+    attributes
+}
+
+/// Render the selection and write it to `destination`.
+pub fn render(
+    selection: &[Selected],
+    options: &ViewOptions,
+    destination: &Destination<'_>,
+) -> Result<RenderedView> {
+    let features: Vec<Feature> = selection
+        .iter()
+        .map(|s| s.feature.with_attributes(row_index_attributes(s.row)))
+        .collect();
+    reject_two_dimensional(&features);
+
+    match options.format {
+        ViewFormat::Gltf => render_gltf(&features, options, destination),
+        ViewFormat::Cesium3DTiles { max_zoom } => {
+            render_tileset(&features, options, max_zoom, destination)
+        }
+    }
+}
+
+fn render_gltf(
+    features: &[Feature],
+    options: &ViewOptions,
+    destination: &Destination<'_>,
+) -> Result<RenderedView> {
+    let glb = build_glb(
+        features,
+        options.metadata_options(),
+        options.render_options(),
+    )
+    .map_err(|e| Error::Render(format!("{e:?}")))?;
+
+    let Some(glb) = glb else {
+        return Ok(RenderedView {
+            rendered_features: 0,
+            entry_point: None,
+            written: Vec::new(),
+        });
+    };
+
+    let uri = destination.write(&format!("{}.glb", destination.prefix), glb)?;
+    Ok(RenderedView {
+        rendered_features: features.len(),
+        entry_point: Some(uri.clone()),
+        written: vec![uri],
+    })
+}
+
+fn render_tileset(
+    features: &[Feature],
+    options: &ViewOptions,
+    max_zoom: u8,
+    destination: &Destination<'_>,
+) -> Result<RenderedView> {
+    // Content glbs are handed over as they are built, so peak memory stays at
+    // one tile rather than the whole tileset; collect only their paths.
+    let written = std::sync::Mutex::new(Vec::new());
+    let built = build(
+        features,
+        options.metadata_options(),
+        max_zoom,
+        options.render_options(),
+        |relative_path, bytes| {
+            let uri = destination
+                .write(&format!("{}/{relative_path}", destination.prefix), bytes)
+                .map_err(|e| {
+                    reearth_flow_action_sink::errors::SinkError::Cesium3DTilesWriter(format!("{e}"))
+                })?;
+            written
+                .lock()
+                .expect("write log is never poisoned")
+                .push(uri);
+            Ok(())
+        },
+    )
+    .map_err(|e| Error::Render(format!("{e:?}")))?;
+
+    let mut written = written.into_inner().expect("write log is never poisoned");
+    for (relative_path, bytes) in built.subtrees {
+        written.push(destination.write(&format!("{}/{relative_path}", destination.prefix), bytes)?);
+    }
+    let entry_point = destination.write(
+        &format!("{}/tileset.json", destination.prefix),
+        built.tileset_json.into_bytes(),
+    )?;
+    written.push(entry_point.clone());
+
+    Ok(RenderedView {
+        rendered_features: features.len(),
+        entry_point: Some(entry_point),
+        written,
+    })
+}
+
+/// 2D has no view yet. Reaching it is a caller error rather than an empty
+/// render, so say so instead of writing a file with nothing in it.
+fn reject_two_dimensional(features: &[Feature]) {
+    if features.iter().any(|f| holds_two_dimensional(&f.geometry)) {
+        unimplemented!("feature views of 2D geometry");
+    }
+}
+
+fn holds_two_dimensional(geometry: &Geometry) -> bool {
+    match geometry {
+        Geometry::Euclidean2D(_) => true,
+        Geometry::GeometryCollection(collection) => {
+            collection.members().iter().any(holds_two_dimensional)
+        }
+        Geometry::None | Geometry::Euclidean3D(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use reearth_flow_geometry::collection::Collection3D;
+    use reearth_flow_geometry::coordinate::{CoordinateFrame, EpsgCode};
+    use reearth_flow_geometry::triangular_mesh::TriangularMesh3D;
+    use reearth_flow_geometry::Euclidean3DGeometry;
+
+    use super::*;
+
+    fn triangle(lat: f64) -> TriangularMesh3D {
+        TriangularMesh3D::from_soup(
+            CoordinateFrame::Crs(EpsgCode::new(4979)),
+            [
+                [lat, 139.0, 10.0],
+                [lat, 139.001, 10.0],
+                [lat + 0.001, 139.0, 10.0],
+            ],
+        )
+    }
+
+    fn feature(kind: &str, geometry: Geometry) -> Feature {
+        let mut attributes = Attributes::new();
+        attributes.insert(
+            Attribute::new("kind"),
+            AttributeValue::String(kind.to_string()),
+        );
+        let mut feature = Feature::from(attributes);
+        feature.set_geometry(geometry);
+        feature
+    }
+
+    fn mesh_feature(kind: &str, lat: f64) -> Feature {
+        feature(
+            kind,
+            Geometry::Euclidean3D(Euclidean3DGeometry::TriangularMesh(Box::new(triangle(lat)))),
+        )
+    }
+
+    fn write_features(dir: &Path, features: &[Feature]) -> Uri {
+        let lines: Vec<String> = features
+            .iter()
+            .map(|f| serde_json::to_string(f).expect("a feature serializes"))
+            .collect();
+        let path = dir.join("node.default.jsonl");
+        std::fs::write(&path, lines.join("\n")).expect("write features");
+        Uri::for_test(&format!("file://{}", path.display()))
+    }
+
+    fn render_to(dir: &Path, selection: &[Selected], options: &ViewOptions) -> RenderedView {
+        let root = Uri::for_test(&format!("file://{}", dir.display()));
+        let resolver = StorageResolver::new();
+        render(
+            selection,
+            options,
+            &Destination {
+                root: &root,
+                prefix: "out",
+                storage_resolver: &resolver,
+            },
+        )
+        .expect("render")
+    }
+
+    fn glb_json(bytes: &[u8]) -> serde_json::Value {
+        let len = u32::from_le_bytes(bytes[12..16].try_into().unwrap()) as usize;
+        serde_json::from_slice(&bytes[20..20 + len]).unwrap()
+    }
+
+    /// Every selection mode must agree on what row N is, and a filter must not
+    /// renumber what survives it.
+    #[test]
+    fn selections_agree_on_row_numbers() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let features: Vec<Feature> = ["a", "keep", "b", "keep"]
+            .iter()
+            .enumerate()
+            .map(|(i, k)| mesh_feature(k, 35.0 + i as f64))
+            .collect();
+        let input = write_features(dir.path(), &features);
+        let resolver = StorageResolver::new();
+
+        let all = load_selected(&input, Selection::All, &resolver).expect("all");
+        assert_eq!(all.scanned, 4);
+        assert_eq!(
+            all.selection.iter().map(|s| s.row).collect::<Vec<_>>(),
+            vec![0, 1, 2, 3]
+        );
+
+        let rows = load_selected(&input, Selection::Rows(&[3, 1]), &resolver).expect("rows");
+        assert_eq!(
+            rows.selection.iter().map(|s| s.row).collect::<Vec<_>>(),
+            vec![1, 3]
+        );
+
+        let filtered = load_selected(
+            &input,
+            Selection::Filter {
+                expr: r#"attributes["kind"] == "keep""#,
+                env_vars: Arc::new(serde_json::Map::new()),
+            },
+            &resolver,
+        )
+        .expect("filter");
+        assert_eq!(filtered.scanned, 4);
+        assert_eq!(
+            filtered.selection.iter().map(|s| s.row).collect::<Vec<_>>(),
+            vec![1, 3]
+        );
+        for selected in &filtered.selection {
+            assert_eq!(selected.feature.id, features[selected.row].id);
+        }
+    }
+
+    /// A view carries the row and no attribute data, and is draco-compressed
+    /// with jpeg textures by default.
+    #[test]
+    fn the_view_carries_only_the_row_index() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let selection = [Selected {
+            row: 4242,
+            feature: mesh_feature("keep", 35.0),
+        }];
+        render_to(dir.path(), &selection, &ViewOptions::default());
+
+        let glb = std::fs::read(dir.path().join("out.glb")).expect("the glb is written");
+        let contains = |n: &str| glb.windows(n.len()).any(|w| w == n.as_bytes());
+        assert_eq!(&glb[..4], b"glTF");
+        assert!(contains(ROW_INDEX_PROPERTY), "the row index is carried");
+        assert!(contains("4242"), "the row is the one it came from");
+        assert!(!contains("kind"), "no source attribute name");
+        assert!(!contains("keep"), "no source attribute value");
+
+        let json = glb_json(&glb);
+        let ext = json["extensionsUsed"].as_array().unwrap();
+        assert!(ext.iter().any(|e| e == "KHR_draco_mesh_compression"));
+    }
+
+    /// A feature holding several meshes renders all of them, as one pickable
+    /// feature.
+    #[test]
+    fn a_collection_renders_every_member_as_one_feature() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let collection =
+            Geometry::Euclidean3D(Euclidean3DGeometry::Collection(Collection3D::new([
+                Euclidean3DGeometry::TriangularMesh(Box::new(triangle(35.0))),
+                Euclidean3DGeometry::TriangularMesh(Box::new(triangle(35.5))),
+            ])));
+        let selection = [Selected {
+            row: 0,
+            feature: feature("k", collection),
+        }];
+        // Draco packs positions away from the accessor, so read the count off an
+        // uncompressed render.
+        let options = ViewOptions {
+            draco: false,
+            ..ViewOptions::default()
+        };
+        render_to(dir.path(), &selection, &options);
+
+        let json = glb_json(&std::fs::read(dir.path().join("out.glb")).unwrap());
+        let accessor = json["meshes"][0]["primitives"][0]["attributes"]["POSITION"]
+            .as_u64()
+            .unwrap() as usize;
+        assert_eq!(
+            json["accessors"][accessor]["count"].as_u64(),
+            Some(6),
+            "both members render: three vertices each"
+        );
+        assert_eq!(
+            json["extensions"]["EXT_structural_metadata"]["propertyTables"][0]["count"].as_u64(),
+            Some(1),
+            "the collection is one feature, not one per member"
+        );
+    }
+
+    #[test]
+    fn a_tileset_writes_a_tileset_and_content() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let selection: Vec<Selected> = [35.0, 35.5]
+            .iter()
+            .enumerate()
+            .map(|(row, &lat)| Selected {
+                row,
+                feature: mesh_feature("k", lat),
+            })
+            .collect();
+        let options = ViewOptions {
+            format: ViewFormat::Cesium3DTiles { max_zoom: 18 },
+            ..ViewOptions::default()
+        };
+        let view = render_to(dir.path(), &selection, &options);
+
+        assert!(dir.path().join("out/tileset.json").exists());
+        assert!(view
+            .written
+            .iter()
+            .any(|uri| uri.as_str().contains("/out/content/")));
+    }
+
+    #[test]
+    fn a_selection_without_geometry_writes_nothing() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let selection = [Selected {
+            row: 0,
+            feature: Feature::from(Attributes::new()),
+        }];
+        let view = render_to(dir.path(), &selection, &ViewOptions::default());
+
+        assert_eq!(view.rendered_features, 0);
+        assert!(view.entry_point.is_none());
+        assert!(view.written.is_empty());
+    }
+}

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.102"
+version = "0.2.103"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.292"
+version = "0.1.293"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
# Overview
This PR implements a new library crate in the reearth-flow engine workspace that reads the feature data from jsonl file and creates a glTF / 3DTiles from it. The feature is also exposed to the cli.
This feature is implemented behind `new-geometry` feature only.

## What the view generation does.
- The 3D view is either glTF or 3DTiles, configurable by the cli arguments. glTF should be used to show per-feature view, and 3DTiles should be used for the global view.
- For glTF views, the CLI expects an argument that specifies the row number of the feature for view generation.
- For 3DTiles views:
  - The CLI accepts an optional argument that allow users to filter attributes from using Flow expression. This is useful for users when their geometry data has multiple themes / LODs that flow onto identical paths; For example, CityGML has multiple LODs, and the user can optionally generate the global view for the LoD2 only, without getting disturbed by LOD1 or LOD3 geometry sitting at the same place.
  - The feature attributes are stripped from the generated 3DTIiles, as the attribute values are already in the table. It does have a `EXT_mesh_features` according to the granularity of the features, and the only mesh property it carries is the row number in the table, which allows the UI to link from geometry to the feature table.

## What's not in this PR
- 2D view is not supported yet. This needs to wait the `MVTWriter` migration.
- Server endpoint for the view is out of scope for this PR. This PR merely implements the ability to generate the 3D views.

## Benchmark
### Input
| | |
|---|---|
| Source CityGML | CityGML (475 MiB, excluding texture) |
| Intermediate data (CityGml3Reader output) | 716 MiB, 14,722 features |

### Results

| view | selection | wall | peak RSS | output |
|---|---|---|---|---|
| glTF | `--row 1784` (1 feature) | 1.87 s | 1.41 GB | 0.81 MB, 1 file |
| 3D Tiles | all 14,722 features | 17.28 s | 8.65 GB | 42.02 MB, 834 files |

## Screenshots
Part of Takeshiba CityGML 3.0 sample, filtered for LOD2: 
<img width="1474" height="799" alt="Screenshot from 2026-07-31 10-30-01" src="https://github.com/user-attachments/assets/c874c2ee-4f0b-4316-a18e-8640175cf197" />

## Notes
- The generated 3D views use jpeg by default because basis universal encoder takes too long for this purpose.
- `build_glb()` function for composing a glb is located in `runtime/action-sink/src/file/cesium3dtiles/next/mod.rs`, though it has nothing to do with 3DTiles. This is because glTF writer is not implemented in the `new-geometry` world. It should be relocated after glTF writer is migrated, and it is explicitly left as a TODO.