### PR TITLE
feat(engine): overlays for new geometry

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.104"
+version = "0.2.105"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "Inflector",
  "approx",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4959,7 +4959,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5008,7 +5008,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5019,7 +5019,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "bytes",
  "clap",
@@ -5061,7 +5061,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5145,7 +5145,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "approx",
  "bvh",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5243,7 +5243,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5272,7 +5272,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5308,7 +5308,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "bytes",
  "futures",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "bytes",
  "futures",
@@ -5375,7 +5375,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "ahash",
  "bytes",
@@ -5459,7 +5459,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.475"
+version = "0.0.476"
 dependencies = [
  "async-trait",
  "axum",
@@ -8225,7 +8225,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.294"
+version = "0.1.295"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.475"
+version = "0.0.476"
 
 [profile.dev]
 opt-level = 0

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -93,7 +93,7 @@ Calculates the planar or sloped area of a feature's geometry and stores it in an
 ### Type
 * processor
 ### Description
-Perform Area Overlay Analysis
+Subdivides overlapping areas into non-overlapping pieces and records how many input features cover each piece. Inputs must be flat 2D geometries sharing one coordinate frame; place a Two Dimension Forcer or a Coordinate Frame Reprojector upstream to flatten or unify them.
 ### Parameters
 ```json
 {
@@ -7802,7 +7802,7 @@ Writes features to JSON files.
 ### Type
 * processor
 ### Description
-Intersection points are turned into point features that can contain the merged list of attributes of the original intersected lines.
+Splits lines where they cross and turns each intersection into a point feature carrying the merged attributes of the lines that meet there. Inputs must be flat 2D geometries sharing one coordinate frame; place a Two Dimension Forcer or a Coordinate Frame Reprojector upstream to flatten or unify them.
 ### Parameters
 ```json
 {

--- a/engine/runtime/action-processor/src/geometry/area_on_area_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/area_on_area_overlayer.rs
@@ -7,13 +7,8 @@ use std::{
 };
 
 use indexmap::IndexMap;
-use nusamai_projection::crs::EpsgCode;
 use once_cell::sync::Lazy;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use reearth_flow_geometry::{
-    algorithm::{area2d::Area2D, bool_ops::BooleanOps},
-    types::{geometry::Geometry2D, multi_polygon::MultiPolygon2D, polygon::Polygon2D},
-};
 use reearth_flow_runtime::{
     cache::executor_cache_subdir,
     errors::BoxedError,
@@ -22,11 +17,33 @@ use reearth_flow_runtime::{
     forwarder::ProcessorChannelForwarder,
     node::{Port, Processor, ProcessorFactory, FEATURES_PORT, REJECTED_PORT},
 };
-use reearth_flow_types::{Attribute, AttributeValue, Feature, Geometry, GeometryValue};
+use reearth_flow_types::{Attribute, AttributeValue, Feature};
 use rstar::{RTree, AABB};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+
+#[cfg(not(feature = "new-geometry"))]
+use nusamai_projection::crs::EpsgCode;
+#[cfg(not(feature = "new-geometry"))]
+use reearth_flow_geometry::{
+    algorithm::{area2d::Area2D, bool_ops::BooleanOps},
+    types::{geometry::Geometry2D, multi_polygon::MultiPolygon2D, polygon::Polygon2D},
+};
+#[cfg(not(feature = "new-geometry"))]
+use reearth_flow_types::{Geometry, GeometryValue};
+
+#[cfg(feature = "new-geometry")]
+use reearth_flow_geometry::{
+    collection::Collection2D,
+    coordinate::CoordinateFrame,
+    line_string::LineString2D,
+    ops::{Aabb, BoundingBox},
+    overlay::{overlay_2d, OverlayOp},
+    polygon::Polygon2D,
+    predicates::view::{flatten_2d, Leaf2D},
+    Euclidean2DGeometry, Geometry,
+};
 
 use super::errors::GeometryProcessorError;
 use crate::ACCUMULATOR_BUFFER_BYTE_THRESHOLD;
@@ -97,7 +114,7 @@ impl ProcessorFactory for AreaOnAreaOverlayerFactory {
             accumulation_mode: param.accumulation_mode,
             tolerance: param.tolerance.unwrap_or(0.0),
             group_map: HashMap::new(),
-            group_epsg: HashMap::new(),
+            group_crs: HashMap::new(),
             group_count: 0,
             temp_dir: None,
             buffer: HashMap::new(),
@@ -136,6 +153,16 @@ struct AreaOnAreaOverlayerParam {
     tolerance: Option<f64>,
 }
 
+/// Per-group CRS bookkeeping: the EPSG folded across the group's inputs and
+/// carried onto its outputs.
+#[cfg(not(feature = "new-geometry"))]
+type GroupCrs = GroupEpsg;
+
+/// Per-group CRS bookkeeping: the coordinate frame every member of the group
+/// must share.
+#[cfg(feature = "new-geometry")]
+type GroupCrs = CoordinateFrame;
+
 struct AreaOnAreaOverlayer {
     group_by: Option<Vec<Attribute>>,
     output_attribute: Option<String>,
@@ -144,10 +171,9 @@ struct AreaOnAreaOverlayer {
     tolerance: f64,
     // Disk-backed state
     group_map: HashMap<AttributeValue, usize>,
-    /// Per-group CRS carried over from the inputs onto the overlay outputs.
-    /// A missing EPSG means unknown, not conflicting; only differing known
-    /// EPSGs drop the CRS.
-    group_epsg: HashMap<usize, GroupEpsg>,
+    /// Per-group CRS state keeping the overlay inputs and outputs in one
+    /// coordinate reference.
+    group_crs: HashMap<usize, GroupCrs>,
     group_count: usize,
     temp_dir: Option<PathBuf>,
     // In-memory buffer: group_idx -> Vec<(aabb_json, feature_json)>
@@ -158,6 +184,7 @@ struct AreaOnAreaOverlayer {
 }
 
 /// Tracks the CRS of the features accumulated into a single overlay group.
+#[cfg(not(feature = "new-geometry"))]
 #[derive(Clone, Copy)]
 enum GroupEpsg {
     /// The single EPSG known so far (`None` while only EPSG-less features
@@ -167,6 +194,7 @@ enum GroupEpsg {
     Mixed,
 }
 
+#[cfg(not(feature = "new-geometry"))]
 impl GroupEpsg {
     /// Fold another feature's EPSG into the group's running state.
     fn observe(&mut self, epsg: Option<EpsgCode>) {
@@ -205,7 +233,7 @@ impl Clone for AreaOnAreaOverlayer {
             accumulation_mode: self.accumulation_mode.clone(),
             tolerance: self.tolerance,
             group_map: HashMap::new(),
-            group_epsg: HashMap::new(),
+            group_crs: HashMap::new(),
             group_count: 0,
             temp_dir: None,
             buffer: HashMap::new(),
@@ -305,6 +333,31 @@ impl AreaOnAreaOverlayer {
         self.buffer_bytes = 0;
         Ok(())
     }
+
+    /// Fold `epsg` into the group's CRS state; every accepted feature joins
+    /// its group.
+    #[cfg(not(feature = "new-geometry"))]
+    fn admit_crs(&mut self, group_idx: usize, epsg: Option<EpsgCode>) -> bool {
+        self.group_crs
+            .entry(group_idx)
+            .or_insert(GroupEpsg::Uniform(epsg))
+            .observe(epsg);
+        true
+    }
+
+    /// Whether `frame` matches the group's coordinate frame, which the first
+    /// feature of the group fixes. Overlay operands must share one frame.
+    #[cfg(feature = "new-geometry")]
+    fn admit_crs(&mut self, group_idx: usize, frame: &CoordinateFrame) -> bool {
+        use std::collections::hash_map::Entry;
+        match self.group_crs.entry(group_idx) {
+            Entry::Occupied(entry) => entry.get() == frame,
+            Entry::Vacant(entry) => {
+                entry.insert(frame.clone());
+                true
+            }
+        }
+    }
 }
 
 impl Drop for AreaOnAreaOverlayer {
@@ -320,7 +373,6 @@ impl Processor for AreaOnAreaOverlayer {
         true
     }
 
-    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -332,62 +384,41 @@ impl Processor for AreaOnAreaOverlayer {
         }
 
         let feature = &ctx.feature;
-        let geometry = &feature.geometry;
-        if geometry.is_empty() {
-            fw.send(ctx.new_with_feature_and_port(ctx.feature.clone(), REJECTED_PORT.clone()));
+        let Some((aabb, crs)) = intake(feature.geometry.as_ref()) else {
+            fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+            return Ok(());
+        };
+
+        let key = if let Some(group_by) = &self.group_by {
+            AttributeValue::Array(
+                group_by
+                    .iter()
+                    .filter_map(|attr| feature.attributes.get(attr).cloned())
+                    .collect(),
+            )
+        } else {
+            AttributeValue::Null
+        };
+
+        let group_idx = if let Some(&idx) = self.group_map.get(&key) {
+            idx
+        } else {
+            let idx = self.group_count;
+            self.group_map.insert(key, idx);
+            self.group_count += 1;
+            idx
+        };
+
+        if !self.admit_crs(group_idx, crs) {
+            fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
             return Ok(());
         }
-        match &geometry.value {
-            GeometryValue::None => {
-                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
-            }
-            GeometryValue::FlowGeometry2D(geom_2d) => {
-                let key = if let Some(group_by) = &self.group_by {
-                    AttributeValue::Array(
-                        group_by
-                            .iter()
-                            .filter_map(|attr| feature.attributes.get(attr).cloned())
-                            .collect(),
-                    )
-                } else {
-                    AttributeValue::Null
-                };
 
-                let group_idx = if let Some(&idx) = self.group_map.get(&key) {
-                    idx
-                } else {
-                    let idx = self.group_count;
-                    self.group_map.insert(key, idx);
-                    self.group_count += 1;
-                    idx
-                };
-
-                // Carry the input CRS forward: the overlay output lives in the
-                // same plane as its inputs.
-                self.group_epsg
-                    .entry(group_idx)
-                    .or_insert(GroupEpsg::Uniform(geometry.epsg))
-                    .observe(geometry.epsg);
-
-                // Compute AABB from geometry (convert closed LineStrings to Polygon first)
-                let mp = geom_to_multipolygon(geom_2d);
-                let aabb = mp.bounding_box();
-                let aabb = match aabb {
-                    Some(rect) => [rect.min().x, rect.min().y, rect.max().x, rect.max().y],
-                    None => [0.0, 0.0, 0.0, 0.0],
-                };
-
-                let feature_json = serde_json::to_string(&ctx.feature)?;
-                self.append_to_group(group_idx, &aabb, &feature_json)?;
-            }
-            _ => {
-                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
-            }
-        }
+        let feature_json = serde_json::to_string(&ctx.feature)?;
+        self.append_to_group(group_idx, &aabb, &feature_json)?;
         Ok(())
     }
 
-    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,
@@ -440,18 +471,23 @@ impl Processor for AreaOnAreaOverlayer {
             overlay_2d_disk(&aabbs, &disk_feats, self.tolerance, &midpolygons_path)?;
 
             // Stream midpolygons from disk, build features, write directly to output files
-            let group_epsg = self
-                .group_epsg
-                .get(&group_idx)
-                .copied()
-                .and_then(GroupEpsg::resolve);
+            #[cfg(not(feature = "new-geometry"))]
+            let shaper = OutputShaper {
+                epsg: self
+                    .group_crs
+                    .get(&group_idx)
+                    .copied()
+                    .and_then(GroupEpsg::resolve),
+            };
+            #[cfg(feature = "new-geometry")]
+            let shaper = OutputShaper::new(&disk_feats);
             let (ac, rc) = from_midpolygons_disk(
                 &midpolygons_path,
                 &disk_feats,
                 &self.output_attribute,
                 &self.generate_list,
                 &self.accumulation_mode,
-                group_epsg,
+                shaper,
                 &mut area_writer,
                 &mut remnants_writer,
             )?;
@@ -532,19 +568,12 @@ impl DiskBackedFeatures {
             .expect("failed to read feature from disk");
         serde_json::from_slice(&buf).expect("failed to deserialize feature")
     }
-
-    /// Read and extract only the geometry from a feature at the given index.
-    #[cfg(not(feature = "new-geometry"))]
-    fn read_geometry(&self, i: usize) -> Arc<Geometry> {
-        let feature = self.read_feature(i);
-        feature.geometry
-    }
 }
 
 /// Polygon that is created in the middle of the overlay process.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct MiddlePolygon {
-    polygon: MultiPolygon2D<f64>,
+    polygon: WorkingArea,
     parents: Vec<usize>,
 }
 
@@ -565,16 +594,20 @@ impl MiddlePolygon {
     }
 }
 
-/// Extract Geometry2D reference from Arc<Geometry>, or None if not FlowGeometry2D
-fn as_geometry_2d(geom: &Arc<Geometry>) -> Option<&Geometry2D<f64>> {
-    match &geom.value {
-        GeometryValue::FlowGeometry2D(flow_geom) => Some(flow_geom),
-        _ => None,
-    }
-}
+// --- world-specific geometry kernel -----------------------------------------
+
+/// The areal value carried through the overlay subdivision.
+#[cfg(not(feature = "new-geometry"))]
+type WorkingArea = MultiPolygon2D<f64>;
+
+/// The areal value carried through the overlay subdivision: a feature's own 2D
+/// geometry, or the constructed faces cut out of one.
+#[cfg(feature = "new-geometry")]
+type WorkingArea = Euclidean2DGeometry;
 
 /// Convert Geometry2D to MultiPolygon2D.
 /// Handles Polygon, MultiPolygon, and closed LineStrings (converted to Polygon).
+#[cfg(not(feature = "new-geometry"))]
 fn geom_to_multipolygon(geom: &Geometry2D<f64>) -> MultiPolygon2D<f64> {
     match geom {
         Geometry2D::Polygon(poly) => MultiPolygon2D::new(vec![poly.clone()]),
@@ -592,23 +625,320 @@ fn geom_to_multipolygon(geom: &Geometry2D<f64>) -> MultiPolygon2D<f64> {
     }
 }
 
-/// Perform intersection between MultiPolygon2D and Geometry2D
-fn bool_op_intersection(mp: &MultiPolygon2D<f64>, geom: &Geometry2D<f64>) -> MultiPolygon2D<f64> {
-    let other = geom_to_multipolygon(geom);
-    if other.0.is_empty() {
-        return MultiPolygon2D::new(vec![]);
+/// Accept an incoming geometry into the overlay: any 2D geometry. Returns its
+/// bounding box and EPSG, or `None` when the feature must be rejected.
+#[cfg(not(feature = "new-geometry"))]
+fn intake(geometry: &Geometry) -> Option<([f64; 4], Option<EpsgCode>)> {
+    if geometry.is_empty() {
+        return None;
     }
-    mp.intersection(&other)
+    let GeometryValue::FlowGeometry2D(geom_2d) = &geometry.value else {
+        return None;
+    };
+    // Compute AABB from geometry (convert closed LineStrings to Polygon first)
+    let mp = geom_to_multipolygon(geom_2d);
+    let aabb = match mp.bounding_box() {
+        Some(rect) => [rect.min().x, rect.min().y, rect.max().x, rect.max().y],
+        None => [0.0, 0.0, 0.0, 0.0],
+    };
+    Some((aabb, geometry.epsg))
 }
 
-/// Perform difference between MultiPolygon2D and Geometry2D
-fn bool_op_difference(mp: &MultiPolygon2D<f64>, geom: &Geometry2D<f64>) -> MultiPolygon2D<f64> {
-    let other = geom_to_multipolygon(geom);
-    if other.0.is_empty() {
-        return mp.clone();
+/// Accept an incoming geometry into the overlay: a 2D areal geometry
+/// (polygons, meshes, or closed line strings) whose leaves share one
+/// coordinate frame. Returns its bounding box and frame, or `None` when the
+/// feature must be rejected.
+#[cfg(feature = "new-geometry")]
+fn intake(geometry: &Geometry) -> Option<([f64; 4], &CoordinateFrame)> {
+    let Geometry::Euclidean2D(geom_2d) = geometry else {
+        return None;
+    };
+    let mut leaves = Vec::new();
+    flatten_2d(geom_2d, &mut leaves);
+    let frame = leaves.first()?.frame();
+    for leaf in &leaves {
+        if leaf.frame() != frame {
+            return None;
+        }
+        match leaf {
+            Leaf2D::Polygon(_) | Leaf2D::PolygonMesh(_) | Leaf2D::TriangularMesh(_) => {}
+            Leaf2D::Line(line) if is_closed_ring(line) => {}
+            _ => return None,
+        }
     }
-    mp.difference(&other)
+    let Ok(Aabb::D2 { min, max }) = geom_2d.bounding_box() else {
+        return None;
+    };
+    Some(([min[0], min[1], max[0], max[1]], frame))
 }
+
+/// Whether the line string traces a closed ring that can enclose area.
+#[cfg(feature = "new-geometry")]
+fn is_closed_ring(line: &LineString2D) -> bool {
+    let coords = line.coords();
+    coords.len() >= 4 && coords.first() == coords.last()
+}
+
+/// The stored feature `i`'s geometry as a working area, or `None` when it is
+/// not a 2D geometry.
+#[cfg(not(feature = "new-geometry"))]
+fn read_working_area(disk_feats: &DiskBackedFeatures, i: usize) -> Option<WorkingArea> {
+    let geometry = disk_feats.read_feature(i).geometry;
+    match &geometry.value {
+        GeometryValue::FlowGeometry2D(geom_2d) => Some(geom_to_multipolygon(geom_2d)),
+        _ => None,
+    }
+}
+
+/// The stored feature `i`'s geometry as a working area, or `None` when it is
+/// not a 2D geometry.
+#[cfg(feature = "new-geometry")]
+fn read_working_area(disk_feats: &DiskBackedFeatures, i: usize) -> Option<WorkingArea> {
+    let geometry = disk_feats.read_feature(i).geometry;
+    let Geometry::Euclidean2D(geom_2d) = geometry.as_ref() else {
+        return None;
+    };
+    Some(normalize_area(geom_2d))
+}
+
+/// The geometry with closed line strings replaced by the polygon faces they
+/// trace; every other member is kept verbatim.
+#[cfg(feature = "new-geometry")]
+fn normalize_area(geom: &Euclidean2DGeometry) -> Euclidean2DGeometry {
+    match geom {
+        Euclidean2DGeometry::LineString(line) if is_closed_ring(line) => {
+            Euclidean2DGeometry::Polygon(Box::new(ring_face(line)))
+        }
+        Euclidean2DGeometry::Collection(collection) => {
+            let members: Vec<_> = collection.members().iter().map(normalize_area).collect();
+            let attrs = collection.member_attributes().to_vec();
+            Euclidean2DGeometry::Collection(
+                Collection2D::with_attributes(members, attrs)
+                    .expect("member count is unchanged by normalization"),
+            )
+        }
+        other => other.clone(),
+    }
+}
+
+/// The polygon face a closed line string traces, at the line's elevation.
+#[cfg(feature = "new-geometry")]
+fn ring_face(line: &LineString2D) -> Polygon2D {
+    let frame = line.frame().clone();
+    let ring = line.coords().iter().copied();
+    let no_holes = Vec::<Vec<[f64; 2]>>::new();
+    match line.elevation() {
+        Some(z) => Polygon2D::from_rings_at_elevation(frame, ring, no_holes, z),
+        None => Polygon2D::from_rings(frame, ring, no_holes),
+    }
+}
+
+/// Constructed polygons as one working area.
+#[cfg(feature = "new-geometry")]
+fn wrap_polygons(mut polygons: Vec<Polygon2D>) -> WorkingArea {
+    if polygons.len() == 1 {
+        Euclidean2DGeometry::Polygon(Box::new(polygons.remove(0)))
+    } else {
+        Euclidean2DGeometry::Collection(Collection2D::new(
+            polygons
+                .into_iter()
+                .map(|p| Euclidean2DGeometry::Polygon(Box::new(p))),
+        ))
+    }
+}
+
+/// The points of `a` not in `b`.
+#[cfg(not(feature = "new-geometry"))]
+fn area_difference(a: &WorkingArea, b: &WorkingArea) -> Result<WorkingArea, BoxedError> {
+    if b.0.is_empty() {
+        return Ok(a.clone());
+    }
+    Ok(a.difference(b))
+}
+
+/// The points of `a` not in `b`, as constructed faces.
+#[cfg(feature = "new-geometry")]
+fn area_difference(a: &WorkingArea, b: &WorkingArea) -> Result<WorkingArea, BoxedError> {
+    let polygons = overlay_2d(a, b, OverlayOp::Difference)
+        .map_err(|e| GeometryProcessorError::AreaOnAreaOverlayer(format!("overlay failed: {e}")))?;
+    Ok(wrap_polygons(polygons))
+}
+
+/// The points in both `a` and `b`.
+#[cfg(not(feature = "new-geometry"))]
+fn area_intersection(a: &WorkingArea, b: &WorkingArea) -> Result<WorkingArea, BoxedError> {
+    if b.0.is_empty() {
+        return Ok(MultiPolygon2D::new(vec![]));
+    }
+    Ok(a.intersection(b))
+}
+
+/// The points in both `a` and `b`, as constructed faces.
+#[cfg(feature = "new-geometry")]
+fn area_intersection(a: &WorkingArea, b: &WorkingArea) -> Result<WorkingArea, BoxedError> {
+    let polygons = overlay_2d(a, b, OverlayOp::Intersection)
+        .map_err(|e| GeometryProcessorError::AreaOnAreaOverlayer(format!("overlay failed: {e}")))?;
+    Ok(wrap_polygons(polygons))
+}
+
+/// The total planar area of `a`.
+#[cfg(not(feature = "new-geometry"))]
+fn area_measure(a: &WorkingArea) -> f64 {
+    a.unsigned_area2d()
+}
+
+/// The total planar area of `a`'s polygon faces; `a` must be a constructed
+/// working area (polygons only).
+#[cfg(feature = "new-geometry")]
+fn area_measure(a: &WorkingArea) -> f64 {
+    let mut leaves = Vec::new();
+    flatten_2d(a, &mut leaves);
+    leaves
+        .iter()
+        .filter_map(|leaf| match leaf {
+            Leaf2D::Polygon(p) => Some(p.area()),
+            _ => None,
+        })
+        .sum()
+}
+
+/// Whether `a` covers no area.
+#[cfg(not(feature = "new-geometry"))]
+fn area_is_empty(a: &WorkingArea) -> bool {
+    a.is_empty()
+}
+
+/// Whether `a` covers no area.
+#[cfg(feature = "new-geometry")]
+fn area_is_empty(a: &WorkingArea) -> bool {
+    let mut leaves = Vec::new();
+    flatten_2d(a, &mut leaves);
+    leaves.is_empty()
+}
+
+/// Shapes each subdivision piece into an output feature's geometry.
+#[cfg(not(feature = "new-geometry"))]
+struct OutputShaper {
+    /// The EPSG stamped onto outputs, when the group's inputs agree on one.
+    epsg: Option<EpsgCode>,
+}
+
+#[cfg(not(feature = "new-geometry"))]
+impl OutputShaper {
+    /// Install `area` as `feature`'s geometry.
+    fn apply(&mut self, feature: &mut Feature, area: WorkingArea, _parents: &[usize]) {
+        feature.geometry_mut().value = GeometryValue::FlowGeometry2D(area.into());
+        feature.geometry_mut().epsg = self.epsg;
+    }
+}
+
+/// Shapes each subdivision piece into an output feature's geometry, carrying a
+/// shared source elevation onto constructed faces.
+#[cfg(feature = "new-geometry")]
+struct OutputShaper<'a> {
+    disk_feats: &'a DiskBackedFeatures,
+    /// Cached uniform elevation per source feature: `Some(z)` when every leaf
+    /// of the feature's geometry lies at `z`.
+    elevations: HashMap<usize, Option<f64>>,
+}
+
+#[cfg(feature = "new-geometry")]
+impl<'a> OutputShaper<'a> {
+    fn new(disk_feats: &'a DiskBackedFeatures) -> Self {
+        Self {
+            disk_feats,
+            elevations: HashMap::new(),
+        }
+    }
+
+    /// Install `area` as `feature`'s geometry. When every parent lies at one
+    /// shared elevation, elevation-less faces of the piece are placed there.
+    fn apply(&mut self, feature: &mut Feature, area: WorkingArea, parents: &[usize]) {
+        let area = match self.shared_elevation(parents) {
+            Some(z) => stamp_elevation(area, z),
+            None => area,
+        };
+        *feature.geometry_mut() = Geometry::Euclidean2D(area);
+    }
+
+    /// The one elevation all `parents` lie at, or `None`.
+    fn shared_elevation(&mut self, parents: &[usize]) -> Option<f64> {
+        let mut shared = None;
+        for (i, &parent) in parents.iter().enumerate() {
+            let disk_feats = self.disk_feats;
+            let z = (*self
+                .elevations
+                .entry(parent)
+                .or_insert_with(|| feature_elevation(disk_feats, parent)))?;
+            if i == 0 {
+                shared = Some(z);
+            } else if shared != Some(z) {
+                return None;
+            }
+        }
+        shared
+    }
+}
+
+/// The one elevation every leaf of the stored feature `i`'s geometry lies at,
+/// or `None`.
+#[cfg(feature = "new-geometry")]
+fn feature_elevation(disk_feats: &DiskBackedFeatures, i: usize) -> Option<f64> {
+    let geometry = disk_feats.read_feature(i).geometry;
+    let Geometry::Euclidean2D(geom_2d) = geometry.as_ref() else {
+        return None;
+    };
+    let mut leaves = Vec::new();
+    flatten_2d(geom_2d, &mut leaves);
+    let mut shared = None;
+    for (i, leaf) in leaves.iter().enumerate() {
+        let z = leaf_elevation(leaf)?;
+        if i == 0 {
+            shared = Some(z);
+        } else if shared != Some(z) {
+            return None;
+        }
+    }
+    shared
+}
+
+/// The elevation a 2D leaf lies at, or `None` when it is pure 2D.
+#[cfg(feature = "new-geometry")]
+fn leaf_elevation(leaf: &Leaf2D<'_>) -> Option<f64> {
+    match leaf {
+        Leaf2D::Polygon(p) => p.elevation(),
+        Leaf2D::PolygonMesh(m) => m.elevation(),
+        Leaf2D::TriangularMesh(m) => m.elevation(),
+        Leaf2D::Line(l) => l.elevation(),
+        Leaf2D::Point(_) => None,
+    }
+}
+
+/// `area` with every elevation-less polygon face placed at `z`.
+#[cfg(feature = "new-geometry")]
+fn stamp_elevation(area: WorkingArea, z: f64) -> WorkingArea {
+    match area {
+        Euclidean2DGeometry::Polygon(p) if p.elevation().is_none() => {
+            Euclidean2DGeometry::Polygon(Box::new(p.at_elevation(z)))
+        }
+        Euclidean2DGeometry::Collection(collection) => {
+            let members: Vec<_> = collection
+                .members()
+                .iter()
+                .cloned()
+                .map(|m| stamp_elevation(m, z))
+                .collect();
+            let attrs = collection.member_attributes().to_vec();
+            Euclidean2DGeometry::Collection(
+                Collection2D::with_attributes(members, attrs)
+                    .expect("member count is unchanged by elevation stamping"),
+            )
+        }
+        other => other,
+    }
+}
+
+// --- shared subdivision ------------------------------------------------------
 
 /// An AABB entry for the RTree built from pre-computed bounding boxes stored on disk.
 #[derive(Clone)]
@@ -665,9 +995,9 @@ impl AabbIndex {
     }
 }
 
-/// Disk-backed version of overlay_2d that reads geometries from disk on demand
-/// and writes MiddlePolygons to a JSONL file instead of collecting in memory.
-#[cfg(not(feature = "new-geometry"))]
+/// Disk-backed subdivision: reads each stored feature's areal geometry, cuts
+/// it against its bounding-box neighbours, and writes the resulting
+/// MiddlePolygons to a JSONL file instead of collecting in memory.
 fn overlay_2d_disk(
     aabbs: &[[f64; 4]],
     disk_feats: &DiskBackedFeatures,
@@ -680,84 +1010,74 @@ fn overlay_2d_disk(
     let aabb_index = AabbIndex::build(aabbs);
     let num = disk_feats.offsets.len();
 
-    // Load all geometries upfront to avoid disk I/O inside parallel iteration
-    let geometries: Vec<Arc<Geometry>> = (0..num).map(|i| disk_feats.read_geometry(i)).collect();
+    // Load all working areas upfront to avoid disk I/O inside parallel iteration
+    let areas: Vec<Option<WorkingArea>> =
+        (0..num).map(|i| read_working_area(disk_feats, i)).collect();
 
-    // Parallel iteration with flat_map to collect all results
-    let results: Vec<MiddlePolygon> = (0..num)
+    let results: Vec<Vec<MiddlePolygon>> = (0..num)
         .into_par_iter()
-        .flat_map(|i| {
-            let geom_i = &geometries[i];
-            let geom_i_2d = match as_geometry_2d(geom_i) {
-                Some(g) => g,
-                None => return Vec::new(),
+        .map(|i| -> Result<Vec<MiddlePolygon>, BoxedError> {
+            let Some(area_i) = &areas[i] else {
+                return Ok(Vec::new());
             };
-
-            let mut polygon_target = geom_to_multipolygon(geom_i_2d);
 
             // Collect overlapping indices once (the iterator is consumed on use)
             let overlapping: Vec<usize> = aabb_index.overlapping_indices(i).collect();
 
-            // cut off the target polygon by upper polygons
+            // cut off the target area by upper areas
+            let mut target = area_i.clone();
             for &j in &overlapping {
                 if i < j {
-                    let geom_j = &geometries[j];
-                    if let Some(geom_j_2d) = as_geometry_2d(geom_j) {
-                        polygon_target = bool_op_difference(&polygon_target, geom_j_2d);
+                    if let Some(area_j) = &areas[j] {
+                        target = area_difference(&target, area_j)?;
                     }
                 }
             }
 
             let mut queue = vec![MiddlePolygon {
-                polygon: polygon_target,
+                polygon: target,
                 parents: vec![i],
             }];
 
-            // divide the target polygon by lower polygons
+            // divide the target area by lower areas
             for &j in &overlapping {
                 if i > j {
-                    let geom_j = &geometries[j];
-                    if let Some(geom_j_2d) = as_geometry_2d(geom_j) {
-                        let mut new_queue = Vec::new();
-                        for subpolygon in queue {
-                            let intersection = bool_op_intersection(&subpolygon.polygon, geom_j_2d);
+                    let Some(area_j) = &areas[j] else {
+                        continue;
+                    };
+                    let mut new_queue = Vec::new();
+                    for subpolygon in queue {
+                        let intersection = area_intersection(&subpolygon.polygon, area_j)?;
 
-                            let min_area = tolerance * tolerance;
-                            let intersection_area = intersection.unsigned_area2d();
-                            let is_significant_intersection = intersection_area > min_area;
+                        let min_area = tolerance * tolerance;
+                        let is_significant_intersection = area_measure(&intersection) > min_area;
 
-                            if !intersection.is_empty() && is_significant_intersection {
-                                new_queue.push(MiddlePolygon {
-                                    polygon: intersection,
-                                    parents: subpolygon
-                                        .parents
-                                        .clone()
-                                        .into_iter()
-                                        .chain(vec![j])
-                                        .collect(),
-                                });
-                            }
-
-                            let difference = bool_op_difference(&subpolygon.polygon, geom_j_2d);
-                            if !difference.is_empty() {
-                                new_queue.push(MiddlePolygon {
-                                    polygon: difference,
-                                    parents: subpolygon.parents.clone(),
-                                });
-                            }
+                        if !area_is_empty(&intersection) && is_significant_intersection {
+                            new_queue.push(MiddlePolygon {
+                                polygon: intersection,
+                                parents: subpolygon.parents.iter().copied().chain([j]).collect(),
+                            });
                         }
-                        queue = new_queue;
+
+                        let difference = area_difference(&subpolygon.polygon, area_j)?;
+                        if !area_is_empty(&difference) {
+                            new_queue.push(MiddlePolygon {
+                                polygon: difference,
+                                parents: subpolygon.parents.clone(),
+                            });
+                        }
                     }
+                    queue = new_queue;
                 }
             }
 
-            queue
+            Ok(queue)
         })
-        .collect();
+        .collect::<Result<Vec<_>, _>>()?;
 
     // Write all results from a single thread
     let mut writer = BufWriter::new(File::create(output_path)?);
-    for mp in results {
+    for mp in results.into_iter().flatten() {
         let line = serde_json::to_string(&mp)?;
         writer.write_all(line.as_bytes())?;
         writer.write_all(b"\n")?;
@@ -770,7 +1090,6 @@ fn overlay_2d_disk(
 /// Stream MiddlePolygons from a JSONL file, convert to Features, and write
 /// directly to area/remnants output files without collecting in memory.
 /// Returns (area_count, remnants_count).
-#[cfg(not(feature = "new-geometry"))]
 #[allow(clippy::too_many_arguments)]
 fn from_midpolygons_disk<W: Write>(
     midpolygons_path: &Path,
@@ -778,7 +1097,7 @@ fn from_midpolygons_disk<W: Write>(
     output_attribute: &Option<String>,
     generate_list: &Option<String>,
     accumulation_mode: &AccumulationMode,
-    epsg: Option<EpsgCode>,
+    mut shaper: OutputShaper,
     area_writer: &mut W,
     remnants_writer: &mut W,
 ) -> Result<(usize, usize), BoxedError> {
@@ -845,9 +1164,7 @@ fn from_midpolygons_disk<W: Write>(
                     );
                 }
 
-                feature.geometry_mut().value =
-                    GeometryValue::FlowGeometry2D(subpolygon.polygon.into());
-                feature.geometry_mut().epsg = epsg;
+                shaper.apply(&mut feature, subpolygon.polygon, &parents);
                 serde_json::to_writer(&mut *area_writer, &feature)?;
                 area_writer.write_all(b"\n")?;
                 area_count += 1;
@@ -886,9 +1203,7 @@ fn from_midpolygons_disk<W: Write>(
                     );
                 }
 
-                feature.geometry_mut().value =
-                    GeometryValue::FlowGeometry2D(subpolygon.polygon.into());
-                feature.geometry_mut().epsg = epsg;
+                shaper.apply(&mut feature, subpolygon.polygon, &[parent]);
                 serde_json::to_writer(&mut *remnants_writer, &feature)?;
                 remnants_writer.write_all(b"\n")?;
                 remnants_count += 1;
@@ -899,7 +1214,7 @@ fn from_midpolygons_disk<W: Write>(
     Ok((area_count, remnants_count))
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "new-geometry")))]
 mod tests {
     use reearth_flow_geometry::types::{
         coordinate::Coordinate2D, line_string::LineString2D, polygon::Polygon2D,
@@ -919,7 +1234,6 @@ mod tests {
         )))
     }
 
-    #[cfg(not(feature = "new-geometry"))]
     fn make_feature(coords: Vec<(f64, f64)>) -> Feature {
         let geom = make_geom(coords);
         let mut f = Feature::new_with_attributes(IndexMap::new());
@@ -962,7 +1276,6 @@ mod tests {
         assert_eq!(state.resolve(), Some(6675));
     }
 
-    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_overlay_two_squares_disk() {
         // Create temp dir and write features to disk
@@ -1014,7 +1327,6 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_overlay_triangles_sharing_an_edge_disk() {
         let dir =
@@ -1048,6 +1360,277 @@ mod tests {
             .filter(|l| l.as_ref().map(|s| !s.is_empty()).unwrap_or(false))
             .count();
         assert_eq!(count, 2);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}
+
+#[cfg(all(test, feature = "new-geometry"))]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use reearth_flow_geometry::triangular_mesh::TriangularMesh2D;
+
+    use super::*;
+
+    fn square_ring(min: [f64; 2], max: [f64; 2]) -> Vec<[f64; 2]> {
+        vec![
+            [min[0], min[1]],
+            [max[0], min[1]],
+            [max[0], max[1]],
+            [min[0], max[1]],
+            [min[0], min[1]],
+        ]
+    }
+
+    fn square(min: [f64; 2], max: [f64; 2]) -> Geometry {
+        Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(Box::new(
+            Polygon2D::from_rings(
+                CoordinateFrame::Euclidean,
+                square_ring(min, max),
+                Vec::<Vec<[f64; 2]>>::new(),
+            ),
+        )))
+    }
+
+    fn square_at(min: [f64; 2], max: [f64; 2], z: f64) -> Geometry {
+        Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(Box::new(
+            Polygon2D::from_rings_at_elevation(
+                CoordinateFrame::Euclidean,
+                square_ring(min, max),
+                Vec::<Vec<[f64; 2]>>::new(),
+                z,
+            ),
+        )))
+    }
+
+    fn triangle(coords: [[f64; 2]; 3]) -> Geometry {
+        let ring = vec![coords[0], coords[1], coords[2], coords[0]];
+        Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(Box::new(
+            Polygon2D::from_rings(
+                CoordinateFrame::Euclidean,
+                ring,
+                Vec::<Vec<[f64; 2]>>::new(),
+            ),
+        )))
+    }
+
+    /// Two triangles forming the square [0,2] x [0,2], as one triangular mesh.
+    fn square_mesh() -> Geometry {
+        let mesh = TriangularMesh2D::from_parts(
+            CoordinateFrame::Euclidean,
+            vec![[0.0, 0.0], [2.0, 0.0], [2.0, 2.0], [0.0, 2.0]],
+            [0u32, 1, 2, 0, 2, 3],
+        )
+        .unwrap();
+        Geometry::Euclidean2D(Euclidean2DGeometry::TriangularMesh(Box::new(mesh)))
+    }
+
+    /// Write `features` as one group on disk, returning its directory and the
+    /// scanned features file.
+    fn setup_group(features: &[Feature]) -> (PathBuf, DiskBackedFeatures) {
+        let dir =
+            engine_cache_dir(uuid::Uuid::nil()).join(format!("test-aoa-{}", uuid::Uuid::new_v4()));
+        let group_dir = dir.join("group_000000");
+        std::fs::create_dir_all(&group_dir).unwrap();
+        let features_path = group_dir.join("features.jsonl");
+        {
+            let mut writer = BufWriter::new(File::create(&features_path).unwrap());
+            for f in features {
+                serde_json::to_writer(&mut writer, f).unwrap();
+                writer.write_all(b"\n").unwrap();
+            }
+            writer.flush().unwrap();
+        }
+        let disk_feats = DiskBackedFeatures::scan(&features_path).unwrap();
+        (dir, disk_feats)
+    }
+
+    fn run_overlay(geometries: Vec<Geometry>, tolerance: f64) -> (PathBuf, Vec<MiddlePolygon>) {
+        let features: Vec<Feature> = geometries.into_iter().map(Feature::from).collect();
+        let aabbs: Vec<[f64; 4]> = features
+            .iter()
+            .map(|f| intake(f.geometry.as_ref()).unwrap().0)
+            .collect();
+        let (dir, disk_feats) = setup_group(&features);
+        let midpolygons_path = dir.join("group_000000").join("midpolygons.jsonl");
+        overlay_2d_disk(&aabbs, &disk_feats, tolerance, &midpolygons_path).unwrap();
+        let pieces = BufReader::new(File::open(&midpolygons_path).unwrap())
+            .lines()
+            .map(|l| l.unwrap())
+            .filter(|l| !l.is_empty())
+            .map(|l| serde_json::from_str(&l).unwrap())
+            .collect();
+        (dir, pieces)
+    }
+
+    #[test]
+    fn two_overlapping_squares_subdivide_into_three_pieces() {
+        let (dir, pieces) = run_overlay(
+            vec![
+                square([0.0, 0.0], [2.0, 2.0]),
+                square([1.0, 1.0], [3.0, 3.0]),
+            ],
+            0.01,
+        );
+        assert_eq!(pieces.len(), 3);
+        let areas = pieces.iter().filter(|p| p.parents.len() == 2).count();
+        let remnants = pieces.iter().filter(|p| p.parents.len() == 1).count();
+        assert_eq!((areas, remnants), (1, 2));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_triangle_atop_the_shared_base_of_another_yields_two_pieces() {
+        let (dir, pieces) = run_overlay(
+            vec![
+                triangle([[0.0, 0.0], [2.0, 0.0], [1.0, 2.0]]),
+                triangle([[0.0, 0.0], [2.0, 0.0], [1.0, 1.0]]),
+            ],
+            0.01,
+        );
+        assert_eq!(pieces.len(), 2);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_mesh_overlaps_a_polygon_like_the_polygon_it_dissolves_to() {
+        let (dir, pieces) = run_overlay(vec![square_mesh(), square([1.0, 1.0], [3.0, 3.0])], 0.01);
+        assert_eq!(pieces.len(), 3);
+        let areas = pieces.iter().filter(|p| p.parents.len() == 2).count();
+        assert_eq!(areas, 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn an_untouched_feature_keeps_its_geometry_verbatim() {
+        let (dir, pieces) = run_overlay(vec![square_mesh()], 0.01);
+        assert_eq!(pieces.len(), 1);
+        let Geometry::Euclidean2D(expected) = square_mesh() else {
+            unreachable!();
+        };
+        assert_eq!(pieces[0].polygon, expected);
+        assert_eq!(pieces[0].parents, vec![0]);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_thin_overlap_below_the_tolerance_is_dropped() {
+        let (dir, pieces) = run_overlay(
+            vec![
+                square([0.0, 0.0], [2.0, 2.0]),
+                square([1.95, 0.0], [3.95, 2.0]),
+            ],
+            0.5,
+        );
+        assert!(pieces.iter().all(|p| p.parents.len() == 1));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn intake_accepts_a_closed_line_string_as_areal() {
+        let line = LineString2D::from_coords(
+            CoordinateFrame::Euclidean,
+            square_ring([0.0, 0.0], [2.0, 2.0]),
+        );
+        let geometry = Geometry::Euclidean2D(Euclidean2DGeometry::LineString(line));
+        let (aabb, frame) = intake(&geometry).unwrap();
+        assert_eq!(aabb, [0.0, 0.0, 2.0, 2.0]);
+        assert_eq!(frame, &CoordinateFrame::Euclidean);
+    }
+
+    #[test]
+    fn intake_rejects_an_open_line_string() {
+        let line = LineString2D::from_coords(
+            CoordinateFrame::Euclidean,
+            [[0.0, 0.0], [2.0, 0.0], [2.0, 2.0]],
+        );
+        let geometry = Geometry::Euclidean2D(Euclidean2DGeometry::LineString(line));
+        assert!(intake(&geometry).is_none());
+    }
+
+    #[test]
+    fn intake_rejects_a_three_dimensional_geometry() {
+        let line = reearth_flow_geometry::line_string::LineString3D::from_coords(
+            CoordinateFrame::Euclidean,
+            [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
+        );
+        let geometry =
+            Geometry::Euclidean3D(reearth_flow_geometry::Euclidean3DGeometry::LineString(line));
+        assert!(intake(&geometry).is_none());
+    }
+
+    #[test]
+    fn intake_rejects_members_in_different_frames() {
+        let in_euclidean = Polygon2D::from_rings(
+            CoordinateFrame::Euclidean,
+            square_ring([0.0, 0.0], [1.0, 1.0]),
+            Vec::<Vec<[f64; 2]>>::new(),
+        );
+        let in_crs = Polygon2D::from_rings(
+            CoordinateFrame::Crs(reearth_flow_geometry::coordinate::EpsgCode::new(6677)),
+            square_ring([0.0, 0.0], [1.0, 1.0]),
+            Vec::<Vec<[f64; 2]>>::new(),
+        );
+        let geometry = Geometry::Euclidean2D(Euclidean2DGeometry::Collection(Collection2D::new([
+            Euclidean2DGeometry::Polygon(Box::new(in_euclidean)),
+            Euclidean2DGeometry::Polygon(Box::new(in_crs)),
+        ])));
+        assert!(intake(&geometry).is_none());
+    }
+
+    #[test]
+    fn pieces_of_parents_at_one_shared_elevation_lie_there() {
+        let features = vec![
+            Feature::from(square_at([0.0, 0.0], [2.0, 2.0], 5.0)),
+            Feature::from(square_at([1.0, 1.0], [3.0, 3.0], 5.0)),
+        ];
+        let (dir, disk_feats) = setup_group(&features);
+        let mut shaper = OutputShaper::new(&disk_feats);
+
+        let area_0 = read_working_area(&disk_feats, 0).unwrap();
+        let area_1 = read_working_area(&disk_feats, 1).unwrap();
+        let piece = area_intersection(&area_0, &area_1).unwrap();
+
+        let mut feature = Feature::new_with_attributes(IndexMap::new());
+        shaper.apply(&mut feature, piece, &[0, 1]);
+        let Geometry::Euclidean2D(geom) = feature.geometry.as_ref() else {
+            panic!("expected a 2D geometry");
+        };
+        let mut leaves = Vec::new();
+        flatten_2d(geom, &mut leaves);
+        assert!(!leaves.is_empty());
+        assert!(leaves.iter().all(|l| leaf_elevation(l) == Some(5.0)));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn pieces_of_parents_at_differing_elevations_stay_planar() {
+        let features = vec![
+            Feature::from(square_at([0.0, 0.0], [2.0, 2.0], 5.0)),
+            Feature::from(square_at([1.0, 1.0], [3.0, 3.0], 7.0)),
+        ];
+        let (dir, disk_feats) = setup_group(&features);
+        let mut shaper = OutputShaper::new(&disk_feats);
+
+        let area_0 = read_working_area(&disk_feats, 0).unwrap();
+        let area_1 = read_working_area(&disk_feats, 1).unwrap();
+        let piece = area_intersection(&area_0, &area_1).unwrap();
+
+        let mut feature = Feature::new_with_attributes(IndexMap::new());
+        shaper.apply(&mut feature, piece, &[0, 1]);
+        let Geometry::Euclidean2D(geom) = feature.geometry.as_ref() else {
+            panic!("expected a 2D geometry");
+        };
+        let mut leaves = Vec::new();
+        flatten_2d(geom, &mut leaves);
+        assert!(!leaves.is_empty());
+        assert!(leaves.iter().all(|l| leaf_elevation(l).is_none()));
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/engine/runtime/action-processor/src/geometry/area_on_area_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/area_on_area_overlayer.rs
@@ -60,7 +60,10 @@ impl ProcessorFactory for AreaOnAreaOverlayerFactory {
     }
 
     fn description(&self) -> &str {
-        "Perform Area Overlay Analysis"
+        "Subdivides overlapping areas into non-overlapping pieces and records how many input \
+         features cover each piece. Inputs must be flat 2D geometries sharing one coordinate \
+         frame; place a Two Dimension Forcer or a Coordinate Frame Reprojector upstream to \
+         flatten or unify them."
     }
 
     fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
@@ -480,7 +483,7 @@ impl Processor for AreaOnAreaOverlayer {
                     .and_then(GroupEpsg::resolve),
             };
             #[cfg(feature = "new-geometry")]
-            let shaper = OutputShaper::new(&disk_feats);
+            let shaper = OutputShaper;
             let (ac, rc) = from_midpolygons_disk(
                 &midpolygons_path,
                 &disk_feats,
@@ -644,10 +647,13 @@ fn intake(geometry: &Geometry) -> Option<([f64; 4], Option<EpsgCode>)> {
     Some((aabb, geometry.epsg))
 }
 
-/// Accept an incoming geometry into the overlay: a 2D areal geometry
+/// Accept an incoming geometry into the overlay: a planar areal geometry
 /// (polygons, meshes, or closed line strings) whose leaves share one
 /// coordinate frame. Returns its bounding box and frame, or `None` when the
 /// feature must be rejected.
+///
+/// The overlay reasons about the plane alone, so a leaf placed at an elevation
+/// is refused rather than silently overlaid with one at a different height.
 #[cfg(feature = "new-geometry")]
 fn intake(geometry: &Geometry) -> Option<([f64; 4], &CoordinateFrame)> {
     let Geometry::Euclidean2D(geom_2d) = geometry else {
@@ -657,7 +663,7 @@ fn intake(geometry: &Geometry) -> Option<([f64; 4], &CoordinateFrame)> {
     flatten_2d(geom_2d, &mut leaves);
     let frame = leaves.first()?.frame();
     for leaf in &leaves {
-        if leaf.frame() != frame {
+        if leaf.frame() != frame || leaf_elevation(leaf).is_some() {
             return None;
         }
         match leaf {
@@ -721,16 +727,14 @@ fn normalize_area(geom: &Euclidean2DGeometry) -> Euclidean2DGeometry {
     }
 }
 
-/// The polygon face a closed line string traces, at the line's elevation.
+/// The polygon face a closed line string traces.
 #[cfg(feature = "new-geometry")]
 fn ring_face(line: &LineString2D) -> Polygon2D {
-    let frame = line.frame().clone();
-    let ring = line.coords().iter().copied();
-    let no_holes = Vec::<Vec<[f64; 2]>>::new();
-    match line.elevation() {
-        Some(z) => Polygon2D::from_rings_at_elevation(frame, ring, no_holes, z),
-        None => Polygon2D::from_rings(frame, ring, no_holes),
-    }
+    Polygon2D::from_rings(
+        line.frame().clone(),
+        line.coords().iter().copied(),
+        Vec::<Vec<[f64; 2]>>::new(),
+    )
 }
 
 /// Constructed polygons as one working area.
@@ -826,83 +830,25 @@ struct OutputShaper {
 #[cfg(not(feature = "new-geometry"))]
 impl OutputShaper {
     /// Install `area` as `feature`'s geometry.
-    fn apply(&mut self, feature: &mut Feature, area: WorkingArea, _parents: &[usize]) {
+    fn apply(&mut self, feature: &mut Feature, area: WorkingArea) {
         feature.geometry_mut().value = GeometryValue::FlowGeometry2D(area.into());
         feature.geometry_mut().epsg = self.epsg;
     }
 }
 
-/// Shapes each subdivision piece into an output feature's geometry, carrying a
-/// shared source elevation onto constructed faces.
+/// Shapes each subdivision piece into an output feature's geometry.
 #[cfg(feature = "new-geometry")]
-struct OutputShaper<'a> {
-    disk_feats: &'a DiskBackedFeatures,
-    /// Cached uniform elevation per source feature: `Some(z)` when every leaf
-    /// of the feature's geometry lies at `z`.
-    elevations: HashMap<usize, Option<f64>>,
-}
+struct OutputShaper;
 
 #[cfg(feature = "new-geometry")]
-impl<'a> OutputShaper<'a> {
-    fn new(disk_feats: &'a DiskBackedFeatures) -> Self {
-        Self {
-            disk_feats,
-            elevations: HashMap::new(),
-        }
-    }
-
-    /// Install `area` as `feature`'s geometry. When every parent lies at one
-    /// shared elevation, elevation-less faces of the piece are placed there.
-    fn apply(&mut self, feature: &mut Feature, area: WorkingArea, parents: &[usize]) {
-        let area = match self.shared_elevation(parents) {
-            Some(z) => stamp_elevation(area, z),
-            None => area,
-        };
+impl OutputShaper {
+    /// Install `area` as `feature`'s geometry.
+    fn apply(&mut self, feature: &mut Feature, area: WorkingArea) {
         *feature.geometry_mut() = Geometry::Euclidean2D(area);
     }
-
-    /// The one elevation all `parents` lie at, or `None`.
-    fn shared_elevation(&mut self, parents: &[usize]) -> Option<f64> {
-        let mut shared = None;
-        for (i, &parent) in parents.iter().enumerate() {
-            let disk_feats = self.disk_feats;
-            let z = (*self
-                .elevations
-                .entry(parent)
-                .or_insert_with(|| feature_elevation(disk_feats, parent)))?;
-            if i == 0 {
-                shared = Some(z);
-            } else if shared != Some(z) {
-                return None;
-            }
-        }
-        shared
-    }
 }
 
-/// The one elevation every leaf of the stored feature `i`'s geometry lies at,
-/// or `None`.
-#[cfg(feature = "new-geometry")]
-fn feature_elevation(disk_feats: &DiskBackedFeatures, i: usize) -> Option<f64> {
-    let geometry = disk_feats.read_feature(i).geometry;
-    let Geometry::Euclidean2D(geom_2d) = geometry.as_ref() else {
-        return None;
-    };
-    let mut leaves = Vec::new();
-    flatten_2d(geom_2d, &mut leaves);
-    let mut shared = None;
-    for (i, leaf) in leaves.iter().enumerate() {
-        let z = leaf_elevation(leaf)?;
-        if i == 0 {
-            shared = Some(z);
-        } else if shared != Some(z) {
-            return None;
-        }
-    }
-    shared
-}
-
-/// The elevation a 2D leaf lies at, or `None` when it is pure 2D.
+/// The elevation a 2D leaf lies at, or `None` when it is planar.
 #[cfg(feature = "new-geometry")]
 fn leaf_elevation(leaf: &Leaf2D<'_>) -> Option<f64> {
     match leaf {
@@ -913,32 +859,6 @@ fn leaf_elevation(leaf: &Leaf2D<'_>) -> Option<f64> {
         Leaf2D::Point(_) => None,
     }
 }
-
-/// `area` with every elevation-less polygon face placed at `z`.
-#[cfg(feature = "new-geometry")]
-fn stamp_elevation(area: WorkingArea, z: f64) -> WorkingArea {
-    match area {
-        Euclidean2DGeometry::Polygon(p) if p.elevation().is_none() => {
-            Euclidean2DGeometry::Polygon(Box::new(p.at_elevation(z)))
-        }
-        Euclidean2DGeometry::Collection(collection) => {
-            let members: Vec<_> = collection
-                .members()
-                .iter()
-                .cloned()
-                .map(|m| stamp_elevation(m, z))
-                .collect();
-            let attrs = collection.member_attributes().to_vec();
-            Euclidean2DGeometry::Collection(
-                Collection2D::with_attributes(members, attrs)
-                    .expect("member count is unchanged by elevation stamping"),
-            )
-        }
-        other => other,
-    }
-}
-
-// --- shared subdivision ------------------------------------------------------
 
 /// An AABB entry for the RTree built from pre-computed bounding boxes stored on disk.
 #[derive(Clone)]
@@ -1164,7 +1084,7 @@ fn from_midpolygons_disk<W: Write>(
                     );
                 }
 
-                shaper.apply(&mut feature, subpolygon.polygon, &parents);
+                shaper.apply(&mut feature, subpolygon.polygon);
                 serde_json::to_writer(&mut *area_writer, &feature)?;
                 area_writer.write_all(b"\n")?;
                 area_count += 1;
@@ -1203,7 +1123,7 @@ fn from_midpolygons_disk<W: Write>(
                     );
                 }
 
-                shaper.apply(&mut feature, subpolygon.polygon, &[parent]);
+                shaper.apply(&mut feature, subpolygon.polygon);
                 serde_json::to_writer(&mut *remnants_writer, &feature)?;
                 remnants_writer.write_all(b"\n")?;
                 remnants_count += 1;
@@ -1584,46 +1504,76 @@ mod tests {
     }
 
     #[test]
-    fn pieces_of_parents_at_one_shared_elevation_lie_there() {
-        let features = vec![
-            Feature::from(square_at([0.0, 0.0], [2.0, 2.0], 5.0)),
-            Feature::from(square_at([1.0, 1.0], [3.0, 3.0], 5.0)),
-        ];
-        let (dir, disk_feats) = setup_group(&features);
-        let mut shaper = OutputShaper::new(&disk_feats);
-
-        let area_0 = read_working_area(&disk_feats, 0).unwrap();
-        let area_1 = read_working_area(&disk_feats, 1).unwrap();
-        let piece = area_intersection(&area_0, &area_1).unwrap();
-
-        let mut feature = Feature::new_with_attributes(IndexMap::new());
-        shaper.apply(&mut feature, piece, &[0, 1]);
-        let Geometry::Euclidean2D(geom) = feature.geometry.as_ref() else {
-            panic!("expected a 2D geometry");
+    fn a_group_admits_only_the_frame_its_first_feature_fixes() {
+        let mut overlayer = AreaOnAreaOverlayer {
+            group_by: None,
+            output_attribute: None,
+            generate_list: None,
+            accumulation_mode: AccumulationMode::default(),
+            tolerance: 0.0,
+            group_map: HashMap::new(),
+            group_crs: HashMap::new(),
+            group_count: 0,
+            temp_dir: None,
+            buffer: HashMap::new(),
+            buffer_bytes: 0,
+            executor_id: None,
         };
-        let mut leaves = Vec::new();
-        flatten_2d(geom, &mut leaves);
-        assert!(!leaves.is_empty());
-        assert!(leaves.iter().all(|l| leaf_elevation(l) == Some(5.0)));
+        let euclidean = CoordinateFrame::Euclidean;
+        let crs = CoordinateFrame::Crs(reearth_flow_geometry::coordinate::EpsgCode::new(6677));
 
-        let _ = std::fs::remove_dir_all(&dir);
+        assert!(overlayer.admit_crs(0, &euclidean));
+        assert!(overlayer.admit_crs(0, &euclidean));
+        assert!(!overlayer.admit_crs(0, &crs));
+        // A different group is free to fix a different frame.
+        assert!(overlayer.admit_crs(1, &crs));
     }
 
     #[test]
-    fn pieces_of_parents_at_differing_elevations_stay_planar() {
+    fn intake_rejects_an_elevated_polygon() {
+        assert!(intake(&square_at([0.0, 0.0], [2.0, 2.0], 5.0)).is_none());
+    }
+
+    #[test]
+    fn intake_rejects_a_geometry_whose_members_are_partly_elevated() {
+        let Geometry::Euclidean2D(planar) = square([0.0, 0.0], [1.0, 1.0]) else {
+            unreachable!();
+        };
+        let Geometry::Euclidean2D(elevated) = square_at([2.0, 2.0], [3.0, 3.0], 5.0) else {
+            unreachable!();
+        };
+        let geometry = Geometry::Euclidean2D(Euclidean2DGeometry::Collection(Collection2D::new([
+            planar, elevated,
+        ])));
+        assert!(intake(&geometry).is_none());
+    }
+
+    #[test]
+    fn intake_rejects_an_elevated_closed_line_string() {
+        let line = LineString2D::from_coords_at_elevation(
+            CoordinateFrame::Euclidean,
+            square_ring([0.0, 0.0], [2.0, 2.0]),
+            5.0,
+        );
+        let geometry = Geometry::Euclidean2D(Euclidean2DGeometry::LineString(line));
+        assert!(intake(&geometry).is_none());
+    }
+
+    #[test]
+    fn pieces_of_planar_parents_stay_planar() {
         let features = vec![
-            Feature::from(square_at([0.0, 0.0], [2.0, 2.0], 5.0)),
-            Feature::from(square_at([1.0, 1.0], [3.0, 3.0], 7.0)),
+            Feature::from(square([0.0, 0.0], [2.0, 2.0])),
+            Feature::from(square([1.0, 1.0], [3.0, 3.0])),
         ];
         let (dir, disk_feats) = setup_group(&features);
-        let mut shaper = OutputShaper::new(&disk_feats);
+        let mut shaper = OutputShaper;
 
         let area_0 = read_working_area(&disk_feats, 0).unwrap();
         let area_1 = read_working_area(&disk_feats, 1).unwrap();
         let piece = area_intersection(&area_0, &area_1).unwrap();
 
         let mut feature = Feature::new_with_attributes(IndexMap::new());
-        shaper.apply(&mut feature, piece, &[0, 1]);
+        shaper.apply(&mut feature, piece);
         let Geometry::Euclidean2D(geom) = feature.geometry.as_ref() else {
             panic!("expected a 2D geometry");
         };

--- a/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
@@ -9,16 +9,6 @@ use std::{
 use indexmap::IndexMap;
 use once_cell::sync::Lazy;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
-use reearth_flow_geometry::algorithm::line_intersection::LineIntersection;
-use reearth_flow_geometry::algorithm::line_string_ops::{
-    LineStringOps, LineStringSplitResult, LineStringWithTree2D,
-};
-use reearth_flow_geometry::algorithm::GeoFloat;
-use reearth_flow_geometry::types::coordinate::Coordinate2D;
-use reearth_flow_geometry::types::geometry::Geometry2D;
-use reearth_flow_geometry::types::line_string::LineString2D;
-use reearth_flow_geometry::types::no_value::NoValue;
-use reearth_flow_geometry::types::point::{Point, Point2D};
 use reearth_flow_runtime::{
     cache::executor_cache_subdir,
     errors::BoxedError,
@@ -27,11 +17,34 @@ use reearth_flow_runtime::{
     forwarder::ProcessorChannelForwarder,
     node::{Port, Processor, ProcessorFactory, FEATURES_PORT, REJECTED_PORT},
 };
-use reearth_flow_types::{Attribute, AttributeValue, Attributes, Feature, Geometry, GeometryValue};
+use reearth_flow_types::{Attribute, AttributeValue, Attributes, Feature};
 use rstar::{RTree, RTreeObject, AABB};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Number, Value};
+
+#[cfg(not(feature = "new-geometry"))]
+use reearth_flow_geometry::{
+    algorithm::line_intersection::LineIntersection,
+    algorithm::line_string_ops::{LineStringOps, LineStringSplitResult, LineStringWithTree2D},
+    types::coordinate::Coordinate2D,
+    types::geometry::Geometry2D,
+    types::line_string::LineString2D,
+    types::no_value::NoValue,
+    types::point::{Point, Point2D},
+};
+#[cfg(not(feature = "new-geometry"))]
+use reearth_flow_types::{Geometry, GeometryValue};
+
+#[cfg(feature = "new-geometry")]
+use reearth_flow_geometry::{
+    coordinate::CoordinateFrame,
+    line_string::LineString2D,
+    point::Point2D,
+    predicates::kernel::{segment_intersection, SegmentIntersection},
+    predicates::view::{flatten_2d, Leaf2D},
+    Euclidean2DGeometry, Geometry,
+};
 
 use super::errors::GeometryProcessorError;
 use crate::ACCUMULATOR_BUFFER_BYTE_THRESHOLD;
@@ -98,6 +111,8 @@ impl ProcessorFactory for LineOnLineOverlayerFactory {
                 .overlaid_lists_attr_name
                 .unwrap_or_else(|| "overlaidLists".to_string()),
             group_map: HashMap::new(),
+            #[cfg(feature = "new-geometry")]
+            group_frame: HashMap::new(),
             group_count: 0,
             temp_dir: None,
             buffer: HashMap::new(),
@@ -125,6 +140,10 @@ pub struct LineOnLineOverlayer {
     overlaid_lists_attr_name: String,
     // Disk-backed state
     group_map: HashMap<AttributeValue, usize>,
+    /// The coordinate frame every member of a group must share, fixed by the
+    /// group's first feature.
+    #[cfg(feature = "new-geometry")]
+    group_frame: HashMap<usize, CoordinateFrame>,
     group_count: usize,
     temp_dir: Option<PathBuf>,
     /// group_idx -> Vec<(aabbs_json_for_feature, feature_json)>.
@@ -151,6 +170,8 @@ impl Clone for LineOnLineOverlayer {
             tolerance: self.tolerance,
             overlaid_lists_attr_name: self.overlaid_lists_attr_name.clone(),
             group_map: HashMap::new(),
+            #[cfg(feature = "new-geometry")]
+            group_frame: HashMap::new(),
             group_count: 0,
             temp_dir: None,
             buffer: HashMap::new(),
@@ -232,6 +253,20 @@ impl LineOnLineOverlayer {
         self.buffer_bytes = 0;
         Ok(())
     }
+
+    /// Whether `frame` matches the group's coordinate frame, which the first
+    /// feature of the group fixes. Overlay operands must share one frame.
+    #[cfg(feature = "new-geometry")]
+    fn admit_frame(&mut self, group_idx: usize, frame: &CoordinateFrame) -> bool {
+        use std::collections::hash_map::Entry;
+        match self.group_frame.entry(group_idx) {
+            Entry::Occupied(entry) => entry.get() == frame,
+            Entry::Vacant(entry) => {
+                entry.insert(frame.clone());
+                true
+            }
+        }
+    }
 }
 
 impl Drop for LineOnLineOverlayer {
@@ -247,7 +282,6 @@ impl Processor for LineOnLineOverlayer {
         true
     }
 
-    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -258,51 +292,46 @@ impl Processor for LineOnLineOverlayer {
         }
 
         let feature = &ctx.feature;
-        let geometry = &feature.geometry;
-        if geometry.is_empty() {
-            fw.send(ctx.new_with_feature_and_port(ctx.feature.clone(), REJECTED_PORT.clone()));
+        let Some(payload) = intake(feature.geometry.as_ref()) else {
+            fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+            return Ok(());
+        };
+        #[cfg(not(feature = "new-geometry"))]
+        let aabbs = payload;
+        #[cfg(feature = "new-geometry")]
+        let (aabbs, frame) = payload;
+
+        let key = if let Some(group_by) = &self.group_by {
+            AttributeValue::Array(
+                group_by
+                    .iter()
+                    .filter_map(|attr| feature.attributes.get(attr).cloned())
+                    .collect(),
+            )
+        } else {
+            AttributeValue::Null
+        };
+        let group_idx = if let Some(&idx) = self.group_map.get(&key) {
+            idx
+        } else {
+            let idx = self.group_count;
+            self.group_map.insert(key, idx);
+            self.group_count += 1;
+            idx
+        };
+
+        #[cfg(feature = "new-geometry")]
+        if !self.admit_frame(group_idx, &frame) {
+            fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
             return Ok(());
         }
-        match &geometry.value {
-            GeometryValue::FlowGeometry2D(geom_2d) => {
-                let line_strings = extract_line_strings(geom_2d);
-                if line_strings.is_empty() {
-                    fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
-                    return Ok(());
-                }
 
-                let key = if let Some(group_by) = &self.group_by {
-                    AttributeValue::Array(
-                        group_by
-                            .iter()
-                            .filter_map(|attr| feature.attributes.get(attr).cloned())
-                            .collect(),
-                    )
-                } else {
-                    AttributeValue::Null
-                };
-                let group_idx = if let Some(&idx) = self.group_map.get(&key) {
-                    idx
-                } else {
-                    let idx = self.group_count;
-                    self.group_map.insert(key, idx);
-                    self.group_count += 1;
-                    idx
-                };
-
-                let aabbs: Vec<[f64; 4]> = line_strings.iter().map(aabb_of_line_string).collect();
-                let aabbs_json = serde_json::to_string(&aabbs)?;
-                let feature_json = serde_json::to_string(&ctx.feature)?;
-                self.append_to_group(group_idx, aabbs_json, feature_json)?;
-            }
-            _ => {
-                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
-            }
-        }
+        let aabbs_json = serde_json::to_string(&aabbs)?;
+        let feature_json = serde_json::to_string(&ctx.feature)?;
+        self.append_to_group(group_idx, aabbs_json, feature_json)?;
         Ok(())
     }
 
-    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,
@@ -363,6 +392,82 @@ impl Processor for LineOnLineOverlayer {
     }
 }
 
+// --- world-specific geometry kernel -----------------------------------------
+
+/// The polyline value carried through the overlay.
+#[cfg(not(feature = "new-geometry"))]
+type SourceLine = LineString2D<f64>;
+
+/// The polyline value carried through the overlay: its coordinates, frame, and
+/// the elevation it lies at.
+#[cfg(feature = "new-geometry")]
+type SourceLine = Polyline;
+
+/// An intersection point produced by the overlay.
+#[cfg(not(feature = "new-geometry"))]
+type SplitPoint = Coordinate2D<f64>;
+
+/// An intersection point produced by the overlay, in the coordinate frame of
+/// the polyline it split.
+#[cfg(feature = "new-geometry")]
+#[derive(Debug, Clone)]
+struct SplitPoint {
+    frame: CoordinateFrame,
+    coord: [f64; 2],
+}
+
+/// One polyline participating in the overlay.
+#[cfg(feature = "new-geometry")]
+#[derive(Debug, Clone)]
+struct Polyline {
+    /// Coordinate frame the coordinates are expressed in.
+    frame: CoordinateFrame,
+    /// The vertices, at least two.
+    coords: Vec<[f64; 2]>,
+    /// The elevation the whole polyline lies at. `None` = pure 2D.
+    elevation: Option<f64>,
+}
+
+/// Accept an incoming geometry into the overlay: any 2D geometry with at
+/// least one line string. Returns the bounding box of each line string, or
+/// `None` when the feature must be rejected.
+#[cfg(not(feature = "new-geometry"))]
+fn intake(geometry: &Geometry) -> Option<Vec<[f64; 4]>> {
+    if geometry.is_empty() {
+        return None;
+    }
+    let GeometryValue::FlowGeometry2D(geom_2d) = &geometry.value else {
+        return None;
+    };
+    let line_strings = extract_line_strings(geom_2d);
+    if line_strings.is_empty() {
+        return None;
+    }
+    Some(line_strings.iter().map(aabb_of_line_string).collect())
+}
+
+/// Accept an incoming geometry into the overlay: a 2D geometry whose line
+/// strings and polygon exteriors yield at least one polyline, all in one
+/// coordinate frame. Returns the bounding box of each polyline and the frame,
+/// or `None` when the feature must be rejected.
+#[cfg(feature = "new-geometry")]
+fn intake(geometry: &Geometry) -> Option<(Vec<[f64; 4]>, CoordinateFrame)> {
+    let Geometry::Euclidean2D(geom_2d) = geometry else {
+        return None;
+    };
+    let polylines = source_lines_2d(geom_2d);
+    let frame = polylines.first()?.frame.clone();
+    if polylines.iter().any(|pl| pl.frame != frame) {
+        return None;
+    }
+    let aabbs = polylines
+        .iter()
+        .map(|pl| polyline_bbox(&pl.coords))
+        .collect();
+    Some((aabbs, frame))
+}
+
+#[cfg(not(feature = "new-geometry"))]
 fn extract_line_strings(geom: &Geometry2D<f64>) -> Vec<LineString2D<f64>> {
     match geom {
         Geometry2D::LineString(line) => vec![line.clone()],
@@ -373,6 +478,89 @@ fn extract_line_strings(geom: &Geometry2D<f64>) -> Vec<LineString2D<f64>> {
     }
 }
 
+/// The polylines of a 2D geometry: line strings verbatim and polygon exterior
+/// rings; other leaves contribute nothing.
+#[cfg(feature = "new-geometry")]
+fn source_lines_2d(geom: &Euclidean2DGeometry) -> Vec<Polyline> {
+    let mut leaves = Vec::new();
+    flatten_2d(geom, &mut leaves);
+    leaves
+        .iter()
+        .filter_map(|leaf| match leaf {
+            Leaf2D::Line(line) if line.coords().len() >= 2 => Some(Polyline {
+                frame: line.frame().clone(),
+                coords: line.coords().to_vec(),
+                elevation: line.elevation(),
+            }),
+            Leaf2D::Polygon(polygon) if polygon.exterior().len() >= 2 => Some(Polyline {
+                frame: polygon.frame().clone(),
+                coords: polygon.exterior().to_vec(),
+                elevation: polygon.elevation(),
+            }),
+            _ => None,
+        })
+        .collect()
+}
+
+/// The stored feature's polylines, empty when it has no 2D geometry.
+#[cfg(not(feature = "new-geometry"))]
+fn feature_source_lines(feature: &Feature) -> Vec<SourceLine> {
+    match &feature.geometry.value {
+        GeometryValue::FlowGeometry2D(g2) => extract_line_strings(g2),
+        _ => Vec::new(),
+    }
+}
+
+/// The stored feature's polylines, empty when it has no 2D geometry.
+#[cfg(feature = "new-geometry")]
+fn feature_source_lines(feature: &Feature) -> Vec<SourceLine> {
+    match feature.geometry.as_ref() {
+        Geometry::Euclidean2D(geom_2d) => source_lines_2d(geom_2d),
+        _ => Vec::new(),
+    }
+}
+
+/// A split line as an output feature's geometry.
+#[cfg(not(feature = "new-geometry"))]
+fn line_output_geometry(line: &SourceLine) -> Geometry {
+    Geometry {
+        value: GeometryValue::FlowGeometry2D(Geometry2D::LineString(line.clone())),
+        ..Default::default()
+    }
+}
+
+/// A split line as an output feature's geometry, in its source's frame and at
+/// its source's elevation.
+#[cfg(feature = "new-geometry")]
+fn line_output_geometry(line: &SourceLine) -> Geometry {
+    let coords = line.coords.iter().copied();
+    let ls = match line.elevation {
+        Some(z) => LineString2D::from_coords_at_elevation(line.frame.clone(), coords, z),
+        None => LineString2D::from_coords(line.frame.clone(), coords),
+    };
+    Geometry::Euclidean2D(Euclidean2DGeometry::LineString(ls))
+}
+
+/// An intersection point as an output feature's geometry.
+#[cfg(not(feature = "new-geometry"))]
+fn point_output_geometry(point: &SplitPoint) -> Geometry {
+    Geometry {
+        value: GeometryValue::FlowGeometry2D(Geometry2D::Point(Point(*point))),
+        ..Default::default()
+    }
+}
+
+/// An intersection point as an output feature's geometry, in the frame of the
+/// polyline it split.
+#[cfg(feature = "new-geometry")]
+fn point_output_geometry(point: &SplitPoint) -> Geometry {
+    Geometry::Euclidean2D(Euclidean2DGeometry::Point(Point2D::new(
+        point.frame.clone(),
+        point.coord,
+    )))
+}
+
+#[cfg(not(feature = "new-geometry"))]
 fn aabb_of_line_string(ls: &LineString2D<f64>) -> [f64; 4] {
     let env = ls.envelope();
     let lo = env.lower();
@@ -380,11 +568,26 @@ fn aabb_of_line_string(ls: &LineString2D<f64>) -> [f64; 4] {
     [lo.x(), lo.y(), hi.x(), hi.y()]
 }
 
-fn aabb_to_rstar(aabb: [f64; 4]) -> AABB<Point2D<f64>> {
-    AABB::from_corners(
-        Point2D::new_(aabb[0], aabb[1], NoValue),
-        Point2D::new_(aabb[2], aabb[3], NoValue),
-    )
+/// The `[min_x, min_y, max_x, max_y]` bounding box of a non-empty polyline.
+#[cfg(feature = "new-geometry")]
+fn polyline_bbox(coords: &[[f64; 2]]) -> [f64; 4] {
+    let mut bbox = [
+        f64::INFINITY,
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+        f64::NEG_INFINITY,
+    ];
+    for c in coords {
+        bbox[0] = bbox[0].min(c[0]);
+        bbox[1] = bbox[1].min(c[1]);
+        bbox[2] = bbox[2].max(c[0]);
+        bbox[3] = bbox[3].max(c[1]);
+    }
+    bbox
+}
+
+fn aabb_to_rstar(aabb: [f64; 4]) -> AABB<[f64; 2]> {
+    AABB::from_corners([aabb[0], aabb[1]], [aabb[2], aabb[3]])
 }
 
 struct DiskBackedFeatures {
@@ -446,18 +649,17 @@ impl DiskBackedFeatures {
 struct AabbEntry {
     feature_idx: usize,
     ls_local_idx: usize,
-    aabb: AABB<Point2D<f64>>,
+    aabb: AABB<[f64; 2]>,
 }
 
 impl RTreeObject for AabbEntry {
-    type Envelope = AABB<Point2D<f64>>;
+    type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
         self.aabb
     }
 }
 
-#[cfg(not(feature = "new-geometry"))]
 fn process_group<W: Write>(
     group_dir: &Path,
     tolerance: f64,
@@ -514,13 +716,10 @@ fn process_group<W: Write>(
         ));
     }
     let mut attributes_by_feature: Vec<Arc<Attributes>> = Vec::with_capacity(disk_feats.len());
-    let mut lss_per_feature: Vec<Vec<LineString2D<f64>>> = Vec::with_capacity(disk_feats.len());
+    let mut lss_per_feature: Vec<Vec<SourceLine>> = Vec::with_capacity(disk_feats.len());
     for i in 0..disk_feats.len() {
         let feat = disk_feats.read_feature(i)?;
-        let lss = match &feat.geometry.value {
-            GeometryValue::FlowGeometry2D(g2) => extract_line_strings(g2),
-            _ => Vec::new(),
-        };
+        let lss = feature_source_lines(&feat);
         attributes_by_feature.push(feat.attributes);
         lss_per_feature.push(lss);
     }
@@ -568,10 +767,7 @@ fn process_group<W: Write>(
             }
         }
 
-        let geometry = Geometry {
-            value: GeometryValue::FlowGeometry2D(Geometry2D::LineString(meta.line_string.clone())),
-            ..Default::default()
-        };
+        let geometry = line_output_geometry(&meta.line_string);
         let out = Feature::new_with_attributes_and_geometry(attributes, geometry);
         serde_json::to_writer(&mut *line_writer, &out)?;
         line_writer.write_all(b"\n")?;
@@ -598,10 +794,7 @@ fn process_group<W: Write>(
             } else {
                 IndexMap::new()
             };
-        let geometry = Geometry {
-            value: GeometryValue::FlowGeometry2D(Geometry2D::Point(Point(*coord))),
-            ..Default::default()
-        };
+        let geometry = point_output_geometry(coord);
         let out = Feature::new_with_attributes_and_geometry(attributes, geometry);
         serde_json::to_writer(&mut *point_writer, &out)?;
         point_writer.write_all(b"\n")?;
@@ -611,9 +804,10 @@ fn process_group<W: Write>(
     Ok((line_count, point_count))
 }
 
+/// A split line and the source features whose lines coincide with it.
 #[derive(Debug, Clone)]
-struct LineString2DWithMetadata<T: GeoFloat> {
-    line_string: LineString2D<T>,
+struct LineStringWithMetadata {
+    line_string: SourceLine,
     /// feature_idx of each source feature that contributed to this segment.
     /// Deduplicated — each feature appears at most once.
     source_feature_idxs: Vec<usize>,
@@ -621,10 +815,11 @@ struct LineString2DWithMetadata<T: GeoFloat> {
 
 #[derive(Debug, Clone)]
 struct OverlayResult {
-    line_strings_with_metadata: Vec<LineString2DWithMetadata<f64>>,
-    split_coords: Vec<Coordinate2D<f64>>,
+    line_strings_with_metadata: Vec<LineStringWithMetadata>,
+    split_coords: Vec<SplitPoint>,
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn overlay_entries(
     entries: Vec<AabbEntry>,
     lss_per_feature: &[Vec<LineString2D<f64>>],
@@ -709,7 +904,7 @@ fn overlay_entries(
     );
 
     let mut processed = vec![false; segments.len()];
-    let mut line_strings_with_metadata: Vec<LineString2DWithMetadata<f64>> = Vec::new();
+    let mut line_strings_with_metadata: Vec<LineStringWithMetadata> = Vec::new();
     for i in 0..segments.len() {
         if processed[i] {
             continue;
@@ -738,7 +933,7 @@ fn overlay_entries(
             }
         }
 
-        line_strings_with_metadata.push(LineString2DWithMetadata {
+        line_strings_with_metadata.push(LineStringWithMetadata {
             line_string: ls1,
             source_feature_idxs,
         });
@@ -801,10 +996,198 @@ fn overlay_entries(
     }
 }
 
+#[cfg(feature = "new-geometry")]
+fn overlay_entries(
+    entries: Vec<AabbEntry>,
+    lss_per_feature: &[Vec<Polyline>],
+    tolerance: f64,
+) -> OverlayResult {
+    let rtree: RTree<AabbEntry> = RTree::bulk_load(entries);
+    let rtree_items: Vec<&AabbEntry> = rtree.iter().collect();
+
+    type PerEntryResult = (Vec<(usize, Polyline)>, Vec<SplitPoint>);
+    let per_entry_results: Vec<PerEntryResult> = rtree_items
+        .par_iter()
+        .map(|&entry_i| {
+            let self_pl = &lss_per_feature[entry_i.feature_idx][entry_i.ls_local_idx];
+
+            // Lazy iteration over R-tree candidates; never materialises the pair list.
+            let mut intersection_coords: Vec<[f64; 2]> = Vec::new();
+            for entry_j in rtree.locate_in_envelope_intersecting(&entry_i.aabb) {
+                if entry_j.feature_idx == entry_i.feature_idx {
+                    continue;
+                }
+                let other = &lss_per_feature[entry_j.feature_idx][entry_j.ls_local_idx];
+                polyline_intersections(&self_pl.coords, &other.coords, &mut intersection_coords);
+            }
+
+            let (split_lines, split_coords) =
+                split_polyline(&self_pl.coords, &intersection_coords, tolerance);
+
+            let segs: Vec<(usize, Polyline)> = split_lines
+                .into_iter()
+                .map(|coords| {
+                    (
+                        entry_i.feature_idx,
+                        Polyline {
+                            frame: self_pl.frame.clone(),
+                            coords,
+                            elevation: self_pl.elevation,
+                        },
+                    )
+                })
+                .collect();
+            let points: Vec<SplitPoint> = split_coords
+                .into_iter()
+                .map(|coord| SplitPoint {
+                    frame: self_pl.frame.clone(),
+                    coord,
+                })
+                .collect();
+
+            (segs, points)
+        })
+        .collect();
+
+    let mut segments: Vec<(usize, Polyline)> = Vec::new();
+    let mut split_points_flat: Vec<SplitPoint> = Vec::new();
+    for (segs, points) in per_entry_results {
+        segments.extend(segs);
+        split_points_flat.extend(points);
+    }
+
+    // Drop sub-tolerance segments — zero-length stubs and near-coincident endpoint slivers
+    // aren't meaningful overlays and previously dominated the line-port output.
+    segments.retain(|(_, pl)| polyline_length(&pl.coords) >= tolerance);
+
+    // Two source entries that overlapped geometrically produce identical split segments from
+    // different per-entry tasks; we cluster them here.
+    let seg_aabbs: Vec<AABB<[f64; 2]>> = segments
+        .iter()
+        .map(|(_, pl)| aabb_to_rstar(polyline_bbox(&pl.coords)))
+        .collect();
+
+    #[derive(Clone, Copy)]
+    struct SegEntry {
+        idx: usize,
+        aabb: AABB<[f64; 2]>,
+    }
+    impl RTreeObject for SegEntry {
+        type Envelope = AABB<[f64; 2]>;
+        fn envelope(&self) -> Self::Envelope {
+            self.aabb
+        }
+    }
+    let seg_rtree: RTree<SegEntry> = RTree::bulk_load(
+        seg_aabbs
+            .iter()
+            .enumerate()
+            .map(|(idx, aabb)| SegEntry { idx, aabb: *aabb })
+            .collect(),
+    );
+
+    let mut processed = vec![false; segments.len()];
+    let mut line_strings_with_metadata: Vec<LineStringWithMetadata> = Vec::new();
+    for i in 0..segments.len() {
+        if processed[i] {
+            continue;
+        }
+        let (feat_i, mut rep) = segments[i].clone();
+        // A single feature may contribute multiple matching segments (e.g. a closed ring
+        // whose split produces several arcs that all coincide with the rep segment). Count
+        // each feature at most once; extra matching segments dedupe silently.
+        let mut source_feature_idxs = vec![feat_i];
+        let mut included_feats: std::collections::HashSet<usize> =
+            std::collections::HashSet::from([feat_i]);
+
+        for cand in seg_rtree.locate_in_envelope_intersecting(&seg_aabbs[i]) {
+            let j = cand.idx;
+            if j <= i || processed[j] {
+                continue;
+            }
+            let (feat_j, pl_j) = (segments[j].0, &segments[j].1);
+            if coords_match(&rep.coords, &pl_j.coords, tolerance) {
+                // Coinciding sources at differing elevations leave the output planar.
+                if pl_j.elevation != rep.elevation {
+                    rep.elevation = None;
+                }
+                if !included_feats.insert(feat_j) {
+                    processed[j] = true;
+                    continue;
+                }
+                source_feature_idxs.push(feat_j);
+                processed[j] = true;
+            }
+        }
+
+        line_strings_with_metadata.push(LineStringWithMetadata {
+            line_string: rep,
+            source_feature_idxs,
+        });
+    }
+
+    // Each physical intersection is discovered by both sides of the crossing plus extras
+    // from 3+-way near-coincidences, so dedup by tolerance-expanded envelope.
+    #[derive(Clone, Copy)]
+    struct PointEntry {
+        idx: usize,
+        point: [f64; 2],
+    }
+    impl RTreeObject for PointEntry {
+        type Envelope = AABB<[f64; 2]>;
+        fn envelope(&self) -> Self::Envelope {
+            AABB::from_point(self.point)
+        }
+    }
+
+    let point_rtree: RTree<PointEntry> = RTree::bulk_load(
+        split_points_flat
+            .iter()
+            .enumerate()
+            .map(|(idx, p)| PointEntry {
+                idx,
+                point: p.coord,
+            })
+            .collect(),
+    );
+
+    let mut processed_pts = vec![false; split_points_flat.len()];
+    let mut unique_points: Vec<SplitPoint> = Vec::new();
+    for i in 0..split_points_flat.len() {
+        if processed_pts[i] {
+            continue;
+        }
+        processed_pts[i] = true;
+        let p_i = split_points_flat[i].clone();
+
+        let search_env = AABB::from_corners(
+            [p_i.coord[0] - tolerance, p_i.coord[1] - tolerance],
+            [p_i.coord[0] + tolerance, p_i.coord[1] + tolerance],
+        );
+        for cand in point_rtree.locate_in_envelope_intersecting(&search_env) {
+            let j = cand.idx;
+            if j <= i || processed_pts[j] {
+                continue;
+            }
+            if dist(p_i.coord, split_points_flat[j].coord) < tolerance {
+                processed_pts[j] = true;
+            }
+        }
+        unique_points.push(p_i);
+    }
+
+    OverlayResult {
+        line_strings_with_metadata,
+        split_coords: unique_points,
+    }
+}
+
+#[cfg(not(feature = "new-geometry"))]
 fn line_string_length_2d(ls: &LineString2D<f64>) -> f64 {
     ls.0.windows(2).map(|w| (w[1] - w[0]).norm()).sum()
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn segments_match(a: &LineString2D<f64>, b: &LineString2D<f64>, tolerance: f64) -> bool {
     if a.0.len() != b.0.len() {
         return false;
@@ -822,7 +1205,142 @@ fn segments_match(a: &LineString2D<f64>, b: &LineString2D<f64>, tolerance: f64) 
         .all(|(&c1, &c2)| (c1 - c2).norm() < tolerance)
 }
 
-#[cfg(test)]
+/// The distance between two 2D coordinates.
+#[cfg(feature = "new-geometry")]
+fn dist(a: [f64; 2], b: [f64; 2]) -> f64 {
+    (a[0] - b[0]).hypot(a[1] - b[1])
+}
+
+/// The length of a polyline.
+#[cfg(feature = "new-geometry")]
+fn polyline_length(coords: &[[f64; 2]]) -> f64 {
+    coords.windows(2).map(|w| dist(w[0], w[1])).sum()
+}
+
+/// Whether two polylines coincide vertex by vertex within `tolerance`, in
+/// either direction.
+#[cfg(feature = "new-geometry")]
+fn coords_match(a: &[[f64; 2]], b: &[[f64; 2]], tolerance: f64) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let forward = a
+        .iter()
+        .zip(b.iter())
+        .all(|(&c1, &c2)| dist(c1, c2) < tolerance);
+    if forward {
+        return true;
+    }
+    a.iter()
+        .rev()
+        .zip(b.iter())
+        .all(|(&c1, &c2)| dist(c1, c2) < tolerance)
+}
+
+/// Every pairwise segment intersection of two polylines, appended to `out`:
+/// crossing points, endpoint touches, and both ends of collinear overlaps.
+#[cfg(feature = "new-geometry")]
+fn polyline_intersections(a: &[[f64; 2]], b: &[[f64; 2]], out: &mut Vec<[f64; 2]>) {
+    for sa in a.windows(2) {
+        for sb in b.windows(2) {
+            match segment_intersection(sa[0], sa[1], sb[0], sb[1]) {
+                Some(SegmentIntersection::SinglePoint { intersection, .. }) => {
+                    out.push(intersection);
+                }
+                Some(SegmentIntersection::Collinear { start, end }) => {
+                    out.push(start);
+                    out.push(end);
+                }
+                None => {}
+            }
+        }
+    }
+}
+
+/// Split a polyline at the candidate points. A candidate splits a segment when
+/// it lies on it within `tolerance` and is not within `tolerance` of either
+/// endpoint; a candidate that fails but coincides with an interior vertex
+/// splits the polyline at that vertex instead. Returns the sub-polylines and
+/// the coordinates where splits occurred.
+#[cfg(feature = "new-geometry")]
+fn split_polyline(
+    coords: &[[f64; 2]],
+    candidates: &[[f64; 2]],
+    tolerance: f64,
+) -> (Vec<Vec<[f64; 2]>>, Vec<[f64; 2]>) {
+    if coords.len() < 2 {
+        return (Vec::new(), Vec::new());
+    }
+
+    let mut split_coords: Vec<[f64; 2]> = Vec::new();
+    let mut ignored: Vec<[f64; 2]> = Vec::new();
+    let mut lines: Vec<Vec<[f64; 2]>> = Vec::new();
+    let mut current: Vec<[f64; 2]> = vec![coords[0]];
+
+    for w in coords.windows(2) {
+        let (start, end) = (w[0], w[1]);
+        let lo = [
+            start[0].min(end[0]) - tolerance,
+            start[1].min(end[1]) - tolerance,
+        ];
+        let hi = [
+            start[0].max(end[0]) + tolerance,
+            start[1].max(end[1]) + tolerance,
+        ];
+
+        // Split this segment iteratively by every nearby candidate; pieces stay
+        // ordered along the segment.
+        let mut pieces: Vec<([f64; 2], [f64; 2])> = vec![(start, end)];
+        for &cand in candidates {
+            if cand[0] < lo[0] || cand[0] > hi[0] || cand[1] < lo[1] || cand[1] > hi[1] {
+                continue;
+            }
+            let mut next = Vec::with_capacity(pieces.len() + 1);
+            for piece in pieces {
+                let on_line = (dist(piece.0, cand) + dist(cand, piece.1) - dist(piece.0, piece.1))
+                    .abs()
+                    < tolerance;
+                if on_line && dist(cand, piece.0) >= tolerance && dist(cand, piece.1) >= tolerance {
+                    next.push((piece.0, cand));
+                    next.push((cand, piece.1));
+                    split_coords.push(cand);
+                } else {
+                    next.push(piece);
+                    ignored.push(cand);
+                }
+            }
+            pieces = next;
+        }
+
+        for piece in &pieces[..pieces.len() - 1] {
+            current.push(piece.1);
+            lines.push(std::mem::replace(&mut current, vec![piece.1]));
+        }
+        current.push(pieces[pieces.len() - 1].1);
+    }
+    lines.push(current);
+
+    // Split further at interior vertices that coincide with candidates that
+    // failed to split a segment (T-junctions at existing vertices).
+    let mut final_lines = Vec::new();
+    for line in lines {
+        let split_idxs: Vec<usize> = (1..line.len().saturating_sub(1))
+            .filter(|&i| ignored.iter().any(|&c| dist(c, line[i]) < tolerance))
+            .collect();
+        let mut curr = line;
+        for &i in split_idxs.iter().rev() {
+            split_coords.push(curr[i]);
+            let second = curr[i..].to_vec();
+            curr.truncate(i + 1);
+            final_lines.push(second);
+        }
+        final_lines.push(curr);
+    }
+
+    (final_lines, split_coords)
+}
+
+#[cfg(all(test, not(feature = "new-geometry")))]
 fn line_string_intersection_2d(
     line_strings: &[LineString2D<f64>],
     tolerance: f64,
@@ -835,13 +1353,13 @@ fn line_string_intersection_2d(
         .map(|(i, ls)| AabbEntry {
             feature_idx: i,
             ls_local_idx: 0,
-            aabb: ls.envelope(),
+            aabb: aabb_to_rstar(aabb_of_line_string(ls)),
         })
         .collect();
     overlay_entries(entries, &lss_per_feature, tolerance)
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "new-geometry")))]
 mod tests {
     use super::*;
 
@@ -1036,17 +1554,17 @@ mod tests {
             AabbEntry {
                 feature_idx: 0,
                 ls_local_idx: 0,
-                aabb: f0_a.envelope(),
+                aabb: aabb_to_rstar(aabb_of_line_string(&f0_a)),
             },
             AabbEntry {
                 feature_idx: 0,
                 ls_local_idx: 1,
-                aabb: f0_b.envelope(),
+                aabb: aabb_to_rstar(aabb_of_line_string(&f0_b)),
             },
             AabbEntry {
                 feature_idx: 1,
                 ls_local_idx: 0,
-                aabb: f1.envelope(),
+                aabb: aabb_to_rstar(aabb_of_line_string(&f1)),
             },
         ];
 
@@ -1093,17 +1611,17 @@ mod tests {
             AabbEntry {
                 feature_idx: 0,
                 ls_local_idx: 0,
-                aabb: f0.envelope(),
+                aabb: aabb_to_rstar(aabb_of_line_string(&f0)),
             },
             AabbEntry {
                 feature_idx: 1,
                 ls_local_idx: 0,
-                aabb: f1_a.envelope(),
+                aabb: aabb_to_rstar(aabb_of_line_string(&f1_a)),
             },
             AabbEntry {
                 feature_idx: 1,
                 ls_local_idx: 1,
-                aabb: f1_b.envelope(),
+                aabb: aabb_to_rstar(aabb_of_line_string(&f1_b)),
             },
         ];
 
@@ -1128,7 +1646,6 @@ mod tests {
         }
     }
 
-    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_process_group_two_crossing_lines() {
         let dir =
@@ -1168,6 +1685,161 @@ mod tests {
             let mut w = BufWriter::new(File::create(group_dir.join("features.jsonl")).unwrap());
             writeln!(w, "{}", serde_json::to_string(&f1).unwrap()).unwrap();
             writeln!(w, "{}", serde_json::to_string(&f2).unwrap()).unwrap();
+            w.flush().unwrap();
+        }
+
+        let mut line_buf: Vec<u8> = Vec::new();
+        let mut point_buf: Vec<u8> = Vec::new();
+        let (lc, pc) = process_group(
+            &group_dir,
+            0.01,
+            None,
+            "overlaidLists",
+            &mut line_buf,
+            &mut point_buf,
+        )
+        .unwrap();
+        assert_eq!(lc, 4);
+        assert_eq!(pc, 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}
+
+#[cfg(all(test, feature = "new-geometry"))]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use reearth_flow_geometry::polygon::Polygon2D;
+
+    use super::*;
+
+    fn line(coords: Vec<[f64; 2]>) -> Geometry {
+        Geometry::Euclidean2D(Euclidean2DGeometry::LineString(LineString2D::from_coords(
+            CoordinateFrame::Euclidean,
+            coords,
+        )))
+    }
+
+    fn overlay_lines(lines: Vec<Vec<[f64; 2]>>, tolerance: f64) -> OverlayResult {
+        let lss_per_feature: Vec<Vec<Polyline>> = lines
+            .into_iter()
+            .map(|coords| {
+                vec![Polyline {
+                    frame: CoordinateFrame::Euclidean,
+                    coords,
+                    elevation: None,
+                }]
+            })
+            .collect();
+        let entries: Vec<AabbEntry> = lss_per_feature
+            .iter()
+            .enumerate()
+            .map(|(i, pls)| AabbEntry {
+                feature_idx: i,
+                ls_local_idx: 0,
+                aabb: aabb_to_rstar(polyline_bbox(&pls[0].coords)),
+            })
+            .collect();
+        overlay_entries(entries, &lss_per_feature, tolerance)
+    }
+
+    #[test]
+    fn crossing_lines_split_into_four_segments_and_one_point() {
+        let result = overlay_lines(
+            vec![vec![[0.0, 0.0], [5.0, 5.0]], vec![[0.0, 5.0], [5.0, 0.0]]],
+            0.1,
+        );
+        assert_eq!(result.line_strings_with_metadata.len(), 4);
+        assert_eq!(result.split_coords.len(), 1);
+        let point = &result.split_coords[0];
+        assert!((point.coord[0] - 2.5).abs() < 1e-6);
+        assert!((point.coord[1] - 2.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn collinear_overlaps_count_each_source_once() {
+        let result = overlay_lines(
+            vec![
+                vec![[0.0, 0.0], [4.0, 4.0]],
+                vec![[1.0, 1.0], [4.0, 4.0]],
+                vec![[2.0, 2.0], [3.0, 3.0]],
+            ],
+            0.1,
+        );
+        assert_eq!(result.line_strings_with_metadata.len(), 4);
+        let mut overlay_counts = result
+            .line_strings_with_metadata
+            .iter()
+            .map(|ls| ls.source_feature_idxs.len())
+            .collect::<Vec<_>>();
+        overlay_counts.sort();
+        assert_eq!(overlay_counts, vec![1, 2, 2, 3]);
+        assert_eq!(result.split_coords.len(), 3);
+    }
+
+    #[test]
+    fn a_polygon_exterior_participates_and_keeps_its_elevation() {
+        let polygon = Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(Box::new(
+            Polygon2D::from_rings_at_elevation(
+                CoordinateFrame::Euclidean,
+                vec![[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]],
+                Vec::<Vec<[f64; 2]>>::new(),
+                5.0,
+            ),
+        )));
+        let ring = feature_source_lines(&Feature::from(polygon));
+        assert_eq!(ring.len(), 1);
+        assert_eq!(ring[0].elevation, Some(5.0));
+
+        let crossing = feature_source_lines(&Feature::from(line(vec![[-1.0, 2.0], [5.0, 2.0]])));
+        let lss_per_feature = vec![ring, crossing];
+        let entries: Vec<AabbEntry> = lss_per_feature
+            .iter()
+            .enumerate()
+            .map(|(i, pls)| AabbEntry {
+                feature_idx: i,
+                ls_local_idx: 0,
+                aabb: aabb_to_rstar(polyline_bbox(&pls[0].coords)),
+            })
+            .collect();
+        let result = overlay_entries(entries, &lss_per_feature, 0.1);
+
+        // The crossing line pierces the ring's left and right edges.
+        assert_eq!(result.split_coords.len(), 2);
+        for meta in &result.line_strings_with_metadata {
+            let expected = match meta.source_feature_idxs[0] {
+                0 => Some(5.0),
+                _ => None,
+            };
+            assert_eq!(meta.line_string.elevation, expected);
+        }
+    }
+
+    #[test]
+    fn process_group_emits_split_lines_and_intersection_points() {
+        let dir =
+            engine_cache_dir(uuid::Uuid::nil()).join(format!("test-lol-{}", uuid::Uuid::new_v4()));
+        let group_dir = dir.join("group_000000");
+        std::fs::create_dir_all(&group_dir).unwrap();
+
+        let features = [
+            Feature::from(line(vec![[0.0, 0.0], [5.0, 5.0]])),
+            Feature::from(line(vec![[0.0, 5.0], [5.0, 0.0]])),
+        ];
+
+        {
+            let mut w = BufWriter::new(File::create(group_dir.join("aabbs.jsonl")).unwrap());
+            for f in &features {
+                let (aabbs, _) = intake(f.geometry.as_ref()).unwrap();
+                writeln!(w, "{}", serde_json::to_string(&aabbs).unwrap()).unwrap();
+            }
+            w.flush().unwrap();
+        }
+        {
+            let mut w = BufWriter::new(File::create(group_dir.join("features.jsonl")).unwrap());
+            for f in &features {
+                writeln!(w, "{}", serde_json::to_string(f).unwrap()).unwrap();
+            }
             w.flush().unwrap();
         }
 

--- a/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
@@ -61,7 +61,10 @@ impl ProcessorFactory for LineOnLineOverlayerFactory {
     }
 
     fn description(&self) -> &str {
-        "Intersection points are turned into point features that can contain the merged list of attributes of the original intersected lines."
+        "Splits lines where they cross and turns each intersection into a point feature carrying \
+         the merged attributes of the lines that meet there. Inputs must be flat 2D geometries \
+         sharing one coordinate frame; place a Two Dimension Forcer or a Coordinate Frame \
+         Reprojector upstream to flatten or unify them."
     }
 
     fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
@@ -398,8 +401,7 @@ impl Processor for LineOnLineOverlayer {
 #[cfg(not(feature = "new-geometry"))]
 type SourceLine = LineString2D<f64>;
 
-/// The polyline value carried through the overlay: its coordinates, frame, and
-/// the elevation it lies at.
+/// The polyline value carried through the overlay: its coordinates and frame.
 #[cfg(feature = "new-geometry")]
 type SourceLine = Polyline;
 
@@ -424,8 +426,6 @@ struct Polyline {
     frame: CoordinateFrame,
     /// The vertices, at least two.
     coords: Vec<[f64; 2]>,
-    /// The elevation the whole polyline lies at. `None` = pure 2D.
-    elevation: Option<f64>,
 }
 
 /// Accept an incoming geometry into the overlay: any 2D geometry with at
@@ -446,15 +446,21 @@ fn intake(geometry: &Geometry) -> Option<Vec<[f64; 4]>> {
     Some(line_strings.iter().map(aabb_of_line_string).collect())
 }
 
-/// Accept an incoming geometry into the overlay: a 2D geometry whose line
+/// Accept an incoming geometry into the overlay: a planar geometry whose line
 /// strings and polygon exteriors yield at least one polyline, all in one
 /// coordinate frame. Returns the bounding box of each polyline and the frame,
 /// or `None` when the feature must be rejected.
+///
+/// The overlay reasons about the plane alone, so a leaf placed at an elevation
+/// is refused rather than crossed with one at a different height.
 #[cfg(feature = "new-geometry")]
 fn intake(geometry: &Geometry) -> Option<(Vec<[f64; 4]>, CoordinateFrame)> {
     let Geometry::Euclidean2D(geom_2d) = geometry else {
         return None;
     };
+    if carries_elevation(geom_2d) {
+        return None;
+    }
     let polylines = source_lines_2d(geom_2d);
     let frame = polylines.first()?.frame.clone();
     if polylines.iter().any(|pl| pl.frame != frame) {
@@ -490,16 +496,28 @@ fn source_lines_2d(geom: &Euclidean2DGeometry) -> Vec<Polyline> {
             Leaf2D::Line(line) if line.coords().len() >= 2 => Some(Polyline {
                 frame: line.frame().clone(),
                 coords: line.coords().to_vec(),
-                elevation: line.elevation(),
             }),
             Leaf2D::Polygon(polygon) if polygon.exterior().len() >= 2 => Some(Polyline {
                 frame: polygon.frame().clone(),
                 coords: polygon.exterior().to_vec(),
-                elevation: polygon.elevation(),
             }),
             _ => None,
         })
         .collect()
+}
+
+/// Whether any leaf of the geometry is placed at an elevation.
+#[cfg(feature = "new-geometry")]
+fn carries_elevation(geom: &Euclidean2DGeometry) -> bool {
+    let mut leaves = Vec::new();
+    flatten_2d(geom, &mut leaves);
+    leaves.iter().any(|leaf| match leaf {
+        Leaf2D::Polygon(p) => p.elevation().is_some(),
+        Leaf2D::PolygonMesh(m) => m.elevation().is_some(),
+        Leaf2D::TriangularMesh(m) => m.elevation().is_some(),
+        Leaf2D::Line(l) => l.elevation().is_some(),
+        Leaf2D::Point(_) => false,
+    })
 }
 
 /// The stored feature's polylines, empty when it has no 2D geometry.
@@ -529,16 +547,13 @@ fn line_output_geometry(line: &SourceLine) -> Geometry {
     }
 }
 
-/// A split line as an output feature's geometry, in its source's frame and at
-/// its source's elevation.
+/// A split line as an output feature's geometry, in its source's frame.
 #[cfg(feature = "new-geometry")]
 fn line_output_geometry(line: &SourceLine) -> Geometry {
-    let coords = line.coords.iter().copied();
-    let ls = match line.elevation {
-        Some(z) => LineString2D::from_coords_at_elevation(line.frame.clone(), coords, z),
-        None => LineString2D::from_coords(line.frame.clone(), coords),
-    };
-    Geometry::Euclidean2D(Euclidean2DGeometry::LineString(ls))
+    Geometry::Euclidean2D(Euclidean2DGeometry::LineString(LineString2D::from_coords(
+        line.frame.clone(),
+        line.coords.iter().copied(),
+    )))
 }
 
 /// An intersection point as an output feature's geometry.
@@ -1032,7 +1047,6 @@ fn overlay_entries(
                         Polyline {
                             frame: self_pl.frame.clone(),
                             coords,
-                            elevation: self_pl.elevation,
                         },
                     )
                 })
@@ -1092,7 +1106,7 @@ fn overlay_entries(
         if processed[i] {
             continue;
         }
-        let (feat_i, mut rep) = segments[i].clone();
+        let (feat_i, rep) = segments[i].clone();
         // A single feature may contribute multiple matching segments (e.g. a closed ring
         // whose split produces several arcs that all coincide with the rep segment). Count
         // each feature at most once; extra matching segments dedupe silently.
@@ -1107,10 +1121,6 @@ fn overlay_entries(
             }
             let (feat_j, pl_j) = (segments[j].0, &segments[j].1);
             if coords_match(&rep.coords, &pl_j.coords, tolerance) {
-                // Coinciding sources at differing elevations leave the output planar.
-                if pl_j.elevation != rep.elevation {
-                    rep.elevation = None;
-                }
                 if !included_feats.insert(feat_j) {
                     processed[j] = true;
                     continue;
@@ -1296,6 +1306,9 @@ fn split_polyline(
                 continue;
             }
             let mut next = Vec::with_capacity(pieces.len() + 1);
+            // A candidate that misses any piece is remembered once, not once per
+            // piece: the second pass only asks whether it is there at all.
+            let mut missed_a_piece = false;
             for piece in pieces {
                 let on_line = (dist(piece.0, cand) + dist(cand, piece.1) - dist(piece.0, piece.1))
                     .abs()
@@ -1306,8 +1319,11 @@ fn split_polyline(
                     split_coords.push(cand);
                 } else {
                     next.push(piece);
-                    ignored.push(cand);
+                    missed_a_piece = true;
                 }
+            }
+            if missed_a_piece {
+                ignored.push(cand);
             }
             pieces = next;
         }
@@ -1720,6 +1736,47 @@ mod tests {
         )))
     }
 
+    #[test]
+    fn a_group_admits_only_the_frame_its_first_feature_fixes() {
+        let mut overlayer = LineOnLineOverlayer {
+            group_by: None,
+            tolerance: 0.0,
+            overlaid_lists_attr_name: "overlaidLists".to_string(),
+            group_map: HashMap::new(),
+            group_frame: HashMap::new(),
+            group_count: 0,
+            temp_dir: None,
+            buffer: HashMap::new(),
+            buffer_bytes: 0,
+            executor_id: None,
+        };
+        let euclidean = CoordinateFrame::Euclidean;
+        let crs = CoordinateFrame::Crs(reearth_flow_geometry::coordinate::EpsgCode::new(6677));
+
+        assert!(overlayer.admit_frame(0, &euclidean));
+        assert!(overlayer.admit_frame(0, &euclidean));
+        assert!(!overlayer.admit_frame(0, &crs));
+        // A different group is free to fix a different frame.
+        assert!(overlayer.admit_frame(1, &crs));
+    }
+
+    #[test]
+    fn intake_rejects_a_feature_whose_members_are_in_different_frames() {
+        let in_euclidean =
+            LineString2D::from_coords(CoordinateFrame::Euclidean, [[0.0, 0.0], [1.0, 1.0]]);
+        let in_crs = LineString2D::from_coords(
+            CoordinateFrame::Crs(reearth_flow_geometry::coordinate::EpsgCode::new(6677)),
+            [[0.0, 0.0], [1.0, 1.0]],
+        );
+        let geometry = Geometry::Euclidean2D(Euclidean2DGeometry::Collection(
+            reearth_flow_geometry::collection::Collection2D::new([
+                Euclidean2DGeometry::LineString(in_euclidean),
+                Euclidean2DGeometry::LineString(in_crs),
+            ]),
+        ));
+        assert!(intake(&geometry).is_none());
+    }
+
     fn overlay_lines(lines: Vec<Vec<[f64; 2]>>, tolerance: f64) -> OverlayResult {
         let lss_per_feature: Vec<Vec<Polyline>> = lines
             .into_iter()
@@ -1727,7 +1784,6 @@ mod tests {
                 vec![Polyline {
                     frame: CoordinateFrame::Euclidean,
                     coords,
-                    elevation: None,
                 }]
             })
             .collect();
@@ -1778,8 +1834,19 @@ mod tests {
     }
 
     #[test]
-    fn a_polygon_exterior_participates_and_keeps_its_elevation() {
-        let polygon = Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(Box::new(
+    fn intake_rejects_an_elevated_line_string() {
+        let elevated = LineString2D::from_coords_at_elevation(
+            CoordinateFrame::Euclidean,
+            [[0.0, 0.0], [1.0, 1.0]],
+            5.0,
+        );
+        let geometry = Geometry::Euclidean2D(Euclidean2DGeometry::LineString(elevated));
+        assert!(intake(&geometry).is_none());
+    }
+
+    #[test]
+    fn intake_rejects_an_elevated_polygon_exterior() {
+        let geometry = Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(Box::new(
             Polygon2D::from_rings_at_elevation(
                 CoordinateFrame::Euclidean,
                 vec![[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]],
@@ -1787,9 +1854,20 @@ mod tests {
                 5.0,
             ),
         )));
+        assert!(intake(&geometry).is_none());
+    }
+
+    #[test]
+    fn a_polygon_exterior_participates_in_the_overlay() {
+        let polygon = Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(Box::new(
+            Polygon2D::from_rings(
+                CoordinateFrame::Euclidean,
+                vec![[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]],
+                Vec::<Vec<[f64; 2]>>::new(),
+            ),
+        )));
         let ring = feature_source_lines(&Feature::from(polygon));
         assert_eq!(ring.len(), 1);
-        assert_eq!(ring[0].elevation, Some(5.0));
 
         let crossing = feature_source_lines(&Feature::from(line(vec![[-1.0, 2.0], [5.0, 2.0]])));
         let lss_per_feature = vec![ring, crossing];
@@ -1806,13 +1884,6 @@ mod tests {
 
         // The crossing line pierces the ring's left and right edges.
         assert_eq!(result.split_coords.len(), 2);
-        for meta in &result.line_strings_with_metadata {
-            let expected = match meta.source_feature_idxs[0] {
-                0 => Some(5.0),
-                _ => None,
-            };
-            assert_eq!(meta.line_string.elevation, expected);
-        }
     }
 
     #[test]

--- a/engine/runtime/geometry/src/polygon/mod.rs
+++ b/engine/runtime/geometry/src/polygon/mod.rs
@@ -101,15 +101,9 @@ impl Polygon2D {
         self.z
     }
 
-    /// This face placed wholly at `elevation`, replacing any previous one.
-    pub fn at_elevation(mut self, elevation: f64) -> Self {
-        self.z = Some(elevation);
-        self
-    }
-
     /// The unsigned planar area of the face: the exterior ring's area minus the
     /// area of the holes. Ring winding does not affect the result; elevation
-    /// does not contribute.
+    /// does not contribute. Rings stored open are measured as if closed.
     pub fn area(&self) -> f64 {
         let exterior = ring_area(self.exterior());
         let holes: f64 = self.interiors().map(ring_area).sum();
@@ -129,12 +123,21 @@ impl Polygon2D {
     }
 }
 
-/// The unsigned shoelace area of one closed ring.
+/// The unsigned shoelace area of one ring. Rings are stored as the builder
+/// received them, so a ring left open is measured with its closing edge
+/// restored; fewer than three vertices enclose nothing.
 fn ring_area(ring: &[[f64; 2]]) -> f64 {
-    let sum: f64 = ring
+    if ring.len() < 3 {
+        return 0.0;
+    }
+    let mut sum: f64 = ring
         .windows(2)
         .map(|w| w[0][0] * w[1][1] - w[1][0] * w[0][1])
         .sum();
+    let (first, last) = (ring[0], ring[ring.len() - 1]);
+    if first != last {
+        sum += last[0] * first[1] - first[0] * last[1];
+    }
     sum.abs() / 2.0
 }
 
@@ -183,3 +186,64 @@ impl Polygon3D {
 // A polygon is a single face, not a multi-part container.
 crate::unsupported!(Polygon2D: Split);
 crate::unsupported!(Polygon3D: Split);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A 2x2 square held away from the origin, so the closing edge carries a
+    /// non-zero shoelace term and an omitted one shows up in the result.
+    fn square(closed: bool) -> Polygon2D {
+        let mut ring = vec![[1.0, 1.0], [3.0, 1.0], [3.0, 3.0], [1.0, 3.0]];
+        if closed {
+            ring.push([1.0, 1.0]);
+        }
+        Polygon2D::from_rings(
+            CoordinateFrame::Euclidean,
+            ring,
+            Vec::<Vec<[f64; 2]>>::new(),
+        )
+    }
+
+    #[test]
+    fn a_ring_left_open_measures_the_same_as_a_closed_one() {
+        assert_eq!(square(true).area(), 4.0);
+        assert_eq!(square(false).area(), 4.0);
+    }
+
+    #[test]
+    fn winding_does_not_affect_the_area() {
+        let clockwise = Polygon2D::from_rings(
+            CoordinateFrame::Euclidean,
+            vec![[0.0, 0.0], [0.0, 2.0], [2.0, 2.0], [2.0, 0.0], [0.0, 0.0]],
+            Vec::<Vec<[f64; 2]>>::new(),
+        );
+        assert_eq!(clockwise.area(), 4.0);
+    }
+
+    #[test]
+    fn holes_are_subtracted() {
+        let with_hole = Polygon2D::from_rings(
+            CoordinateFrame::Euclidean,
+            vec![[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]],
+            vec![vec![
+                [1.0, 1.0],
+                [2.0, 1.0],
+                [2.0, 2.0],
+                [1.0, 2.0],
+                [1.0, 1.0],
+            ]],
+        );
+        assert_eq!(with_hole.area(), 15.0);
+    }
+
+    #[test]
+    fn a_ring_too_short_to_enclose_anything_has_no_area() {
+        let degenerate = Polygon2D::from_rings(
+            CoordinateFrame::Euclidean,
+            vec![[0.0, 0.0], [2.0, 0.0]],
+            Vec::<Vec<[f64; 2]>>::new(),
+        );
+        assert_eq!(degenerate.area(), 0.0);
+    }
+}

--- a/engine/runtime/geometry/src/polygon/mod.rs
+++ b/engine/runtime/geometry/src/polygon/mod.rs
@@ -101,6 +101,21 @@ impl Polygon2D {
         self.z
     }
 
+    /// This face placed wholly at `elevation`, replacing any previous one.
+    pub fn at_elevation(mut self, elevation: f64) -> Self {
+        self.z = Some(elevation);
+        self
+    }
+
+    /// The unsigned planar area of the face: the exterior ring's area minus the
+    /// area of the holes. Ring winding does not affect the result; elevation
+    /// does not contribute.
+    pub fn area(&self) -> f64 {
+        let exterior = ring_area(self.exterior());
+        let holes: f64 = self.interiors().map(ring_area).sum();
+        (exterior - holes).max(0.0)
+    }
+
     /// Borrow the appearance, if any.
     #[inline]
     pub fn appearance(&self) -> &Option<Appearance> {
@@ -112,6 +127,15 @@ impl Polygon2D {
     pub fn appearance_mut(&mut self) -> &mut Option<Appearance> {
         &mut self.appearance
     }
+}
+
+/// The unsigned shoelace area of one closed ring.
+fn ring_area(ring: &[[f64; 2]]) -> f64 {
+    let sum: f64 = ring
+        .windows(2)
+        .map(|w| w[0][0] * w[1][1] - w[1][0] * w[0][1])
+        .sum();
+    sum.abs() / 2.0
 }
 
 impl Polygon3D {

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -99,7 +99,7 @@
     {
       "name": "Area On Area Overlayer",
       "type": "processor",
-      "description": "Perform Area Overlay Analysis",
+      "description": "Subdivides overlapping areas into non-overlapping pieces and records how many input features cover each piece. Inputs must be flat 2D geometries sharing one coordinate frame; place a Two Dimension Forcer or a Coordinate Frame Reprojector upstream to flatten or unify them.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Area On Area Overlayer Parameters",
@@ -7990,7 +7990,7 @@
     {
       "name": "Line On Line Overlayer",
       "type": "processor",
-      "description": "Intersection points are turned into point features that can contain the merged list of attributes of the original intersected lines.",
+      "description": "Splits lines where they cross and turns each intersection into a point feature carrying the merged attributes of the lines that meet there. Inputs must be flat 2D geometries sharing one coordinate frame; place a Two Dimension Forcer or a Coordinate Frame Reprojector upstream to flatten or unify them.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Line On Line Overlayer Parameters",

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -99,7 +99,7 @@
     {
       "name": "Area On Area Overlayer",
       "type": "processor",
-      "description": "Superpone un área sobre otra área",
+      "description": "Subdivide las áreas superpuestas en fragmentos disjuntos y registra cuántas entidades de entrada cubren cada fragmento. Las entradas deben ser geometrías 2D planas, sin elevación, que compartan un mismo marco de coordenadas; coloque un Two Dimension Forcer o un Coordinate Frame Reprojector antes para aplanarlas o unificarlas.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Area On Area Overlayer Parameters",
@@ -7991,7 +7991,7 @@
     {
       "name": "Line On Line Overlayer",
       "type": "processor",
-      "description": "Los puntos de intersección se convierten en entidades de puntos que pueden contener la lista combinada de atributos de las líneas originales intersectadas.",
+      "description": "Divide las líneas en sus intersecciones y convierte cada intersección en una entidad de punto que lleva los atributos combinados de las líneas que se cruzan allí. Las entradas deben ser geometrías 2D planas, sin elevación, que compartan un mismo marco de coordenadas; coloque un Two Dimension Forcer o un Coordinate Frame Reprojector antes para aplanarlas o unificarlas.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Line On Line Overlayer Parameters",

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -99,7 +99,7 @@
     {
       "name": "Area On Area Overlayer",
       "type": "processor",
-      "description": "Perform Area Overlay Analysis",
+      "description": "Subdivise les zones qui se chevauchent en fragments disjoints et enregistre le nombre d'entités d'entrée couvrant chaque fragment. Les entrées doivent être des géométries 2D planes, sans altitude, partageant un même référentiel de coordonnées ; placez un Two Dimension Forcer ou un Coordinate Frame Reprojector en amont pour les aplatir ou les unifier.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Area On Area Overlayer Parameters",
@@ -7991,7 +7991,7 @@
     {
       "name": "Line On Line Overlayer",
       "type": "processor",
-      "description": "Intersection points are turned into point features that can contain the merged list of attributes of the original intersected lines.",
+      "description": "Découpe les lignes à leurs intersections et transforme chaque intersection en une entité ponctuelle portant les attributs fusionnés des lignes qui s'y rencontrent. Les entrées doivent être des géométries 2D planes, sans altitude, partageant un même référentiel de coordonnées ; placez un Two Dimension Forcer ou un Coordinate Frame Reprojector en amont pour les aplatir ou les unifier.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Line On Line Overlayer Parameters",

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -99,7 +99,7 @@
     {
       "name": "Area On Area Overlayer",
       "type": "processor",
-      "description": "あるエリアの上に別のエリアを重ね合わせる",
+      "description": "重なり合うエリアを重複のない断片に分割し、各断片を覆う入力地物の数を記録する。入力は標高を持たない平面の2Dジオメトリで、かつ同一の座標フレームである必要があるため、前段にTwo Dimension ForcerやCoordinate Frame Reprojectorを配置して平面化・統一する",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Area On Area Overlayer パラメータ",
@@ -7991,7 +7991,7 @@
     {
       "name": "Line On Line Overlayer",
       "type": "processor",
-      "description": "交点を点地物に変換し、元の交差したラインの属性リストを結合して含めることができる",
+      "description": "交差する位置でラインを分割し、各交点を、そこで交わるラインの属性を結合して持つ点地物に変換する。入力は標高を持たない平面の2Dジオメトリで、かつ同一の座標フレームである必要があるため、前段にTwo Dimension ForcerやCoordinate Frame Reprojectorを配置して平面化・統一する",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Line On Line Overlayer パラメータ",

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -99,7 +99,7 @@
     {
       "name": "Area On Area Overlayer",
       "type": "processor",
-      "description": "在一个区域上叠加另一个区域",
+      "description": "将重叠区域细分为互不重叠的碎片，并记录覆盖每个碎片的输入实体数量。输入必须是不带高程的平面2D几何且共享同一坐标框架，请在上游放置Two Dimension Forcer或Coordinate Frame Reprojector进行展平或统一",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Area On Area Overlayer Parameters",
@@ -7991,7 +7991,7 @@
     {
       "name": "Line On Line Overlayer",
       "type": "processor",
-      "description": "交点转换为点实体，并可包含原始相交线段组合的属性列表",
+      "description": "在相交处分割线，并将每个交点转换为携带相交各线合并属性的点实体。输入必须是不带高程的平面2D几何且共享同一坐标框架，请在上游放置Two Dimension Forcer或Coordinate Frame Reprojector进行展平或统一",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Line On Line Overlayer Parameters",

--- a/engine/schema/i18n/actions/es.json
+++ b/engine/schema/i18n/actions/es.json
@@ -40,7 +40,7 @@
     },
     {
       "name": "Area On Area Overlayer",
-      "description": "Superpone un área sobre otra área",
+      "description": "Subdivide las áreas superpuestas en fragmentos disjuntos y registra cuántas entidades de entrada cubren cada fragmento. Las entradas deben ser geometrías 2D planas, sin elevación, que compartan un mismo marco de coordenadas; coloque un Two Dimension Forcer o un Coordinate Frame Reprojector antes para aplanarlas o unificarlas.",
       "parameterI18n": {
         "": {
           "title": "Area On Area Overlayer Parameters",
@@ -2339,7 +2339,7 @@
     },
     {
       "name": "Line On Line Overlayer",
-      "description": "Los puntos de intersección se convierten en entidades de puntos que pueden contener la lista combinada de atributos de las líneas originales intersectadas.",
+      "description": "Divide las líneas en sus intersecciones y convierte cada intersección en una entidad de punto que lleva los atributos combinados de las líneas que se cruzan allí. Las entradas deben ser geometrías 2D planas, sin elevación, que compartan un mismo marco de coordenadas; coloque un Two Dimension Forcer o un Coordinate Frame Reprojector antes para aplanarlas o unificarlas.",
       "parameterI18n": {
         "": {
           "title": "Line On Line Overlayer Parameters",

--- a/engine/schema/i18n/actions/fr.json
+++ b/engine/schema/i18n/actions/fr.json
@@ -40,7 +40,7 @@
     },
     {
       "name": "Area On Area Overlayer",
-      "description": "Perform Area Overlay Analysis",
+      "description": "Subdivise les zones qui se chevauchent en fragments disjoints et enregistre le nombre d'entités d'entrée couvrant chaque fragment. Les entrées doivent être des géométries 2D planes, sans altitude, partageant un même référentiel de coordonnées ; placez un Two Dimension Forcer ou un Coordinate Frame Reprojector en amont pour les aplatir ou les unifier.",
       "parameterI18n": {
         "": {
           "title": "Area On Area Overlayer Parameters",
@@ -2339,7 +2339,7 @@
     },
     {
       "name": "Line On Line Overlayer",
-      "description": "Intersection points are turned into point features that can contain the merged list of attributes of the original intersected lines.",
+      "description": "Découpe les lignes à leurs intersections et transforme chaque intersection en une entité ponctuelle portant les attributs fusionnés des lignes qui s'y rencontrent. Les entrées doivent être des géométries 2D planes, sans altitude, partageant un même référentiel de coordonnées ; placez un Two Dimension Forcer ou un Coordinate Frame Reprojector en amont pour les aplatir ou les unifier.",
       "parameterI18n": {
         "": {
           "title": "Line On Line Overlayer Parameters",

--- a/engine/schema/i18n/actions/ja.json
+++ b/engine/schema/i18n/actions/ja.json
@@ -40,7 +40,7 @@
     },
     {
       "name": "Area On Area Overlayer",
-      "description": "あるエリアの上に別のエリアを重ね合わせる",
+      "description": "重なり合うエリアを重複のない断片に分割し、各断片を覆う入力地物の数を記録する。入力は標高を持たない平面の2Dジオメトリで、かつ同一の座標フレームである必要があるため、前段にTwo Dimension ForcerやCoordinate Frame Reprojectorを配置して平面化・統一する",
       "parameterI18n": {
         "": {
           "title": "Area On Area Overlayer パラメータ",
@@ -2339,7 +2339,7 @@
     },
     {
       "name": "Line On Line Overlayer",
-      "description": "交点を点地物に変換し、元の交差したラインの属性リストを結合して含めることができる",
+      "description": "交差する位置でラインを分割し、各交点を、そこで交わるラインの属性を結合して持つ点地物に変換する。入力は標高を持たない平面の2Dジオメトリで、かつ同一の座標フレームである必要があるため、前段にTwo Dimension ForcerやCoordinate Frame Reprojectorを配置して平面化・統一する",
       "parameterI18n": {
         "": {
           "title": "Line On Line Overlayer パラメータ",

--- a/engine/schema/i18n/actions/zh.json
+++ b/engine/schema/i18n/actions/zh.json
@@ -40,7 +40,7 @@
     },
     {
       "name": "Area On Area Overlayer",
-      "description": "在一个区域上叠加另一个区域",
+      "description": "将重叠区域细分为互不重叠的碎片，并记录覆盖每个碎片的输入实体数量。输入必须是不带高程的平面2D几何且共享同一坐标框架，请在上游放置Two Dimension Forcer或Coordinate Frame Reprojector进行展平或统一",
       "parameterI18n": {
         "": {
           "title": "Area On Area Overlayer Parameters",
@@ -2339,7 +2339,7 @@
     },
     {
       "name": "Line On Line Overlayer",
-      "description": "交点转换为点实体，并可包含原始相交线段组合的属性列表",
+      "description": "在相交处分割线，并将每个交点转换为携带相交各线合并属性的点实体。输入必须是不带高程的平面2D几何且共享同一坐标框架，请在上游放置Two Dimension Forcer或Coordinate Frame Reprojector进行展平或统一",
       "parameterI18n": {
         "": {
           "title": "Line On Line Overlayer Parameters",

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.104"
+version = "0.2.105"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.294"
+version = "0.1.295"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
# Overview
This PR implements area overlays and line overlays for new-geometry. The local overlay computation relies on the core algorithms from the `geometry` crate, and the global spatial indexing reuse the legacy implementation. Thus, most behaviors are preserved. Below, we describe the differences from the legacy branch.

## AreaOnAreaOverlayer
- It accepts 2D geometries only.
- 2D meshes are also supported. They are also dissolved to be outer boundary before overlay, and the internal structure is thus discarded on the output.
- 2.5D geometry is rejected.

## LineOnLineOverlayer
- The output carries the coordinate frames.
- 2.5D geometry is rejected.

## Notes
The regression tests against PLATEAU 4/5 workflows will be implemented later, together with other PLATEAU-related actions.