### PR TITLE
fix(api,subscriber): stop logging database credentials in the config dump

### DIFF
--- a/server/api/internal/app/config/config.go
+++ b/server/api/internal/app/config/config.go
@@ -181,7 +181,7 @@ func (c *Config) Print() string {
 }
 
 func (c *Config) secrets() []string {
-	s := []string{c.DB, c.DB_PG, c.Auth0.ClientSecret, c.HealthCheck.Password, c.SignupSecret, c.WebsocketAPISecret, c.CMS_Token}
+	s := []string{c.DB, c.DB_PG, c.Redis_URL, c.Auth0.ClientSecret, c.HealthCheck.Password, c.SignupSecret, c.WebsocketAPISecret, c.CMS_Token}
 	for _, ac := range c.DB_Users {
 		s = append(s, ac.URI)
 	}

--- a/server/api/internal/app/config/config.go
+++ b/server/api/internal/app/config/config.go
@@ -181,7 +181,7 @@ func (c *Config) Print() string {
 }
 
 func (c *Config) secrets() []string {
-	s := []string{c.DB, c.Auth0.ClientSecret, c.HealthCheck.Password}
+	s := []string{c.DB, c.DB_PG, c.Auth0.ClientSecret, c.HealthCheck.Password, c.SignupSecret, c.WebsocketAPISecret, c.CMS_Token}
 	for _, ac := range c.DB_Users {
 		s = append(s, ac.URI)
 	}

--- a/server/api/internal/app/config/config_redact_test.go
+++ b/server/api/internal/app/config/config_redact_test.go
@@ -17,13 +17,14 @@ func TestConfig_Print_MasksCredentials(t *testing.T) {
 	c.SignupSecret = "signupsecret"
 	c.WebsocketAPISecret = "wssecret"
 	c.CMS_Token = "cmstoken"
+	c.Redis_URL = "redis://:redispass@10.0.0.1:6379"
 	c.AssetBaseURL = "http://localhost:8080/assets"
 
 	out := c.Print()
 
 	for _, leaked := range []string{
 		"mpass", "pgpass123", "auth0secret", "hcpass",
-		"signupsecret", "wssecret", "cmstoken",
+		"signupsecret", "wssecret", "cmstoken", "redispass",
 	} {
 		if strings.Contains(out, leaked) {
 			t.Errorf("Print leaked %q", leaked)

--- a/server/api/internal/app/config/config_redact_test.go
+++ b/server/api/internal/app/config/config_redact_test.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// pp dumps every config field, so secrets() has to list each credential-bearing
+// one. DB_PG was missing, which put the Postgres DSN into Cloud Logging in
+// cleartext once DB_Driver was switched to postgres.
+func TestConfig_Print_MasksCredentials(t *testing.T) {
+	c := &Config{}
+	c.DB = "mongodb+srv://muser:mpass@cluster.example.net/db"
+	c.DB_PG = "postgres://reearth_flow:pgpass123@10.46.0.3:5432/reearth_flow?sslmode=disable"
+	c.Auth0.ClientSecret = "auth0secret"
+	c.HealthCheck.Password = "hcpass"
+	c.SignupSecret = "signupsecret"
+	c.WebsocketAPISecret = "wssecret"
+	c.CMS_Token = "cmstoken"
+	c.AssetBaseURL = "http://localhost:8080/assets"
+
+	out := c.Print()
+
+	for _, leaked := range []string{
+		"mpass", "pgpass123", "auth0secret", "hcpass",
+		"signupsecret", "wssecret", "cmstoken",
+	} {
+		if strings.Contains(out, leaked) {
+			t.Errorf("Print leaked %q", leaked)
+		}
+	}
+	if !strings.Contains(out, "http://localhost:8080/assets") {
+		t.Error("Print masked a non-secret field")
+	}
+}

--- a/server/subscriber/cmd/reearth-flow-subscriber/config.go
+++ b/server/subscriber/cmd/reearth-flow-subscriber/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strings"
 
 	"github.com/joho/godotenv"
 	"github.com/k0kubun/pp/v3"
@@ -58,5 +59,17 @@ func ReadConfig(debug bool) (*Config, error) {
 
 func (c *Config) Print() string {
 	s := pp.Sprint(c)
+	for _, secret := range c.secrets() {
+		if secret == "" {
+			continue
+		}
+		s = strings.ReplaceAll(s, secret, "***")
+	}
 	return s
+}
+
+// secrets lists the values Print must not emit. pp dumps every field, so a
+// credential-bearing field added without being listed here is logged verbatim.
+func (c *Config) secrets() []string {
+	return []string{c.DB, c.DBPG, c.RedisURL, c.HealthCheckPassword}
 }

--- a/server/subscriber/cmd/reearth-flow-subscriber/config_redact_test.go
+++ b/server/subscriber/cmd/reearth-flow-subscriber/config_redact_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// pp dumps every config field, so Print must mask the credential-bearing ones.
+// The Postgres DSN reached Cloud Logging in cleartext because it was not masked.
+func TestConfig_Print_MasksCredentials(t *testing.T) {
+	c := &Config{
+		DB:                  "mongodb+srv://muser:mpass@cluster.example.net/db",
+		DBPG:                "postgres://reearth_flow:pgpass123@10.46.0.3:5432/reearth_flow?sslmode=disable",
+		RedisURL:            "redis://:redispass@10.0.0.1:6379",
+		HealthCheckPassword: "hcpass",
+		GCSBucket:           "some-bucket",
+	}
+
+	out := c.Print()
+
+	for _, leaked := range []string{"mpass", "pgpass123", "redispass", "hcpass"} {
+		if strings.Contains(out, leaked) {
+			t.Errorf("Print leaked %q", leaked)
+		}
+	}
+	if !strings.Contains(out, "some-bucket") {
+		t.Error("Print masked a non-secret field")
+	}
+}


### PR DESCRIPTION
Both services log their entire config at startup through `pp`, which prints every field. That has been putting live database credentials into Cloud Logging.

**Merge and deploy this before rotating the password** — see the sequencing note at the bottom.

## What is exposed

Confirmed against `reearth-oss` (counts only, values not reproduced):

| Service | Entries with the Postgres DSN password | Entries with the Mongo URI |
|---|---|---|
| `reearth-flow-api` | **8** | 0 — `c.DB` was already masked |
| `reearth-flow-subscriber` | **6** | **300+** (query limit) |

Readable by anyone with log-viewer access on the project.

## Cause

The API already had the right mechanism, and `DB_PG` was simply never added to it:

```go
func (c *Config) secrets() []string {
    return []string{c.DB, c.Auth0.ClientSecret, c.HealthCheck.Password}
}
```

That is exactly why the Mongo URI shows 0 hits and the Postgres DSN shows 8 — the DSN became reachable the moment `DB_DRIVER` was switched to `postgres`. My #2324 added the equivalent field to the subscriber's config without noticing `Print()` dumps everything, which is where the subscriber's DSN exposure comes from.

The subscriber had **no** masking at all, hence the long-standing Mongo URI exposure.

## Changes

**API** — one line. Writing the test surfaced three more fields that were also being logged in cleartext, so they are covered too:

```
+ c.DB_PG, c.SignupSecret, c.WebsocketAPISecret, c.CMS_Token
```

**Subscriber** — gains the same mechanism as the API, covering `DB`, `DBPG`, `RedisURL` and `HealthCheckPassword`, with a comment noting that a credential field added without being listed gets logged verbatim.

## Verification

Both tests assert each credential is absent from `Print()` and that a non-secret field still appears. Both fail against the previous code, which is the point:

```
# subscriber, before
Print leaked "mpass" / "pgpass123" / "redispass" / "hcpass"

# api, with DB_PG et al. removed from secrets()
Print leaked "pgpass123" / "signupsecret" / "wssecret" / "cmstoken"
```

`go build`, `go vet`, `gofmt` clean; `./internal/app/...` and the full subscriber suite pass.

## Sequencing

1. **This PR** merges and deploys.
2. **Then** rotate the Postgres password — it is already in the logs, so the credential has to be considered compromised. Rotating first would just write the new password into the logs on the redeploy.

Existing log entries are not removed by either step; purging or shortening retention on them is a separate decision.