### PR TITLE
feat(engine): migrarte workflow tests

### DIFF
--- a/.github/workflows/ci_engine.yml
+++ b/.github/workflows/ci_engine.yml
@@ -158,6 +158,27 @@ jobs:
         # test-qc` defaults to N_CPUs for local development.
         run: cargo make test-qc -- --test-threads=16
 
+  test-qc-new-geometry:
+    name: test-qc-new-geometry (workflow integration tests, new-geometry)
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-engine-ci
+      # This build enables `new-geometry`, whose `ktx2-rw` dep compiles
+      # KTX-Software from source.
+      - uses: ./.github/actions/install-ktx-toolchain
+      # NOTE: no XSD schema cache here. Every test case is still `#[ignore]`d
+      # under new-geometry, so nothing fetches a remote schema. Add the same
+      # cache step test-qc uses once migrated cases start running.
+      - name: test-qc-new-geometry
+        run: cargo make test-qc-new-geometry -- --test-threads=16
+
   test-conv:
     name: test-conv (tile output validation)
     runs-on: blacksmith-4vcpu-ubuntu-2204

--- a/.github/workflows/ci_engine.yml
+++ b/.github/workflows/ci_engine.yml
@@ -135,6 +135,9 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-engine-ci
+      # This build enables `new-geometry`, whose `ktx2-rw` dep compiles
+      # KTX-Software from source.
+      - uses: ./.github/actions/install-ktx-toolchain
       - name: Cache XSD schema downloads
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -157,27 +160,6 @@ jobs:
         # tests toward CPU-bound). Kept on the caller side so `cargo make
         # test-qc` defaults to N_CPUs for local development.
         run: cargo make test-qc -- --test-threads=16
-
-  test-qc-new-geometry:
-    name: test-qc-new-geometry (workflow integration tests, new-geometry)
-    runs-on: blacksmith-4vcpu-ubuntu-2204
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
-        with:
-          egress-policy: audit
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          fetch-depth: 0
-      - uses: ./.github/actions/setup-engine-ci
-      # This build enables `new-geometry`, whose `ktx2-rw` dep compiles
-      # KTX-Software from source.
-      - uses: ./.github/actions/install-ktx-toolchain
-      # NOTE: no XSD schema cache here. Every test case is still `#[ignore]`d
-      # under new-geometry, so nothing fetches a remote schema. Add the same
-      # cache step test-qc uses once migrated cases start running.
-      - name: test-qc-new-geometry
-        run: cargo make test-qc-new-geometry -- --test-threads=16
 
   test-conv:
     name: test-conv (tile output validation)

--- a/engine/AGENTS.md
+++ b/engine/AGENTS.md
@@ -66,19 +66,17 @@ Use the `add-action` skill for a full step-by-step guide including i18n workflow
 
 ## Testing
 
-These test suites run via `cargo make test`:
+Three test suites run via `cargo make test`:
 
 ```bash
-cargo make test-rs                 # Unit tests (workspace-wide, excludes workflow-tests)
-cargo make test-qc                 # Workflow integration tests (quality-check)
-cargo make test-qc-new-geometry    # Same suite under `new-geometry` (unmigrated cases are ignored)
-cargo make test-conv               # Tile output validation tests (3D Tiles, MVT, raster comparison)
-cargo make test-conv-new-geometry  # Tile output validation under `new-geometry`
+cargo make test-rs    # Unit tests (workspace-wide, excludes workflow-tests)
+cargo make test-qc    # Workflow integration tests (quality-check)
+cargo make test-conv  # Tile output validation tests (3D Tiles, MVT, raster comparison)
 ```
 
 - **Unit tests** — alongside implementation files, use `pretty_assertions`
 - **`runtime/tests/`** — small integration tests with YAML workflow fixtures
-- **`testing/workflow-tests/`** — end-to-end workflow tests. Test cases defined in `testing/data/testcases/` as `workflow_test.json`. `build.rs` auto-generates test functions from these files. A case runs under `new-geometry` only once `skipNewGeometry` is dropped from its profile
+- **`testing/workflow-tests/`** — end-to-end workflow tests. Test cases defined in `testing/data/testcases/` as `workflow_test.json`. `build.rs` auto-generates test functions from these files
 - **`testing/plateau-tiles-test/`** — tile output comparison tests. Configured via `profile.toml`, compares flow output against truth data
 - **`testing/data/fixtures/`** — shared PLATEAU CityGML test data used across test suites
 

--- a/engine/AGENTS.md
+++ b/engine/AGENTS.md
@@ -66,17 +66,19 @@ Use the `add-action` skill for a full step-by-step guide including i18n workflow
 
 ## Testing
 
-Three test suites run via `cargo make test`:
+These test suites run via `cargo make test`:
 
 ```bash
-cargo make test-rs    # Unit tests (workspace-wide, excludes workflow-tests)
-cargo make test-qc    # Workflow integration tests (quality-check)
-cargo make test-conv  # Tile output validation tests (3D Tiles, MVT, raster comparison)
+cargo make test-rs                 # Unit tests (workspace-wide, excludes workflow-tests)
+cargo make test-qc                 # Workflow integration tests (quality-check)
+cargo make test-qc-new-geometry    # Same suite under `new-geometry` (unmigrated cases are ignored)
+cargo make test-conv               # Tile output validation tests (3D Tiles, MVT, raster comparison)
+cargo make test-conv-new-geometry  # Tile output validation under `new-geometry`
 ```
 
 - **Unit tests** — alongside implementation files, use `pretty_assertions`
 - **`runtime/tests/`** — small integration tests with YAML workflow fixtures
-- **`testing/workflow-tests/`** — end-to-end workflow tests. Test cases defined in `testing/data/testcases/` as `workflow_test.json`. `build.rs` auto-generates test functions from these files
+- **`testing/workflow-tests/`** — end-to-end workflow tests. Test cases defined in `testing/data/testcases/` as `workflow_test.json`. `build.rs` auto-generates test functions from these files. A case runs under `new-geometry` only once `skipNewGeometry` is dropped from its profile
 - **`testing/plateau-tiles-test/`** — tile output comparison tests. Configured via `profile.toml`, compares flow output against truth data
 - **`testing/data/fixtures/`** — shared PLATEAU CityGML test data used across test suites
 

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "Inflector",
  "approx",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4959,7 +4959,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5008,7 +5008,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5019,7 +5019,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "bytes",
  "clap",
@@ -5061,7 +5061,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5145,7 +5145,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "approx",
  "bvh",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5243,7 +5243,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5272,7 +5272,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5308,7 +5308,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "bytes",
  "futures",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "bytes",
  "futures",
@@ -5375,7 +5375,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "ahash",
  "bytes",
@@ -5459,7 +5459,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.473"
+version = "0.0.474"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.103"
+version = "0.2.104"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "Inflector",
  "approx",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4959,7 +4959,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5008,7 +5008,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5019,7 +5019,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "bytes",
  "clap",
@@ -5061,7 +5061,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5145,7 +5145,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "approx",
  "bvh",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5243,7 +5243,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5272,7 +5272,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5308,7 +5308,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "bytes",
  "futures",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "bytes",
  "futures",
@@ -5375,7 +5375,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "ahash",
  "bytes",
@@ -5459,7 +5459,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.474"
+version = "0.0.475"
 dependencies = [
  "async-trait",
  "axum",
@@ -8225,7 +8225,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.293"
+version = "0.1.294"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.474"
+version = "0.0.475"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.473"
+version = "0.0.474"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Makefile.toml
+++ b/engine/Makefile.toml
@@ -42,7 +42,6 @@ script = ['''
 #!/usr/bin/env bash -eux
 cargo make test-rs ${@:-}
 cargo make test-qc ${@:-}
-cargo make test-qc-new-geometry ${@:-}
 cargo make test-conv ${@:-}
 cargo make test-conv-new-geometry ${@:-}
 ''']
@@ -56,22 +55,15 @@ cargo test --workspace --all-targets --features new-geometry,schema \
   --exclude workflow-tests --exclude reearth-flow-tests ${@:-}
 ''']
 
+# Runs in the new-geometry world. Every test case whose `workflow_test.json`
+# still has `skipNewGeometry` set is `#[ignore]`d, so today this only builds the
+# suite; cases are enabled as their workflows are migrated.
 [tasks.test-qc]
 script = ['''
 #!/usr/bin/env bash -eux
 # Defaults to cargo's normal thread count (= N_CPUs). CI overrides via
 # `cargo make test-qc -- --test-threads=16` so local development is not
 # forced to a CI-specific value.
-cargo test -p workflow-tests ${@:-}
-''']
-
-# Runs the same suite in the new-geometry world. Every test case whose
-# `workflow_test.json` still has `skipNewGeometry` set is `#[ignore]`d here, so
-# today this only builds the suite; cases are enabled as their workflows are
-# migrated. Folds into test-qc once new-geometry becomes the default.
-[tasks.test-qc-new-geometry]
-script = ['''
-#!/usr/bin/env bash -eux
 cargo test -p workflow-tests --features new-geometry ${@:-}
 ''']
 

--- a/engine/Makefile.toml
+++ b/engine/Makefile.toml
@@ -20,7 +20,7 @@ script = ['''
 #!/usr/bin/env bash -eux
 cargo check --workspace --all-targets
 cargo check --workspace --all-targets --features new-geometry \
-  --exclude workflow-tests --exclude reearth-flow-tests
+  --exclude reearth-flow-tests
 ''']
 
 [tasks.clippy]
@@ -28,7 +28,7 @@ script = ['''
 #!/usr/bin/env bash -eux
 cargo clippy --workspace --all-targets -- -D warnings
 cargo clippy --workspace --all-targets --features new-geometry \
-  --exclude workflow-tests --exclude reearth-flow-tests -- -D warnings
+  --exclude reearth-flow-tests -- -D warnings
 ''']
 
 [tasks.clippy-fix]
@@ -42,6 +42,7 @@ script = ['''
 #!/usr/bin/env bash -eux
 cargo make test-rs ${@:-}
 cargo make test-qc ${@:-}
+cargo make test-qc-new-geometry ${@:-}
 cargo make test-conv ${@:-}
 cargo make test-conv-new-geometry ${@:-}
 ''']
@@ -62,6 +63,16 @@ script = ['''
 # `cargo make test-qc -- --test-threads=16` so local development is not
 # forced to a CI-specific value.
 cargo test -p workflow-tests ${@:-}
+''']
+
+# Runs the same suite in the new-geometry world. Every test case whose
+# `workflow_test.json` still has `skipNewGeometry` set is `#[ignore]`d here, so
+# today this only builds the suite; cases are enabled as their workflows are
+# migrated. Folds into test-qc once new-geometry becomes the default.
+[tasks.test-qc-new-geometry]
+script = ['''
+#!/usr/bin/env bash -eux
+cargo test -p workflow-tests --features new-geometry ${@:-}
 ''']
 
 [tasks.ensure-glb-decompress]

--- a/engine/testing/data/testcases/datetime_converter/basic_conversions/workflow_test.json
+++ b/engine/testing/data/testcases/datetime_converter/basic_conversions/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test basic datetime conversions from RFC3339 to Unix seconds",
+  "skipNewGeometry": true,
   "workflowPath": "datetime_converter/basic_conversions.yml",
   "workflowVariables": [],
   "expectedOutput": {

--- a/engine/testing/data/testcases/datetime_converter/custom_format/workflow_test.json
+++ b/engine/testing/data/testcases/datetime_converter/custom_format/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test DateTimeConverter with custom input and output formats",
+  "skipNewGeometry": true,
   "workflowPath": "datetime_converter/custom_format.yml",
   "workflowVariables": [],
   "expectedOutput": {

--- a/engine/testing/data/testcases/datetime_converter/error_handling/workflow_test.json
+++ b/engine/testing/data/testcases/datetime_converter/error_handling/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test DateTimeConverter error handling with failed port",
+  "skipNewGeometry": true,
   "workflowPath": "datetime_converter/error_handling.yml",
   "workflowVariables": [],
   "intermediateAssertions": [

--- a/engine/testing/data/testcases/executor/feature-write/diamond/workflow_test.json
+++ b/engine/testing/data/testcases/executor/feature-write/diamond/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test feature writing with diamond dependency: two different subgraphs (A and B) sharing the same child subgraph, with different routing of its outputs",
+  "skipNewGeometry": true,
   "workflowPath": "executor-testing/feature-write/diamond.yml",
   "expectedOutput": {
     "expectedFile": "output.csv"

--- a/engine/testing/data/testcases/executor/feature-write/nested-subgraph/workflow_test.json
+++ b/engine/testing/data/testcases/executor/feature-write/nested-subgraph/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test feature writing through nested subgraphs (entry -> outer -> inner, 3 levels deep)",
+  "skipNewGeometry": true,
   "workflowPath": "executor-testing/feature-write/nested-subgraph.yml",
   "expectedOutput": {
     "expectedFile": "output.csv"

--- a/engine/testing/data/testcases/executor/feature-write/subgraph/workflow_test.json
+++ b/engine/testing/data/testcases/executor/feature-write/subgraph/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test feature writing through subgraph with FeatureFilter dynamic ports, OutputRouter, and CsvWriter",
+  "skipNewGeometry": true,
   "workflowPath": "executor-testing/feature-write/subgraph.yml",
   "expectedOutput": {
     "expectedFile": "output.csv"

--- a/engine/testing/data/testcases/executor/feature-write/two-copies/workflow_test.json
+++ b/engine/testing/data/testcases/executor/feature-write/two-copies/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test feature writing with two instances of the same subgraph definition (fan-out to two copies)",
+  "skipNewGeometry": true,
   "workflowPath": "executor-testing/feature-write/two-copies.yml",
   "expectedOutput": {
     "expectedFile": "output.csv"

--- a/engine/testing/data/testcases/quality-check/plateau4/01-01-common/C01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/01-01-common/C01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for C01",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/01-01-common/L-frn-01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/01-01-common/L-frn-01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for L-frn-01",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/01-01-common/L01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/01-01-common/L01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for L01. Intentionally malformed XML with unclosed tag causes null pointer errors and workflow failure.",
+  "skipNewGeometry": true,
   "skip": true,
   "workflowPath": "quality-check/plateau4/01-common/workflow.yml",
   "workflowVariables": [

--- a/engine/testing/data/testcases/quality-check/plateau4/01-01-common/L02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/01-01-common/L02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for L02",
+  "skipNewGeometry": true,
   "skip": true,
   "workflowPath": "quality-check/plateau4/01-common/workflow.yml",
   "workflowVariables": [

--- a/engine/testing/data/testcases/quality-check/plateau4/01-01-common/L03/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/01-01-common/L03/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for L03",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/01-01-common/L04_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/01-01-common/L04_01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for L04 #1",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/01-01-common/L04_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/01-01-common/L04_02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for L04 #2",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/01-01-common/L05/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/01-01-common/L05/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for L05",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/01-01-common/L06/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/01-01-common/L06/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for L06",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/01-01-common/T03_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/01-01-common/T03_01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for T03 #1",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/01-01-common/T03_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/01-01-common/T03_02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for T03 #2",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/01-01-common/X-invalid-gml-id/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/01-01-common/X-invalid-gml-id/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Detect invalid gml:id",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/01-01-common/Z-common-00_no-error/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/01-01-common/Z-common-00_no-error/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Verify output files for quality check with no errors",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/01-01-common/Z-common-01_xlink_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/01-01-common/Z-common-01_xlink_01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "CityObjectGroup cross-member xlink refs should not be false-positive XLink_NoReference (valid refs)",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/01-01-common/Z-common-01_xlink_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/01-01-common/Z-common-01_xlink_02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "CityObjectGroup xlink to non-existent gml:id should be detected as XLink_NoReference (checked against file-wide gml:ids)",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/01-01-common/Z-common-01_xlink_03/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/01-01-common/Z-common-01_xlink_03/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Non-CityObjectGroup member with missing xlink ref should still be detected as XLink_NoReference",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/01-02-common/C05/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/01-02-common/C05/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for C05",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/01-02-common/C06/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/01-02-common/C06/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for C06",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/01-02-common/C07/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/01-02-common/C07/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for C07",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/01-02-common/C08/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/01-02-common/C08/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for C08",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/C-BLDG-01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/C-BLDG-01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test PLATEAU4 C-BLDG-01 quality check",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/C02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/C02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test PLATEAU4 C02 quality check",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/CITY-CODE/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/CITY-CODE/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test PLATEAU4 city code validation check",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L-BLDG-01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L-BLDG-01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test PLATEAU4 L-BLSG-1 quality check solid intersection",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L-BLDG-04-05_multi/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L-BLDG-04-05_multi/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test PLATEAU4 L-BLDG-04-05 multi-violation single building quality check",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L-BLDG-04/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L-BLDG-04/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test PLATEAU4 L-BLDG-04-05 quality check",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L-BLDG-05/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L-BLDG-05/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test PLATEAU4 L-BLDG-04-05 quality check",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L-BLDG-06/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L-BLDG-06/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test PLATEAU4 L-BLDG-06",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L-bldg-02_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L-bldg-02_01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test L-bldg-02 error detection: BuildingPart connectivity check with single isolated BuildingPart (status='alone')",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L-bldg-02_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L-bldg-02_02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test L-bldg-02 error detection: Multiple isolated BuildingParts (3 parts, all disconnected, status='alone')",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L07_LOD0_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L07_LOD0_01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L07 for LOD0",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L07_LOD0_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L07_LOD0_02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L07 extension (LinearRing with fewer than 4 points) for LOD0 on plateau4. A 3-point LOD0 exterior LinearRing is expected to be reported as a TooFewPoints error.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L07_LOD1/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L07_LOD1/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L07 for LOD1",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L07_LOD2-4/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L07_LOD2-4/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L07 for LOD2-4",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L09_LOD0/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L09_LOD0/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L09 for LOD0",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L09_LOD1_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L09_LOD1_01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L09 for LOD1 #1",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L09_LOD1_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L09_LOD1_02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L09 for LOD1 #2",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L09_LOD1_03/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L09_LOD1_03/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L09 for LOD1 #3",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L11_LOD1/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L11_LOD1/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L11 for LOD1",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L13_LOD0_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L13_LOD0_01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L13 for LOD0 #1",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L13_LOD0_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L13_LOD0_02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L13 for LOD0 #2",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L13_LOD0_03/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L13_LOD0_03/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L13 for LOD0 #3",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L13_LOD1_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L13_LOD1_01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L13 for LOD1 #1",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L13_LOD1_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L13_LOD1_02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L13 for LOD1 #2",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L13_LOD1_03/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L13_LOD1_03/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L13 for LOD1 #3",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L14/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/L14/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L14",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/T-BLDG-02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/T-BLDG-02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test PLATEAU4 T-bldg-02",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-00_no-error_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-00_no-error_01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Verify output files: no errors, empty CityGML (no features)",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-01_URO/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-01_URO/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test PLATEAU4 URO building ID format check",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-02_surface-intersection-LOD0/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-02_surface-intersection-LOD0/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test surface intersection for LOD0 surfaces",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-03_meshcode-extractor_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-03_meshcode-extractor_01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test PLATEAU4.DestinationMeshCodeExtractor",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-03_meshcode-extractor_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-03_meshcode-extractor_02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test PLATEAU4.DestinationMeshCodeExtractor",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-03_meshcode-extractor_03/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-03_meshcode-extractor_03/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test PLATEAU4.DestinationMeshCodeExtractor with cross-mesh features having equal areas - should select mesh with smaller mesh code",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-04_lod0or1-buildingpart/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-04_lod0or1-buildingpart/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test LOD0-1 BuildingPart detection",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/common/C01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/common/C01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for C01",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/common/C05/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/common/C05/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for C05",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/03-tran/L-TRAN-02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/03-tran/L-TRAN-02/workflow_test.json
@@ -1,6 +1,7 @@
 {
   "description": "Test for plateau4 L-TRAN-02 inspection.",
   "skip": true,
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/03-tran/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/03-tran/L-TRAN-03/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/03-tran/L-TRAN-03/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test for plateau4 L-TRAN-03 inspection.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/03-tran/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/03-tran/Z-TRAN-01-surface-orientation/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/03-tran/Z-TRAN-01-surface-orientation/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test for checking transportation objects' surface orientation errors.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/03-tran/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/03-tran/Z-tran-00_no-error/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/03-tran/Z-tran-00_no-error/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Verify output files: no errors, empty CityGML",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/03-tran/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/03-tran/common/C01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/03-tran/common/C01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for C01. L-TRAN-02 隣接面重複 is excluded from the summary because the input files are duplicates (with different names).",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/03-tran/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/03-tran/common/C05/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/03-tran/common/C05/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for C05",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/03-tran/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/04-frn-veg/Z-01-INSTANCE_COUNTS/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/04-frn-veg/Z-01-INSTANCE_COUNTS/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test for plateau4 instance counts inspection.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/04-frn-veg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/04-frn-veg/Z-02-SURFACE_ERROR/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/04-frn-veg/Z-02-SURFACE_ERROR/workflow_test.json
@@ -1,6 +1,7 @@
 {
   "description": "Test for plateau4 surface errors.",
   "skip": true,
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/04-frn-veg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/04-frn-veg/Z-03-SOLID_ERROR/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/04-frn-veg/Z-03-SOLID_ERROR/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test for plateau4 solid errors.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/04-frn-veg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/04-frn-veg/Z-04-GEOMETRY_TYPE_ERROR/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/04-frn-veg/Z-04-GEOMETRY_TYPE_ERROR/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test for plateau4 geometry type errors.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/04-frn-veg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/04-frn-veg/common/C01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/04-frn-veg/common/C01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for C01",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/04-frn-veg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/04-frn-veg/common/C05/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/04-frn-veg/common/C05/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for C05",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/04-frn-veg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/05-luse-urf-area/Z-01-INSTANCE_COUNTS/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/05-luse-urf-area/Z-01-INSTANCE_COUNTS/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test for plateau4 instance counts inspection.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/05-luse-urf-area/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/05-luse-urf-area/Z-02-SURFACE-ORIENTATION/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/05-luse-urf-area/Z-02-SURFACE-ORIENTATION/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test for plateau4 05 surface orientation error.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/05-luse-urf-area/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/05-luse-urf-area/Z-03-SURFACE-ERROR/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/05-luse-urf-area/Z-03-SURFACE-ERROR/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test for plateau4 05 surface error.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/05-luse-urf-area/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/05-luse-urf-area/Z-LUSE-URF-AREA-00_no-error/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/05-luse-urf-area/Z-LUSE-URF-AREA-00_no-error/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Verify output files: no errors, empty CityGML",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/05-luse-urf-area/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/05-luse-urf-area/common/C01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/05-luse-urf-area/common/C01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for C01",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/05-luse-urf-area/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/05-luse-urf-area/common/C05/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/05-luse-urf-area/common/C05/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for C05",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/05-luse-urf-area/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-00_no-error-fld/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-00_no-error-fld/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Verify output files for quality check with no errors",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/06-fld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-00_no-error-htd/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-00_no-error-htd/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Verify output files for quality check with no errors",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/06-fld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-00_no-error-ifld/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-00_no-error-ifld/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Verify output files for quality check with no errors",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/06-fld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-00_no-error-rfld/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-00_no-error-rfld/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Verify output files for quality check with no errors",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/06-fld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-00_no-error-tnm/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-00_no-error-tnm/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Verify output files for quality check with no errors",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/06-fld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-01_invalid-vertex-count_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-01_invalid-vertex-count_01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for invalid vertex count in triangles (natl/kikuchigawa)",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/06-fld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-01_invalid-vertex-count_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-01_invalid-vertex-count_02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for invalid vertex count (pref/river_a)",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/06-fld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-02_degenerate-triangle_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-02_degenerate-triangle_01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for degenerate triangles (natl/kikuchigawa)",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/06-fld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-02_degenerate-triangle_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-02_degenerate-triangle_02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for degenerate triangles (pref/river_b)",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/06-fld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-03_invalid-orientation/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-03_invalid-orientation/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for invalid orientation (natl/kikuchigawa)",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/06-fld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-04_unclosed-triangle/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-04_unclosed-triangle/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for unclosed triangles (natl/kikuchigawa)",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/06-fld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-05_unshared-edge_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-05_unshared-edge_01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Unshared edges in multiple files",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/06-fld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-05_unshared-edge_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-05_unshared-edge_02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "No errors including no unshared edges — passes cleanly",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/06-fld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-05_unshared-edge_03/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-05_unshared-edge_03/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Only unshared edges detected (reported in CSV but excluded from error count) — passes as OK",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/06-fld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-05_unshared-edge_04/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-05_unshared-edge_04/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Regression test for false-positive unshared edge detection (ajigasawa-machi, pref/nakamuragawa)",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/06-fld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-05_unshared-edge_05/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/06-fld/Z-fld-05_unshared-edge_05/workflow_test.json
@@ -2,6 +2,7 @@
   "description": "Regression test for false-positive unshared edge detection (tsuyama-shi, pref/yoshiigawa)",
   "skip": true,
   "skipReason": "Unshared edge checks do not affect the overall quality check result, so exhaustive regression testing is low priority",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/06-fld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/07-lsld/Z-01-INSTANCE-COUNTS/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/07-lsld/Z-01-INSTANCE-COUNTS/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test for plateau4 instance counts inspection.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/07-lsld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/07-lsld/Z-02-WRONG-SURFACE-ORIENTATION/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/07-lsld/Z-02-WRONG-SURFACE-ORIENTATION/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test for plateau4 07 surface orientation error.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/07-lsld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/07-lsld/Z-03-SURFACE-ERROR/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/07-lsld/Z-03-SURFACE-ERROR/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test for plateau4 07 surface error.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/07-lsld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/07-lsld/Z-LSLD-00_no-error/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/07-lsld/Z-LSLD-00_no-error/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Verify output files: no errors, empty CityGML",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/07-lsld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/07-lsld/common/C01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/07-lsld/common/C01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for C01",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/07-lsld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/07-lsld/common/C05/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/07-lsld/common/C05/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for C05",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/07-lsld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/08-dem/Z-01-TRIANGLE-ORIENTATION/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/08-dem/Z-01-TRIANGLE-ORIENTATION/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test for plateau4 08 triangle orientation error.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/08-dem/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/08-dem/Z-02-DEGENERATE-TRIANGLE/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/08-dem/Z-02-DEGENERATE-TRIANGLE/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test for plateau4 08 degenerate triangles.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/08-dem/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/08-dem/Z-03-INCORRECT-NUM-VERTICES/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/08-dem/Z-03-INCORRECT-NUM-VERTICES/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test for plateau4 08 incorrect number of vertices.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/08-dem/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/08-dem/Z-04-HOLES/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/08-dem/Z-04-HOLES/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test for plateau4 08 holes error.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/08-dem/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/08-dem/Z-05-TRIANGLE-NOT-CLOSED/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/08-dem/Z-05-TRIANGLE-NOT-CLOSED/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test for plateau4 08 not-closed triangle error.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/08-dem/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/08-dem/Z-DEM-00_no-error/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/08-dem/Z-DEM-00_no-error/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Verify output files: no errors, empty CityGML",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/08-dem/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/08-dem/common/C01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/08-dem/common/C01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for C01. checks for 不正な穴 is excluded as it is innebitable in this case. Relief Index is also excluded as it depends on processing order.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/08-dem/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/08-dem/common/C05/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/08-dem/common/C05/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for C05",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/08-dem/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/09-brid-tun-ubld/C02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/09-brid-tun-ubld/C02/workflow_test.json
@@ -1,6 +1,7 @@
 {
   "description": "Test C02 histogram creation.",
   "skip": true,
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/09-brid-tun-ubld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/09-brid-tun-ubld/Z-BRID-TUN-UBLD-00_no-error/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/09-brid-tun-ubld/Z-BRID-TUN-UBLD-00_no-error/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Verify output files: no errors, empty CityGML",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/09-brid-tun-ubld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/09-brid-tun-ubld/common/C01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/09-brid-tun-ubld/common/C01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for C01. checks for 不正な穴 is excluded as it is innebitable in this case.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/09-brid-tun-ubld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/09-brid-tun-ubld/common/C05/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/09-brid-tun-ubld/common/C05/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for C05",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/09-brid-tun-ubld/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/10-cons/Z-cons-00_no-error/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/10-cons/Z-cons-00_no-error/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Verify output files for other construction quality check with no errors",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/10-cons/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/10-cons/Z-cons-01_surface-errors/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/10-cons/Z-cons-01_surface-errors/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Verify output files for other construction quality check with surface errors",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/10-cons/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/10-cons/Z-cons-02_surface-orientation/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/10-cons/Z-cons-02_surface-orientation/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Verify output files for other construction quality check with surface orientation error",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/10-cons/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/10-cons/Z-cons-03_surface-not-closed/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/10-cons/Z-cons-03_surface-not-closed/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Verify output files for other construction quality check with surface-not-closed",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/10-cons/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/10-cons/Z-cons-04_solid-issues/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/10-cons/Z-cons-04_solid-issues/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Verify output files for other construction quality check with solid errors",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/10-cons/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/11-wtr/Z-wtr-00_no-error/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/11-wtr/Z-wtr-00_no-error/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Verify output files for water body quality check with no errors",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/11-wtr/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/11-wtr/Z-wtr-01_invalid-geometry-type/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/11-wtr/Z-wtr-01_invalid-geometry-type/workflow_test.json
@@ -1,6 +1,7 @@
 {
   "description": "Test quality check for invalid geometry type errors",
   "skipReason": "Requires nusamai bug fix. On hold for higher priority tasks.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/11-wtr/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/11-wtr/Z-wtr-02_surface-not-closed/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/11-wtr/Z-wtr-02_surface-not-closed/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for surface-not-closed errors",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/11-wtr/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/11-wtr/Z-wtr-03_solid-other-issues/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/11-wtr/Z-wtr-03_solid-other-issues/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for solid-other-issues errors",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/11-wtr/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/11-wtr/Z-wtr-04_solid-boundary-surface-errors/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/11-wtr/Z-wtr-04_solid-boundary-surface-errors/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for solid boundary surface errors",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/11-wtr/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/11-wtr/Z-wtr-05_surface-errors/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/11-wtr/Z-wtr-05_surface-errors/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for surface errors",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/11-wtr/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/12-unf/Z-unf-00_no-error/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/12-unf/Z-unf-00_no-error/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Verify output files for underground facility quality check with no errors",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/12-unf/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/12-unf/Z-unf-01_invalid-geometry-type/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/12-unf/Z-unf-01_invalid-geometry-type/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Verify output files for underground facility quality check with no errors",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/12-unf/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/12-unf/Z-unf-02_surface-not-closed/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/12-unf/Z-unf-02_surface-not-closed/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for surface-not-closed errors",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/12-unf/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/12-unf/Z-unf-03_solid-other-issues/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/12-unf/Z-unf-03_solid-other-issues/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for solid-other-issues errors",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/12-unf/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/12-unf/Z-unf-04_solid-boundary-surface-errors/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/12-unf/Z-unf-04_solid-boundary-surface-errors/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for solid boundary surface errors",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/12-unf/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/12-unf/Z-unf-05_surface-errors/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/12-unf/Z-unf-05_surface-errors/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for surface errors",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/12-unf/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/12-unf/Z-unf-06_discontinuous_comosite_surface/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/12-unf/Z-unf-06_discontinuous_comosite_surface/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for discontinuous composite surface",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/12-unf/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/12-unf/Z-unf-06_discontinuous_comosite_surface_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/12-unf/Z-unf-06_discontinuous_comosite_surface_02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Discontinuous MultiSurface should not be flagged as an error (CompositeSurface continuity is still checked)",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/12-unf/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/13-gen/Z-gen-00_no-error/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/13-gen/Z-gen-00_no-error/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Verify output files for generic city object quality check with no errors",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/13-gen/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/13-gen/Z-gen-01_surface-errors/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/13-gen/Z-gen-01_surface-errors/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for surface errors in generic city object",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/13-gen/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/13-gen/Z-gen-02_surface-orientation/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/13-gen/Z-gen-02_surface-orientation/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for surface orientation errors (clockwise instead of counter-clockwise) in generic city object",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/13-gen/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/13-gen/Z-gen-03_surface-not-closed/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/13-gen/Z-gen-03_surface-not-closed/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for ring not closed errors in generic city object",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/13-gen/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/13-gen/Z-gen-04_solid-issues/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/13-gen/Z-gen-04_solid-issues/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for solid issues (Face Wrong Orientation) in generic city object. A closed solid with one face having wrong normal direction causing solid error detection.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/13-gen/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/13-gen/Z-gen-05-gml-name-errors/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/13-gen/Z-gen-05-gml-name-errors/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check for uncoded gml:name errors in generic city object. The gml:name element is missing the codeSpace attribute, making it 'uncoded'.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/13-gen/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/01-01-common/L01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/01-01-common/L01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "quality-check L01 for plateau6 (CityGML 3.0). Input GML is intentionally malformed (bldg:usage start tag closed with </bldg:class>, a tag mismatch) so the XML parser raises a SyntaxError. Verifies only the L01 error CSV.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/01-01-common/L02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/01-01-common/L02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test L02 for plateau6. A schema error on con:dateOfConstruction with an invalid xs:date value.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/01-01-common/L03/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/01-01-common/L03/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "L03 for plateau6 (CityGML 3.0): a veg:PlantCover placed under the bldg package (which accepts only Building / CityObjectGroup) yields one invalid feature type (L03エラー=1, 詳細={PlantCover:1}). PACKAGE_TO_VALID_FEATURE_TYPES is local-name based, so the 2.0 map applies unchanged.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/01-01-common/L04_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/01-01-common/L04_01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "L04 #1 for plateau6 (CityGML 3.0): bldg:class codeSpace resolves (absolute https URL via filename fallback) but value 100 is undefined in Building_class → L04エラー=1, 不正なcodeSpace数=0.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/01-01-common/L04_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/01-01-common/L04_02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "L04 #2 for plateau6 (CityGML 3.0): bldg:class codeSpace points at a nonexistent codelist (invalid_codespace.xml) that cannot be resolved → 不正なcodeSpace数=1, L04エラー=0 (value 3003 itself is valid).",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/01-01-common/Z-common-00_no-error/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/01-01-common/Z-common-00_no-error/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "No-error reference for plateau6 (CityGML 3.0 + i-UR 4.0)",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/01-02-common/C05/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/01-02-common/C05/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "quality-check C05 (required attribute missing on a feature) for plateau6. The first bldg:Building omits the required core:creationDate, so one C05 error is detected.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/01-02-common/C06/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/01-02-common/C06/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "quality-check C06 (attribute missing across the whole dataset) for plateau6. core:creationDate is omitted from every building so it never appears. Uses a dedicated objectlist where creationDate is a C06 target instead of a C05 required attribute.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/01-02-common/C07/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/01-02-common/C07/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "quality-check C07 (quality attribute missing for an existing LOD) for plateau6. The first bldg:Building has LOD1 geometry but omits urc:geometrySrcDescLod1, so C07 is detected.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/01-02-common/C08/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/01-02-common/C08/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "quality-check C08 (public-survey quality attribute missing) for plateau6. The first bldg:Building has urc:geometrySrcDescLod0 = \"000\" but omits urc:srcScaleLod0, so C08 is detected.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/01-common/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/C-bldg-01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/C-bldg-01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test C-bldg-01 for plateau6",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L-bldg-01_LOD1/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L-bldg-01_LOD1/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test L-BLDG-01 for LOD1 on plateau6. Two buildings whose lod1Solid volumes overlap, reported as one Solid Intersection under 'LOD1 立体の交差'.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L-bldg-01_LOD2-3/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L-bldg-01_LOD2-3/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L-BLDG-01 (solid intersection) for LOD2/LOD3 on plateau6 (CityGML 3.0 + i-UR 4.0). One overlapping pair per LOD reported as a Solid Intersection (LOD2/LOD3 立体の交差).",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L-bldg-02_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L-bldg-02_01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test L-bldg-02 for plateau6: single isolated LOD2 BuildingPart (status='alone')",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L-bldg-02_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L-bldg-02_02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test L-bldg-02 for plateau6: three LOD2 BuildingParts, two connected (partial) and one isolated (alone)",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L-bldg-04-05_multi/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L-bldg-04-05_multi/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test L-bldg-04,05 multi-violation single building for plateau6",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L-bldg-04/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L-bldg-04/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test L-bldg-04 for plateau6",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L-bldg-05/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L-bldg-05/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test L-bldg-05 for plateau6",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L-bldg-06/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L-bldg-06/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test L-bldg-06 for plateau6",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L07_LOD0_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L07_LOD0_01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test L07 (base) for LOD0 on plateau6. A LOD0 ring with near-duplicate consecutive points, reported as DuplicateConsecutivePoints under 'LOD0 面のエラー'.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L07_LOD0_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L07_LOD0_02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test L07 extension for LOD0 on plateau6. A LOD0 ring with fewer than 4 points reported as TooFewPoints under 'LOD0 面のエラー'.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L07_LOD1/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L07_LOD1/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test L07 for LOD1 on plateau6. A lod1Solid face with near-duplicate consecutive points, reported as DuplicateConsecutivePoints under 'LOD1 境界面のエラー'.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L07_LOD2-3/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L07_LOD2-3/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L07 (boundary-surface errors) for LOD2/LOD3 on plateau6 (CityGML 3.0 + i-UR 4.0).",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L09_LOD0/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L09_LOD0/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test L09 for LOD0 on plateau6. A self-intersecting (bow-tie) LOD0 ring reported as SelfIntersection under 'LOD0 面のエラー'.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L09_LOD1_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L09_LOD1_01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test L09 for LOD1 on plateau6. Two lod1Solid faces with self-intersecting (bow-tie) exterior rings, reported as two SelfIntersection errors under 'LOD1 境界面のエラー'.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L09_LOD1_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L09_LOD1_02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L09_LOD1_02 for plateau6 (SelfIntersection@LOD1, another building variant).",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L09_LOD1_03/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L09_LOD1_03/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L09_LOD1_03 for plateau6 (DuplicateConsecutivePoints@LOD1).",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L11_LOD1/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L11_LOD1/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test L11 for LOD1 on plateau6. A non-planar lod1Solid face reported as NonPlanarSurface under 'LOD1 境界面のエラー'.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L13_LOD0_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L13_LOD0_01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L13 for LOD0 #1 on plateau6 (CityGML 3.0 + i-UR 4.0). #01: square exterior, interior ring extends outside it. Reported as InteriorRingNotContainedInExteriorRing under 'LOD0 面のエラー'.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L13_LOD0_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L13_LOD0_02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L13 for LOD0 #2 on plateau6 (CityGML 3.0 + i-UR 4.0). #02: triangle exterior, interior ring touches its boundary. Reported as InteriorRingNotContainedInExteriorRing under 'LOD0 面のエラー'.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L13_LOD0_03/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L13_LOD0_03/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L13 for LOD0 #3 on plateau6 (CityGML 3.0 + i-UR 4.0). #03: square exterior, two interior rings that overlap each other. Reported as IntersectionBetweenInteriorAndInterior under 'LOD0 面のエラー'.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L13_LOD1_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L13_LOD1_01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test L13 (#1) for LOD1 on plateau6. A lod1Solid interior ring crossing the exterior ring, reported as InteriorRingNotContainedInExteriorRing under 'LOD1 境界面のエラー'.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L13_LOD1_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L13_LOD1_02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test L13 (#2) for LOD1 on plateau6. A lod1Solid interior ring touching the exterior ring, reported as InteriorRingNotContainedInExteriorRing under 'LOD1 境界面のエラー'.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L13_LOD1_03/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L13_LOD1_03/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test L13 (#3) for LOD1 on plateau6. Two overlapping lod1Solid interior rings, reported as IntersectionBetweenInteriorAndInterior under 'LOD1 境界面のエラー'.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L14_LOD1/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L14_LOD1/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test L14 for LOD1 on plateau6. Four lod1Solid buildings: two with InvalidSolidBoundaries under 'LOD1 立体のエラー' and one non-watertight reported as 'Surface Not Closed' under 'LOD1 非水密立体'.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L14_LOD2-3/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L14_LOD2-3/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test quality check L14 (solid errors) for LOD2/LOD3 on plateau6 (CityGML 3.0 + i-UR 4.0). Covers 立体のエラー (InvalidSolidBoundaries) and 非水密立体 (Surface Not Closed) on both lod2Solid and lod3Solid.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-00_no-error/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-00_no-error/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "No-error reference for plateau6 02-bldg (CityGML 3.0 + i-UR 4.0). A single valid bldg:Building is expected to produce zero building/common errors.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-01_URO/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-01_URO/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test Z-bldg-01_URO for plateau6",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-02_surface-intersection-LOD0/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-02_surface-intersection-LOD0/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test Z-bldg-02 LOD0 surface intersection for plateau6. Two buildings whose LOD0 footprints overlap, reported under 'LOD0 面の交差'.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-03_meshcode-extractor_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-03_meshcode-extractor_01/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test Z-bldg-03 (図郭不正 / meshcode) for plateau6",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-03_meshcode-extractor_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-03_meshcode-extractor_02/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test Z-bldg-03 (図郭不正 / meshcode) for plateau6 (crosses mesh boundary)",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-03_meshcode-extractor_03/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-03_meshcode-extractor_03/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test Z-bldg-03 (図郭不正 / meshcode) for plateau6 (equal-area cross-mesh tie-break)",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-04_lod0or1-buildingpart/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-04_lod0or1-buildingpart/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test Z-bldg-04 for plateau6: a BuildingPart carrying LOD0/LOD1 geometry (LOD0-1 BuildingPart error)",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-05_surface-orientation/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-05_surface-orientation/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test LOD0 surface orientation error for plateau6 (CityGML 3.0 + i-UR 4.0). Two buildings: one whose lod0MultiSurface exterior ring is clockwise (reported as 'IncorrectOrientation' under 'LOD0 面の向きエラー') and one counter-clockwise control (no error).",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-06_nonplanar-wall-LOD2/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-06_nonplanar-wall-LOD2/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Demo: a LOD2 box building with six boundary surfaces where only the west wall is non-planar. Exactly that one con:WallSurface is reported under 'LOD2以上境界面のエラー', showing surface-level error identification.",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/city-code/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/city-code/workflow_test.json
@@ -1,5 +1,6 @@
 {
   "description": "Test CITY-CODE for plateau6",
+  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.103"
+version = "0.2.104"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -3,6 +3,18 @@ name = "workflow-tests"
 version = "0.1.293"
 edition = "2021"
 
+[features]
+default = []
+# Temporary migration flag for the new-geometry migration.
+# TODO: Remove after migration.
+new-geometry = [
+  "reearth-flow-action-plateau-processor/new-geometry",
+  "reearth-flow-action-processor/new-geometry",
+  "reearth-flow-action-sink/new-geometry",
+  "reearth-flow-action-source/new-geometry",
+  "reearth-flow-types/new-geometry",
+]
+
 [[bin]]
 name = "normalize-workflow-tests"
 path = "src/normalize.rs"

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.293"
+version = "0.1.294"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/README.md
+++ b/engine/testing/workflow-tests/README.md
@@ -30,6 +30,7 @@ Each testdata is a folder consisting of a test profile named `workflow_test.json
   - Set to `false`: Verify that the workflow does NOT generate a result OK marker file
   - Used primarily for testing no-error scenarios (`true`) or error detection scenarios (`false`)
 - **skip**: Skip this test (useful for debugging)
+- **skipNewGeometry**: Skip this test in the `new-geometry` build only. Every profile carries it today; drop it once the workflow has been migrated, and the test then runs in both `cargo make test-qc` and `cargo make test-qc-new-geometry`.
 
 ## JSON Filtering System
 

--- a/engine/testing/workflow-tests/README.md
+++ b/engine/testing/workflow-tests/README.md
@@ -30,7 +30,7 @@ Each testdata is a folder consisting of a test profile named `workflow_test.json
   - Set to `false`: Verify that the workflow does NOT generate a result OK marker file
   - Used primarily for testing no-error scenarios (`true`) or error detection scenarios (`false`)
 - **skip**: Skip this test (useful for debugging)
-- **skipNewGeometry**: Skip this test in the `new-geometry` build only. Every profile carries it today; drop it once the workflow has been migrated, and the test then runs in both `cargo make test-qc` and `cargo make test-qc-new-geometry`.
+- **skipNewGeometry**: Skip this test under `new-geometry`, which is how `cargo make test-qc` runs the suite. Every profile carries it today; drop it once the workflow has been migrated and the test starts running.
 
 ## JSON Filtering System
 

--- a/engine/testing/workflow-tests/build.rs
+++ b/engine/testing/workflow-tests/build.rs
@@ -100,6 +100,13 @@ fn generate_test_code(
                 .as_deref()
                 .unwrap_or("Skipped");
             quote! { #[ignore = #reason] }
+        } else if test_case.profile.skip_new_geometry {
+            quote! {
+                #[cfg_attr(
+                    feature = "new-geometry",
+                    ignore = "Workflow not yet migrated to new-geometry"
+                )]
+            }
         } else {
             quote! {}
         };

--- a/engine/testing/workflow-tests/shared_types.rs
+++ b/engine/testing/workflow-tests/shared_types.rs
@@ -56,6 +56,12 @@ pub struct WorkflowTestProfile {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub skip_reason: Option<String>,
 
+    /// Whether to skip this test in the `new-geometry` build. Drop it once the
+    /// workflow has been migrated.
+    /// TODO: Remove after the new-geometry migration.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub skip_new_geometry: bool,
+
     /// Path to the workflow file (relative to fixture/workflow/)
     pub workflow_path: String,
     

--- a/engine/testing/workflow-tests/src/main.rs
+++ b/engine/testing/workflow-tests/src/main.rs
@@ -1519,6 +1519,7 @@ mod tests {
             description: None,
             skip: false,
             skip_reason: None,
+            skip_new_geometry: false,
             workflow_path: "dummy".to_string(),
             workflow_variables: vec![],
             zip_before_test: vec![],


### PR DESCRIPTION
# What I have done
This PR make the workflow-tests run with `new-geometry` feature flag. Since the migration is in-progress, all tests fail, so each test is configured to skip the test. We will re-enable them gradually as the migration progresses.
This PR deliberately reconfigure each test profile to skip the test, instead of modifying only the test framework to skip them all. This is because we want to re-enable tests gradually later.
Note that the `skipNewGeometry` property will be removed after migration.

## Side fix
I noticed that the normalization test was no-op after the test relocation that happened before. This is fixed, and some tests are normalized accordingly.