### PR TITLE
feat(engine): port GeoJSON writers to new geometry

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.107"
+version = "0.2.108"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "Inflector",
  "approx",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4959,7 +4959,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5008,7 +5008,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5019,7 +5019,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "bytes",
  "clap",
@@ -5061,7 +5061,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5145,7 +5145,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "approx",
  "bvh",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5243,7 +5243,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5272,7 +5272,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5308,7 +5308,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "bytes",
  "futures",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "bytes",
  "futures",
@@ -5375,7 +5375,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "ahash",
  "bytes",
@@ -5459,7 +5459,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.480"
+version = "0.0.481"
 dependencies = [
  "async-trait",
  "axum",
@@ -8225,7 +8225,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.297"
+version = "0.1.298"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.480"
+version = "0.0.481"
 
 [profile.dev]
 opt-level = 0

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -3871,6 +3871,12 @@ Writes features to a GeoJSON file for each resolved output path.
           "type": "string"
         }
       }
+    },
+    "writeCrs": {
+      "title": "Write CRS",
+      "description": "Whether to declare the coordinate reference system of the written coordinates in a legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates are not WGS84 longitude / latitude and the consumer reads that member.",
+      "default": false,
+      "type": "boolean"
     }
   }
 }
@@ -4999,6 +5005,12 @@ Writes features to GeoJSON files, optionally grouping them into separate files.
       "items": {
         "$ref": "#/definitions/Attribute"
       }
+    },
+    "writeCrs": {
+      "title": "Write CRS",
+      "description": "Whether to declare the coordinate reference system of the written coordinates in a legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates are not WGS84 longitude / latitude and the consumer reads that member.",
+      "default": false,
+      "type": "boolean"
     }
   },
   "definitions": {

--- a/engine/runtime/action-processor/src/feature.rs
+++ b/engine/runtime/action-processor/src/feature.rs
@@ -3,7 +3,6 @@ pub(crate) mod duplicate_filter;
 pub(crate) mod errors;
 pub(crate) mod file_path_extractor;
 pub(crate) mod filter;
-pub(crate) mod geojson_writer;
 pub(crate) mod joiner;
 pub(crate) mod json_fragmenter;
 pub(crate) mod list_concatenator;

--- a/engine/runtime/action-processor/src/feature/mapping.rs
+++ b/engine/runtime/action-processor/src/feature/mapping.rs
@@ -8,7 +8,6 @@ use super::{
     duplicate_filter::FeatureDuplicateFilterFactory,
     file_path_extractor::FeatureFilePathExtractorFactory,
     filter::FeatureFilterFactory,
-    geojson_writer::FeatureGeoJsonWriterFactory,
     joiner::FeatureJoinerFactory,
     json_fragmenter::JSONFragmenterFactory,
     list_concatenator::ListConcatenatorFactory,
@@ -23,7 +22,7 @@ use super::{
     sorter::FeatureSorterFactory,
     transformer::FeatureTransformerFactory,
     type_filter::FeatureTypeFilterFactory,
-    writer::FeatureWriterFactory,
+    writer::{geojson::FeatureGeoJsonWriterFactory, FeatureWriterFactory},
 };
 
 pub(crate) static ACTION_FACTORY_MAPPINGS: Lazy<HashMap<String, NodeKind>> = Lazy::new(|| {

--- a/engine/runtime/action-processor/src/feature/writer.rs
+++ b/engine/runtime/action-processor/src/feature/writer.rs
@@ -1,5 +1,6 @@
 mod citygml;
 mod csv;
+pub(super) mod geojson;
 mod json;
 
 use std::collections::HashMap;

--- a/engine/runtime/action-processor/src/feature/writer/geojson.rs
+++ b/engine/runtime/action-processor/src/feature/writer/geojson.rs
@@ -16,10 +16,10 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::errors::FeatureProcessorError;
+use crate::feature::errors::FeatureProcessorError;
 
 #[derive(Debug, Clone, Default)]
-pub(super) struct FeatureGeoJsonWriterFactory;
+pub(crate) struct FeatureGeoJsonWriterFactory;
 
 impl ProcessorFactory for FeatureGeoJsonWriterFactory {
     fn name(&self) -> &str {

--- a/engine/runtime/action-processor/src/feature/writer/geojson.rs
+++ b/engine/runtime/action-processor/src/feature/writer/geojson.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use indexmap::IndexMap;
-#[cfg(not(feature = "new-geometry"))]
 use reearth_flow_action_sink::file::geojson::write_geojson_to_storage;
 use reearth_flow_runtime::{
     errors::BoxedError,
@@ -81,6 +80,7 @@ impl ProcessorFactory for FeatureGeoJsonWriterFactory {
             .map_err(|e| FeatureProcessorError::FeatureGeoJsonWriterFactory(format!("{e:?}")))?;
         Ok(Box::new(FeatureGeoJsonWriter {
             output,
+            write_crs: params.write_crs,
             buffer: HashMap::new(),
         }))
     }
@@ -103,11 +103,23 @@ struct FeatureGeoJsonWriterParam {
         description = "Path (or expression evaluated per feature) of the GeoJSON file to write. Features sharing a resolved path are written to the same file, so the expression can split features across files by attribute value."
     )]
     output: Code,
+    /// # Write CRS
+    ///
+    /// Whether to declare the coordinate reference system of the written coordinates in a
+    /// legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates
+    /// are not WGS84 longitude / latitude and the consumer reads that member.
+    #[schemars(
+        title = "Write CRS",
+        description = "Whether to declare the coordinate reference system of the written coordinates in a legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates are not WGS84 longitude / latitude and the consumer reads that member."
+    )]
+    #[serde(default)]
+    write_crs: bool,
 }
 
 #[derive(Debug, Clone)]
 struct FeatureGeoJsonWriter {
     output: CompiledCode,
+    write_crs: bool,
     buffer: HashMap<String, Vec<Feature>>,
 }
 
@@ -128,10 +140,6 @@ impl Processor for FeatureGeoJsonWriter {
         Ok(())
     }
 
-    // Gated on `not(new-geometry)`, like `FeatureWriter::finish`: the GeoJSON
-    // write path depends on `TryFrom<Feature> for Vec<geojson::Feature>`, which
-    // is only available in the current geometry world.
-    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,
@@ -150,7 +158,7 @@ impl Processor for FeatureGeoJsonWriter {
                     "sink output {rel_path:?} rejected by sandbox: {e}"
                 ))
             })?;
-            write_geojson_to_storage(&sink_output, features)
+            write_geojson_to_storage(&sink_output, features, self.write_crs)
                 .map_err(|e| FeatureProcessorError::FeatureGeoJsonWriter(format!("{e:?}")))?;
 
             let feature: Feature = IndexMap::<Attribute, AttributeValue>::from([(

--- a/engine/runtime/action-sink/src/file/geojson.rs
+++ b/engine/runtime/action-sink/src/file/geojson.rs
@@ -182,15 +182,12 @@ pub fn write_geojson_to_storage(
     write_crs: bool,
 ) -> Result<(), SinkError> {
     let mut geojson_features: Vec<geojson::Feature> = Vec::with_capacity(features.len());
-    let mut emitted: Vec<Feature> = Vec::with_capacity(features.len());
+    let mut emitted = EmittedCrs::default();
     let mut failed = 0usize;
 
     for feature in features {
-        match TryInto::<Vec<geojson::Feature>>::try_into(feature.clone()) {
-            Ok(mut converted) => {
-                geojson_features.append(&mut converted);
-                emitted.push(feature.clone());
-            }
+        match convert_feature(feature, &mut emitted) {
+            Ok(mut converted) => geojson_features.append(&mut converted),
             Err(e) => {
                 failed += 1;
                 tracing::warn!(feature_id = %feature.id, error = %e, "failed to convert feature to GeoJSON; omitting it");
@@ -201,7 +198,7 @@ pub fn write_geojson_to_storage(
     let feature_collection = geojson::FeatureCollection {
         bbox: None,
         features: geojson_features,
-        foreign_members: crs_foreign_members(write_crs, &emitted, output.uri()),
+        foreign_members: write_crs.then(|| crs_foreign_members(&emitted, output.uri())),
     };
     let buffer = serde_json::to_vec(&feature_collection)
         .map_err(|e| SinkError::GeoJsonWriter(format!("{e}")))?;
@@ -219,31 +216,72 @@ pub fn write_geojson_to_storage(
     Ok(())
 }
 
-/// Build the `crs` foreign member for a `FeatureCollection` from the EPSG codes
-/// of the coordinates actually emitted to the output, or nothing when
-/// `write_crs` is false.
-///
-/// Used by quality-check error detail files. Quality checks run on a non-WGS84
-/// CRS and output the source coordinates as-is, so the CRS must be recorded via
-/// this legacy GeoJSON 2008 `crs` member (non-standard under RFC 7946, which
-/// fixes coordinates to WGS84). It is opt-in for that reason: a reader that
-/// follows RFC 7946 has no use for it.
-///
-/// When asked for, it is a named CRS when one EPSG code covers every emitted
-/// coordinate, and an explicit `null` otherwise. `null` rather than an absent
-/// member because under GeoJSON 2008 an absent `crs` means WGS84 longitude /
-/// latitude, which coordinates in an unknown or mixed reference system are not;
-/// `null` says the CRS is unknown. Emitted once per output file, so the warning
-/// is too.
-fn crs_foreign_members(
-    write_crs: bool,
-    features: &[Feature],
-    output: &Uri,
-) -> Option<geojson::JsonObject> {
-    if !write_crs {
-        return None;
+/// What the coordinates emitted so far are expressed in: the first EPSG code seen,
+/// and the first one after it that differs.
+#[cfg(not(feature = "new-geometry"))]
+#[derive(Default)]
+struct EmittedCrs {
+    first: Option<u16>,
+    differing: Option<u16>,
+}
+
+#[cfg(not(feature = "new-geometry"))]
+impl EmittedCrs {
+    /// Record what one emitted feature's coordinates are expressed in. A feature
+    /// carrying no EPSG code says nothing about them rather than placing them
+    /// outside the code its neighbours name.
+    fn observe(&mut self, epsg: Option<u16>) {
+        let Some(code) = epsg else {
+            return;
+        };
+        match self.first {
+            None => self.first = Some(code),
+            Some(first) if first != code => self.differing = self.differing.or(Some(code)),
+            Some(_) => {}
+        }
     }
-    let crs = match emitted_epsg(features) {
+}
+
+/// As above, as the coordinate frames of the leaves that reached the output: in
+/// the new geometry a feature has no single EPSG code.
+#[cfg(feature = "new-geometry")]
+type EmittedCrs = reearth_flow_types::conversion::geojson::WrittenFrames;
+
+/// Convert one feature, recording in `emitted` what the coordinates it writes are
+/// expressed in. Only a feature that converts is recorded, so what is dropped
+/// names no CRS for coordinates the file does not carry.
+#[cfg(not(feature = "new-geometry"))]
+fn convert_feature(
+    feature: &Feature,
+    emitted: &mut EmittedCrs,
+) -> Result<Vec<geojson::Feature>, reearth_flow_types::error::Error> {
+    let converted: Vec<geojson::Feature> = feature.clone().try_into()?;
+    emitted.observe(feature.geometry.epsg);
+    Ok(converted)
+}
+
+/// As above, taking the frames the conversion hands back rather than asking the
+/// feature: the write is what establishes which coordinates reach the file, so
+/// nothing has to walk the geometry a second time to recover their frames.
+#[cfg(feature = "new-geometry")]
+fn convert_feature(
+    feature: &Feature,
+    emitted: &mut EmittedCrs,
+) -> Result<Vec<geojson::Feature>, reearth_flow_types::error::Error> {
+    let written = reearth_flow_types::conversion::geojson::write_feature(feature)?;
+    *emitted = std::mem::take(emitted).and(written.frames);
+    Ok(written.features)
+}
+
+/// Build the legacy GeoJSON 2008 `crs` member, for outputs whose coordinates are
+/// not in WGS84 longitude / latitude. RFC 7946 has no such member, so callers
+/// write it only when a consumer needs it.
+///
+/// A named CRS when one EPSG code covers every emitted coordinate, `null`
+/// otherwise — an absent member would instead claim the GeoJSON 2008 default,
+/// WGS84 longitude / latitude.
+fn crs_foreign_members(emitted: &EmittedCrs, output: &Uri) -> geojson::JsonObject {
+    let crs = match emitted_epsg(emitted) {
         Ok(epsg) => {
             let mut properties = geojson::JsonObject::new();
             properties.insert(
@@ -268,39 +306,29 @@ fn crs_foreign_members(
 
     let mut foreign_members = geojson::JsonObject::new();
     foreign_members.insert("crs".to_string(), crs);
-    Some(foreign_members)
+    foreign_members
 }
 
 /// The one EPSG code every emitted coordinate is expressed in, or the reason
 /// there is no such code.
 #[cfg(not(feature = "new-geometry"))]
-fn emitted_epsg(features: &[Feature]) -> Result<u16, String> {
-    let mut epsg: Option<u16> = None;
-    for feature in features {
-        let Some(code) = feature.geometry.epsg else {
-            continue;
-        };
-        match epsg {
-            None => epsg = Some(code),
-            Some(existing) if existing != code => {
-                return Err(format!(
-                    "features carry both EPSG:{existing} and EPSG:{code}"
-                ))
-            }
-            Some(_) => {}
+fn emitted_epsg(emitted: &EmittedCrs) -> Result<u16, String> {
+    match (emitted.first, emitted.differing) {
+        (Some(first), Some(other)) => {
+            Err(format!("features carry both EPSG:{first} and EPSG:{other}"))
         }
+        (Some(first), None) => Ok(first),
+        _ => Err("no feature carries an EPSG code".to_string()),
     }
-    epsg.ok_or_else(|| "no feature carries an EPSG code".to_string())
 }
 
-/// As above, reading the frame of every leaf that reaches the output: in the new
-/// geometry a feature has no single EPSG code, and a `Euclidean` or `Tangent`
-/// frame names no CRS at all.
+/// As above, from the frames of the leaves that reached the output: a `Euclidean`
+/// or `Tangent` frame names no CRS at all.
 #[cfg(feature = "new-geometry")]
-fn emitted_epsg(features: &[Feature]) -> Result<u16, String> {
-    use reearth_flow_types::conversion::geojson::{written_crs, WrittenCrs};
+fn emitted_epsg(emitted: &EmittedCrs) -> Result<u16, String> {
+    use reearth_flow_types::conversion::geojson::WrittenCrs;
 
-    match written_crs(features) {
+    match emitted.crs() {
         WrittenCrs::Single(code) => Ok(code.get()),
         WrittenCrs::Mixed { first, other } => {
             Err(format!("features carry both EPSG:{first} and EPSG:{other}"))
@@ -319,24 +347,29 @@ mod tests {
     /// same `crs` assertions read the same in both geometry worlds.
     #[cfg(not(feature = "new-geometry"))]
     mod fixture {
+        use reearth_flow_geometry::types::{
+            geometry::Geometry2D, no_value::NoValue, point::Point2D,
+        };
         use reearth_flow_types::{Feature, Geometry, GeometryValue};
 
-        fn feature(epsg: Option<u16>) -> Feature {
+        fn point_in(epsg: Option<u16>) -> Feature {
             Feature::new_with_attributes_and_geometry(
                 indexmap::IndexMap::new(),
                 Geometry {
                     epsg,
-                    value: GeometryValue::None,
+                    value: GeometryValue::FlowGeometry2D(Geometry2D::Point(Point2D::new(
+                        0.0, 0.0, NoValue,
+                    ))),
                 },
             )
         }
 
         pub(super) fn in_epsg(code: u16) -> Feature {
-            feature(Some(code))
+            point_in(Some(code))
         }
 
         pub(super) fn without_crs() -> Feature {
-            feature(None)
+            point_in(None)
         }
     }
 
@@ -384,10 +417,19 @@ mod tests {
         Uri::from_str("file:///tmp/out.geojson").unwrap()
     }
 
+    /// What converting `features` for the output records about their CRS, as the
+    /// write itself accumulates it.
+    fn emitted(features: &[Feature]) -> EmittedCrs {
+        let mut emitted = EmittedCrs::default();
+        for feature in features {
+            convert_feature(feature, &mut emitted).expect("feature expected to convert");
+        }
+        emitted
+    }
+
     /// The `crs` member written for `features` when one is asked for.
     fn crs_of(features: &[Feature]) -> Value {
-        crs_foreign_members(true, features, &output()).expect("a crs member was asked for")["crs"]
-            .clone()
+        crs_foreign_members(&emitted(features), &output())["crs"].clone()
     }
 
     #[test]
@@ -421,10 +463,6 @@ mod tests {
     // asked for — not even as `null`, which would still be an extension member.
     #[test]
     fn no_crs_member_unless_it_is_asked_for() {
-        assert_eq!(
-            crs_foreign_members(false, &[fixture::in_epsg(6675)], &output()),
-            None
-        );
         let json = serialized(false, &[fixture::in_epsg(6675)]);
         assert!(!json.contains("crs"), "got: {json}");
     }
@@ -435,7 +473,7 @@ mod tests {
         let collection = geojson::FeatureCollection {
             bbox: None,
             features: Vec::new(),
-            foreign_members: crs_foreign_members(write_crs, features, &output()),
+            foreign_members: write_crs.then(|| crs_foreign_members(&emitted(features), &output())),
         };
         serde_json::to_string(&collection).unwrap()
     }
@@ -459,5 +497,24 @@ mod tests {
     fn null_crs_when_only_some_coordinates_carry_one() {
         let crs = crs_of(&[fixture::in_epsg(6675), fixture::without_crs()]);
         assert_eq!(crs, Value::Null);
+    }
+
+    // What leaves the CRS unstated differs by geometry. Here a feature can carry
+    // coordinates without an EPSG code, which says nothing about them rather than
+    // placing them outside the code its neighbours name.
+    #[cfg(not(feature = "new-geometry"))]
+    #[test]
+    fn named_crs_survives_a_feature_without_an_epsg() {
+        let crs = crs_of(&[fixture::in_epsg(6675), fixture::without_crs()]);
+        assert_eq!(crs["properties"]["name"], "urn:ogc:def:crs:EPSG::6675");
+    }
+
+    // Here every leaf states its frame, so the only feature saying nothing about
+    // the CRS is one that writes no coordinates at all.
+    #[cfg(feature = "new-geometry")]
+    #[test]
+    fn named_crs_survives_a_feature_without_coordinates() {
+        let crs = crs_of(&[fixture::in_epsg(6675), fixture::without_geometry()]);
+        assert_eq!(crs["properties"]["name"], "urn:ogc:def:crs:EPSG::6675");
     }
 }

--- a/engine/runtime/action-sink/src/file/geojson.rs
+++ b/engine/runtime/action-sink/src/file/geojson.rs
@@ -8,6 +8,7 @@ use reearth_flow_runtime::errors::BoxedError;
 use reearth_flow_runtime::event::EventHub;
 use reearth_flow_runtime::executor_operation::{ExecutorContext, NodeContext};
 use reearth_flow_runtime::node::{Port, Sink, SinkFactory, FEATURES_PORT};
+use reearth_flow_types::conversion::geojson::{write_feature, CrsCoverage};
 use reearth_flow_types::{Attribute, AttributeValue, Code, Feature};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -182,12 +183,17 @@ pub fn write_geojson_to_storage(
     write_crs: bool,
 ) -> Result<(), SinkError> {
     let mut geojson_features: Vec<geojson::Feature> = Vec::with_capacity(features.len());
-    let mut emitted = EmittedCrs::default();
+    // Accumulated as the features are written, so it covers exactly what reaches
+    // the file: a feature the writer drops contributes no CRS.
+    let mut crs = CrsCoverage::default();
     let mut failed = 0usize;
 
     for feature in features {
-        match convert_feature(feature, &mut emitted) {
-            Ok(mut converted) => geojson_features.append(&mut converted),
+        match write_feature(feature) {
+            Ok(written) => {
+                crs = crs.and(written.crs);
+                geojson_features.extend(written.features);
+            }
             Err(e) => {
                 failed += 1;
                 tracing::warn!(feature_id = %feature.id, error = %e, "failed to convert feature to GeoJSON; omitting it");
@@ -198,7 +204,7 @@ pub fn write_geojson_to_storage(
     let feature_collection = geojson::FeatureCollection {
         bbox: None,
         features: geojson_features,
-        foreign_members: write_crs.then(|| crs_foreign_members(&emitted, output.uri())),
+        foreign_members: write_crs.then(|| crs_foreign_members(crs, output.uri())),
     };
     let buffer = serde_json::to_vec(&feature_collection)
         .map_err(|e| SinkError::GeoJsonWriter(format!("{e}")))?;
@@ -216,73 +222,16 @@ pub fn write_geojson_to_storage(
     Ok(())
 }
 
-/// What the coordinates emitted so far are expressed in: the first EPSG code seen,
-/// and the first one after it that differs.
-#[cfg(not(feature = "new-geometry"))]
-#[derive(Default)]
-struct EmittedCrs {
-    first: Option<u16>,
-    differing: Option<u16>,
-}
-
-#[cfg(not(feature = "new-geometry"))]
-impl EmittedCrs {
-    /// Record what one emitted feature's coordinates are expressed in. A feature
-    /// carrying no EPSG code says nothing about them rather than placing them
-    /// outside the code its neighbours name.
-    fn observe(&mut self, epsg: Option<u16>) {
-        let Some(code) = epsg else {
-            return;
-        };
-        match self.first {
-            None => self.first = Some(code),
-            Some(first) if first != code => self.differing = self.differing.or(Some(code)),
-            Some(_) => {}
-        }
-    }
-}
-
-/// As above, as the coordinate frames of the leaves that reached the output: in
-/// the new geometry a feature has no single EPSG code.
-#[cfg(feature = "new-geometry")]
-type EmittedCrs = reearth_flow_types::conversion::geojson::WrittenFrames;
-
-/// Convert one feature, recording in `emitted` what the coordinates it writes are
-/// expressed in. Only a feature that converts is recorded, so what is dropped
-/// names no CRS for coordinates the file does not carry.
-#[cfg(not(feature = "new-geometry"))]
-fn convert_feature(
-    feature: &Feature,
-    emitted: &mut EmittedCrs,
-) -> Result<Vec<geojson::Feature>, reearth_flow_types::error::Error> {
-    let converted: Vec<geojson::Feature> = feature.clone().try_into()?;
-    emitted.observe(feature.geometry.epsg);
-    Ok(converted)
-}
-
-/// As above, taking the frames the conversion hands back rather than asking the
-/// feature: the write is what establishes which coordinates reach the file, so
-/// nothing has to walk the geometry a second time to recover their frames.
-#[cfg(feature = "new-geometry")]
-fn convert_feature(
-    feature: &Feature,
-    emitted: &mut EmittedCrs,
-) -> Result<Vec<geojson::Feature>, reearth_flow_types::error::Error> {
-    let written = reearth_flow_types::conversion::geojson::write_feature(feature)?;
-    *emitted = std::mem::take(emitted).and(written.frames);
-    Ok(written.features)
-}
-
 /// Build the legacy GeoJSON 2008 `crs` member, for outputs whose coordinates are
 /// not in WGS84 longitude / latitude. RFC 7946 has no such member, so callers
 /// write it only when a consumer needs it.
 ///
-/// A named CRS when one EPSG code covers every emitted coordinate, `null`
+/// A named CRS when one EPSG code covers every written coordinate, `null`
 /// otherwise — an absent member would instead claim the GeoJSON 2008 default,
 /// WGS84 longitude / latitude.
-fn crs_foreign_members(emitted: &EmittedCrs, output: &Uri) -> geojson::JsonObject {
-    let crs = match emitted_epsg(emitted) {
-        Ok(epsg) => {
+fn crs_foreign_members(coverage: CrsCoverage, output: &Uri) -> geojson::JsonObject {
+    let crs = match coverage {
+        CrsCoverage::Single(epsg) => {
             let mut properties = geojson::JsonObject::new();
             properties.insert(
                 "name".to_string(),
@@ -293,9 +242,9 @@ fn crs_foreign_members(emitted: &EmittedCrs, output: &Uri) -> geojson::JsonObjec
             crs.insert("properties".to_string(), Value::Object(properties));
             Value::Object(crs)
         }
-        Err(reason) => {
+        reason => {
             tracing::warn!(
-                reason,
+                %reason,
                 "no single CRS covers the coordinates written to {output}; \
                  writing `\"crs\": null` so they are not read as the GeoJSON \
                  default CRS (WGS84 longitude / latitude)"
@@ -307,34 +256,6 @@ fn crs_foreign_members(emitted: &EmittedCrs, output: &Uri) -> geojson::JsonObjec
     let mut foreign_members = geojson::JsonObject::new();
     foreign_members.insert("crs".to_string(), crs);
     foreign_members
-}
-
-/// The one EPSG code every emitted coordinate is expressed in, or the reason
-/// there is no such code.
-#[cfg(not(feature = "new-geometry"))]
-fn emitted_epsg(emitted: &EmittedCrs) -> Result<u16, String> {
-    match (emitted.first, emitted.differing) {
-        (Some(first), Some(other)) => {
-            Err(format!("features carry both EPSG:{first} and EPSG:{other}"))
-        }
-        (Some(first), None) => Ok(first),
-        _ => Err("no feature carries an EPSG code".to_string()),
-    }
-}
-
-/// As above, from the frames of the leaves that reached the output: a `Euclidean`
-/// or `Tangent` frame names no CRS at all.
-#[cfg(feature = "new-geometry")]
-fn emitted_epsg(emitted: &EmittedCrs) -> Result<u16, String> {
-    use reearth_flow_types::conversion::geojson::WrittenCrs;
-
-    match emitted.crs() {
-        WrittenCrs::Single(code) => Ok(code.get()),
-        WrittenCrs::Mixed { first, other } => {
-            Err(format!("features carry both EPSG:{first} and EPSG:{other}"))
-        }
-        WrittenCrs::Unknown => Err("no emitted coordinate carries an EPSG code".to_string()),
-    }
 }
 
 #[cfg(test)]
@@ -417,19 +338,33 @@ mod tests {
         Uri::from_str("file:///tmp/out.geojson").unwrap()
     }
 
-    /// What converting `features` for the output records about their CRS, as the
+    /// How far one CRS covers what writing `features` puts in the output, as the
     /// write itself accumulates it.
-    fn emitted(features: &[Feature]) -> EmittedCrs {
-        let mut emitted = EmittedCrs::default();
-        for feature in features {
-            convert_feature(feature, &mut emitted).expect("feature expected to convert");
-        }
-        emitted
+    fn coverage_of(features: &[Feature]) -> CrsCoverage {
+        features
+            .iter()
+            .map(|feature| {
+                write_feature(feature)
+                    .expect("feature expected to convert")
+                    .crs
+            })
+            .fold(CrsCoverage::default(), CrsCoverage::and)
     }
 
     /// The `crs` member written for `features` when one is asked for.
     fn crs_of(features: &[Feature]) -> Value {
-        crs_foreign_members(&emitted(features), &output())["crs"].clone()
+        crs_foreign_members(coverage_of(features), &output())["crs"].clone()
+    }
+
+    /// An empty `FeatureCollection` serialized as it would be written, so the
+    /// assertions on it are about the `crs` member alone.
+    fn serialized_crs_member(write_crs: bool, coverage: CrsCoverage) -> String {
+        let collection = geojson::FeatureCollection {
+            bbox: None,
+            features: Vec::new(),
+            foreign_members: write_crs.then(|| crs_foreign_members(coverage, &output())),
+        };
+        serde_json::to_string(&collection).unwrap()
     }
 
     #[test]
@@ -455,7 +390,7 @@ mod tests {
     // default CRS (WGS84 longitude / latitude) for coordinates that are not in it.
     #[test]
     fn null_crs_is_serialized_rather_than_omitted() {
-        let json = serialized(true, &[fixture::without_crs()]);
+        let json = serialized_crs_member(true, coverage_of(&[fixture::without_crs()]));
         assert!(json.contains("\"crs\":null"), "got: {json}");
     }
 
@@ -463,19 +398,8 @@ mod tests {
     // asked for — not even as `null`, which would still be an extension member.
     #[test]
     fn no_crs_member_unless_it_is_asked_for() {
-        let json = serialized(false, &[fixture::in_epsg(6675)]);
+        let json = serialized_crs_member(false, coverage_of(&[fixture::in_epsg(6675)]));
         assert!(!json.contains("crs"), "got: {json}");
-    }
-
-    /// A `FeatureCollection` carrying only what `features` say about the CRS,
-    /// serialized as it would be written.
-    fn serialized(write_crs: bool, features: &[Feature]) -> String {
-        let collection = geojson::FeatureCollection {
-            bbox: None,
-            features: Vec::new(),
-            foreign_members: write_crs.then(|| crs_foreign_members(&emitted(features), &output())),
-        };
-        serde_json::to_string(&collection).unwrap()
     }
 
     #[cfg(feature = "new-geometry")]

--- a/engine/runtime/action-sink/src/file/geojson.rs
+++ b/engine/runtime/action-sink/src/file/geojson.rs
@@ -3,6 +3,7 @@ use std::vec;
 
 use bytes::Bytes;
 use reearth_flow_common::str::to_hash;
+use reearth_flow_common::uri::Uri;
 use reearth_flow_runtime::errors::BoxedError;
 use reearth_flow_runtime::event::EventHub;
 use reearth_flow_runtime::executor_operation::{ExecutorContext, NodeContext};
@@ -84,6 +85,7 @@ impl SinkFactory for GeoJsonWriterFactory {
         let sink = GeoJsonWriter {
             output,
             group_by: params.group_by,
+            write_crs: params.write_crs,
             buffer: Default::default(),
         };
         Ok(Box::new(sink))
@@ -94,6 +96,7 @@ impl SinkFactory for GeoJsonWriterFactory {
 pub(super) struct GeoJsonWriter {
     output: String,
     group_by: Option<Vec<Attribute>>,
+    write_crs: bool,
     pub(super) buffer: HashMap<AttributeValue, Vec<Feature>>,
 }
 
@@ -109,6 +112,12 @@ pub(super) struct GeoJsonWriterParam {
     /// # Group By
     /// Attributes to group features by, writing a separate file for each distinct group.
     pub(super) group_by: Option<Vec<Attribute>>,
+    /// # Write CRS
+    /// Whether to declare the coordinate reference system of the written coordinates in a
+    /// legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates
+    /// are not WGS84 longitude / latitude and the consumer reads that member.
+    #[serde(default)]
+    pub(super) write_crs: bool,
 }
 
 impl Sink for GeoJsonWriter {
@@ -116,7 +125,6 @@ impl Sink for GeoJsonWriter {
         "GeoJSON Writer"
     }
 
-    #[cfg(not(feature = "new-geometry"))]
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
         let feature = &ctx.feature;
 
@@ -137,7 +145,6 @@ impl Sink for GeoJsonWriter {
         Ok(())
     }
 
-    #[cfg(not(feature = "new-geometry"))]
     fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
         let path = self.output.as_str();
         for (key, features) in self.buffer.iter() {
@@ -151,7 +158,7 @@ impl Sink for GeoJsonWriter {
             // the actual serialization/write to the shared helper.
             let out = crate::SinkOutput::new(&ctx.sandbox_root, &out_path, &ctx.storage_resolver)
                 .map_err(crate::errors::SinkError::geojson_writer)?;
-            write_geojson_to_storage(&out, features)?;
+            write_geojson_to_storage(&out, features, self.write_crs)?;
         }
         Ok(())
     }
@@ -160,18 +167,19 @@ impl Sink for GeoJsonWriter {
 /// Serialize `features` as a GeoJSON `FeatureCollection` and write it to `output`.
 ///
 /// This is the single canonical implementation shared by both the `GeoJsonWriter`
-/// sink and the `FeatureGeoJsonWriter` processor. It is gated on
-/// `not(new-geometry)` because it relies on `TryFrom<Feature> for
-/// Vec<geojson::Feature>`, which is only provided in the current geometry world.
+/// sink and the `FeatureGeoJsonWriter` processor.
 ///
 /// It takes a [`SinkOutput`](crate::SinkOutput) rather than a bare `Uri` so the
 /// sandbox gate stays coupled to the write: callers must go through
 /// `SinkOutput::new` (which validates the path against the sandbox root and
 /// acquires the storage backend) before they can reach this helper.
-#[cfg(not(feature = "new-geometry"))]
+///
+/// `write_crs` requests the legacy `crs` member described on
+/// [`crs_foreign_members`].
 pub fn write_geojson_to_storage(
     output: &crate::SinkOutput,
     features: &[Feature],
+    write_crs: bool,
 ) -> Result<(), SinkError> {
     let mut geojson_features: Vec<geojson::Feature> = Vec::with_capacity(features.len());
     let mut emitted: Vec<Feature> = Vec::with_capacity(features.len());
@@ -193,7 +201,7 @@ pub fn write_geojson_to_storage(
     let feature_collection = geojson::FeatureCollection {
         bbox: None,
         features: geojson_features,
-        foreign_members: crs_foreign_members(&emitted),
+        foreign_members: crs_foreign_members(write_crs, &emitted, output.uri()),
     };
     let buffer = serde_json::to_vec(&feature_collection)
         .map_err(|e| SinkError::GeoJsonWriter(format!("{e}")))?;
@@ -211,18 +219,62 @@ pub fn write_geojson_to_storage(
     Ok(())
 }
 
-/// Build the `crs` foreign member for a `FeatureCollection` from the geometry
-/// EPSG codes of the features actually emitted to the output.
+/// Build the `crs` foreign member for a `FeatureCollection` from the EPSG codes
+/// of the coordinates actually emitted to the output, or nothing when
+/// `write_crs` is false.
 ///
 /// Used by quality-check error detail files. Quality checks run on a non-WGS84
 /// CRS and output the source coordinates as-is, so the CRS must be recorded via
 /// this legacy GeoJSON 2008 `crs` member (non-standard under RFC 7946, which
-/// fixes coordinates to WGS84).
+/// fixes coordinates to WGS84). It is opt-in for that reason: a reader that
+/// follows RFC 7946 has no use for it.
 ///
-/// Returns `None` when no feature carries an EPSG code, or when features carry
-/// multiple distinct codes (no single correct CRS).
+/// When asked for, it is a named CRS when one EPSG code covers every emitted
+/// coordinate, and an explicit `null` otherwise. `null` rather than an absent
+/// member because under GeoJSON 2008 an absent `crs` means WGS84 longitude /
+/// latitude, which coordinates in an unknown or mixed reference system are not;
+/// `null` says the CRS is unknown. Emitted once per output file, so the warning
+/// is too.
+fn crs_foreign_members(
+    write_crs: bool,
+    features: &[Feature],
+    output: &Uri,
+) -> Option<geojson::JsonObject> {
+    if !write_crs {
+        return None;
+    }
+    let crs = match emitted_epsg(features) {
+        Ok(epsg) => {
+            let mut properties = geojson::JsonObject::new();
+            properties.insert(
+                "name".to_string(),
+                Value::String(format!("urn:ogc:def:crs:EPSG::{epsg}")),
+            );
+            let mut crs = geojson::JsonObject::new();
+            crs.insert("type".to_string(), Value::String("name".to_string()));
+            crs.insert("properties".to_string(), Value::Object(properties));
+            Value::Object(crs)
+        }
+        Err(reason) => {
+            tracing::warn!(
+                reason,
+                "no single CRS covers the coordinates written to {output}; \
+                 writing `\"crs\": null` so they are not read as the GeoJSON \
+                 default CRS (WGS84 longitude / latitude)"
+            );
+            Value::Null
+        }
+    };
+
+    let mut foreign_members = geojson::JsonObject::new();
+    foreign_members.insert("crs".to_string(), crs);
+    Some(foreign_members)
+}
+
+/// The one EPSG code every emitted coordinate is expressed in, or the reason
+/// there is no such code.
 #[cfg(not(feature = "new-geometry"))]
-fn crs_foreign_members(features: &[Feature]) -> Option<geojson::JsonObject> {
+fn emitted_epsg(features: &[Feature]) -> Result<u16, String> {
     let mut epsg: Option<u16> = None;
     for feature in features {
         let Some(code) = feature.geometry.epsg else {
@@ -231,72 +283,181 @@ fn crs_foreign_members(features: &[Feature]) -> Option<geojson::JsonObject> {
         match epsg {
             None => epsg = Some(code),
             Some(existing) if existing != code => {
-                tracing::warn!(
-                    first = existing,
-                    other = code,
-                    "GeoJSON features have mixed EPSG codes; omitting the `crs` member"
-                );
-                return None;
+                return Err(format!(
+                    "features carry both EPSG:{existing} and EPSG:{code}"
+                ))
             }
             Some(_) => {}
         }
     }
-
-    let epsg = epsg?;
-    let mut properties = geojson::JsonObject::new();
-    properties.insert(
-        "name".to_string(),
-        Value::String(format!("urn:ogc:def:crs:EPSG::{epsg}")),
-    );
-    let mut crs = geojson::JsonObject::new();
-    crs.insert("type".to_string(), Value::String("name".to_string()));
-    crs.insert("properties".to_string(), Value::Object(properties));
-
-    let mut foreign_members = geojson::JsonObject::new();
-    foreign_members.insert("crs".to_string(), Value::Object(crs));
-    Some(foreign_members)
+    epsg.ok_or_else(|| "no feature carries an EPSG code".to_string())
 }
 
-#[cfg(all(test, not(feature = "new-geometry")))]
+/// As above, reading the frame of every leaf that reaches the output: in the new
+/// geometry a feature has no single EPSG code, and a `Euclidean` or `Tangent`
+/// frame names no CRS at all.
+#[cfg(feature = "new-geometry")]
+fn emitted_epsg(features: &[Feature]) -> Result<u16, String> {
+    use reearth_flow_types::conversion::geojson::{written_crs, WrittenCrs};
+
+    match written_crs(features) {
+        WrittenCrs::Single(code) => Ok(code.get()),
+        WrittenCrs::Mixed { first, other } => {
+            Err(format!("features carry both EPSG:{first} and EPSG:{other}"))
+        }
+        WrittenCrs::Unknown => Err("no emitted coordinate carries an EPSG code".to_string()),
+    }
+}
+
+#[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
-    use reearth_flow_types::{Geometry, GeometryValue};
 
-    fn feature_with_epsg(epsg: Option<u16>) -> Feature {
-        Feature::new_with_attributes_and_geometry(
-            indexmap::IndexMap::new(),
-            Geometry {
-                epsg,
-                value: GeometryValue::None,
-            },
-        )
+    /// Fixtures naming what a feature's coordinates are expressed in, so the
+    /// same `crs` assertions read the same in both geometry worlds.
+    #[cfg(not(feature = "new-geometry"))]
+    mod fixture {
+        use reearth_flow_types::{Feature, Geometry, GeometryValue};
+
+        fn feature(epsg: Option<u16>) -> Feature {
+            Feature::new_with_attributes_and_geometry(
+                indexmap::IndexMap::new(),
+                Geometry {
+                    epsg,
+                    value: GeometryValue::None,
+                },
+            )
+        }
+
+        pub(super) fn in_epsg(code: u16) -> Feature {
+            feature(Some(code))
+        }
+
+        pub(super) fn without_crs() -> Feature {
+            feature(None)
+        }
     }
 
-    fn crs_name(members: &geojson::JsonObject) -> &str {
-        members["crs"]["properties"]["name"].as_str().unwrap()
+    #[cfg(feature = "new-geometry")]
+    mod fixture {
+        use reearth_flow_geometry::{
+            coordinate::{BaseFrame, CoordinateFrame, EpsgCode, TangentPlane},
+            point::Point2D,
+            Euclidean2DGeometry, Geometry,
+        };
+        use reearth_flow_types::Feature;
+
+        fn point_in(frame: CoordinateFrame) -> Feature {
+            Feature::new_with_attributes_and_geometry(
+                indexmap::IndexMap::new(),
+                Geometry::Euclidean2D(Euclidean2DGeometry::Point(Point2D::new(frame, [0.0, 0.0]))),
+            )
+        }
+
+        pub(super) fn in_epsg(code: u16) -> Feature {
+            point_in(CoordinateFrame::Crs(EpsgCode::new(code)))
+        }
+
+        pub(super) fn without_crs() -> Feature {
+            point_in(CoordinateFrame::Euclidean)
+        }
+
+        /// In-plane coordinates are metres, not the base CRS's, so the base EPSG
+        /// must not be claimed as the collection's CRS.
+        pub(super) fn in_tangent_plane() -> Feature {
+            point_in(CoordinateFrame::Tangent(Box::new(TangentPlane {
+                base: BaseFrame::Crs(EpsgCode::new(6675)),
+                origin: [0.0, 0.0, 0.0],
+                u: [1.0, 0.0, 0.0],
+                v: [0.0, 1.0, 0.0],
+            })))
+        }
+
+        pub(super) fn without_geometry() -> Feature {
+            Feature::new_with_attributes_and_geometry(indexmap::IndexMap::new(), Geometry::None)
+        }
+    }
+
+    fn output() -> Uri {
+        Uri::from_str("file:///tmp/out.geojson").unwrap()
+    }
+
+    /// The `crs` member written for `features` when one is asked for.
+    fn crs_of(features: &[Feature]) -> Value {
+        crs_foreign_members(true, features, &output()).expect("a crs member was asked for")["crs"]
+            .clone()
     }
 
     #[test]
-    fn crs_member_from_single_epsg() {
-        let features = vec![feature_with_epsg(Some(6675))];
-        let members = crs_foreign_members(&features).expect("crs member expected");
-        assert_eq!(members["crs"]["type"], "name");
-        assert_eq!(crs_name(&members), "urn:ogc:def:crs:EPSG::6675");
+    fn named_crs_from_a_single_epsg() {
+        let crs = crs_of(&[fixture::in_epsg(6675), fixture::in_epsg(6675)]);
+        assert_eq!(crs["type"], "name");
+        assert_eq!(crs["properties"]["name"], "urn:ogc:def:crs:EPSG::6675");
     }
 
     #[test]
-    fn no_crs_member_when_all_epsg_missing() {
-        let features = vec![feature_with_epsg(None), feature_with_epsg(None)];
-        assert!(crs_foreign_members(&features).is_none());
+    fn null_crs_when_epsg_codes_differ() {
+        let crs = crs_of(&[fixture::in_epsg(6675), fixture::in_epsg(6669)]);
+        assert_eq!(crs, Value::Null);
     }
 
     #[test]
-    fn no_crs_member_when_epsg_mixed() {
-        let features = vec![
-            feature_with_epsg(None),
-            feature_with_epsg(Some(6675)),
-            feature_with_epsg(Some(6669)),
-        ];
-        assert!(crs_foreign_members(&features).is_none());
+    fn null_crs_when_no_coordinate_carries_one() {
+        let crs = crs_of(&[fixture::without_crs(), fixture::without_crs()]);
+        assert_eq!(crs, Value::Null);
+    }
+
+    // A null `crs` must reach the file: an absent member would claim the GeoJSON
+    // default CRS (WGS84 longitude / latitude) for coordinates that are not in it.
+    #[test]
+    fn null_crs_is_serialized_rather_than_omitted() {
+        let json = serialized(true, &[fixture::without_crs()]);
+        assert!(json.contains("\"crs\":null"), "got: {json}");
+    }
+
+    // The `crs` member is a GeoJSON 2008 extension, so it is written only when
+    // asked for — not even as `null`, which would still be an extension member.
+    #[test]
+    fn no_crs_member_unless_it_is_asked_for() {
+        assert_eq!(
+            crs_foreign_members(false, &[fixture::in_epsg(6675)], &output()),
+            None
+        );
+        let json = serialized(false, &[fixture::in_epsg(6675)]);
+        assert!(!json.contains("crs"), "got: {json}");
+    }
+
+    /// A `FeatureCollection` carrying only what `features` say about the CRS,
+    /// serialized as it would be written.
+    fn serialized(write_crs: bool, features: &[Feature]) -> String {
+        let collection = geojson::FeatureCollection {
+            bbox: None,
+            features: Vec::new(),
+            foreign_members: crs_foreign_members(write_crs, features, &output()),
+        };
+        serde_json::to_string(&collection).unwrap()
+    }
+
+    #[cfg(feature = "new-geometry")]
+    #[test]
+    fn null_crs_for_a_tangent_plane() {
+        assert_eq!(crs_of(&[fixture::in_tangent_plane()]), Value::Null);
+    }
+
+    #[cfg(feature = "new-geometry")]
+    #[test]
+    fn null_crs_when_nothing_carries_coordinates() {
+        assert_eq!(crs_of(&[fixture::without_geometry()]), Value::Null);
+    }
+
+    // One CRS-bearing feature does not name the collection's CRS while another
+    // feature's coordinates are not in that CRS.
+    #[cfg(feature = "new-geometry")]
+    #[test]
+    fn null_crs_when_only_some_coordinates_carry_one() {
+        let crs = crs_of(&[fixture::in_epsg(6675), fixture::without_crs()]);
+        assert_eq!(crs, Value::Null);
     }
 }

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau6/02-bldg/building_checks.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau6/02-bldg/building_checks.yml
@@ -303,6 +303,7 @@ nodes:
       output:
         type: string
         value: error_geometry/02_建築物_LOD0面の交差.geojson
+      writeCrs: true
 
   # --- LOD0 surface orientation pipeline ---
   # SurfaceValidator2D emits LOD0 surfaces whose exterior ring is not
@@ -1298,6 +1299,7 @@ nodes:
       output:
         type: string
         value: error_geometry/02_建築物_LOD2以上境界面のエラー.geojson
+      writeCrs: true
 
   # --- LOD2 solid-boundary validation pipeline (L14) ---
   - id: f2cfc80d-26e2-43e9-9038-89f698e84147

--- a/engine/runtime/types/src/conversion.rs
+++ b/engine/runtime/types/src/conversion.rs
@@ -1,5 +1,8 @@
 // The GeoJSON <-> Feature conversion depends on the feature geometry type, so it
-// splits by world: `geojson.rs` (old) vs `geojson_next.rs` (new-geometry).
+// splits by world: `geojson.rs` (old) vs `geojson_next.rs` (new-geometry). What the
+// two have in common is re-exported from both, so callers see one path.
+mod geojson_shared;
+
 #[cfg(not(feature = "new-geometry"))]
 pub mod geojson;
 #[cfg(feature = "new-geometry")]

--- a/engine/runtime/types/src/conversion/geojson.rs
+++ b/engine/runtime/types/src/conversion/geojson.rs
@@ -1,7 +1,3 @@
-// Several imports here are only used by the `Feature`-geometry conversions that
-// are gated off under `new-geometry`.
-#![cfg_attr(feature = "new-geometry", allow(unused_imports))]
-
 use std::sync::Arc;
 
 use indexmap::IndexMap;
@@ -15,8 +11,26 @@ use crate::{
     Attribute, AttributeValue, Feature, GeometryValue, GmlGeometry,
 };
 
-// TODO(new-geometry): port to new geometry; gated off until then.
-#[cfg(not(feature = "new-geometry"))]
+pub use super::geojson_shared::{CrsCoverage, WrittenFeature};
+
+/// What `feature` writes to as GeoJSON.
+///
+/// One EPSG code covers a whole feature here, so its coordinates are all in that
+/// code or in none: a feature carrying no code says nothing about the CRS rather
+/// than placing its coordinates outside every one.
+pub fn write_feature(feature: &Feature) -> Result<WrittenFeature> {
+    let features: Vec<geojson::Feature> = feature.clone().try_into()?;
+    let crs = match feature.geometry.epsg {
+        // A feature can write a row without coordinates, which the code it
+        // carries does not describe.
+        Some(code) if features.iter().any(|f| f.geometry.is_some()) => {
+            CrsCoverage::Single(code.into())
+        }
+        _ => CrsCoverage::NoCoordinates,
+    };
+    Ok(WrittenFeature { features, crs })
+}
+
 impl TryFrom<Feature> for Vec<geojson::Feature> {
     type Error = Error;
 
@@ -76,7 +90,6 @@ impl TryFrom<Feature> for Vec<geojson::Feature> {
     }
 }
 
-#[cfg(not(feature = "new-geometry"))]
 fn from_attribute_value_map_to_geojson_object(
     map: &IndexMap<Attribute, AttributeValue>,
 ) -> geojson::JsonObject {
@@ -119,8 +132,6 @@ impl From<GmlGeometry> for Vec<geojson::Value> {
     }
 }
 
-// TODO(new-geometry): port to new geometry; gated off until then.
-#[cfg(not(feature = "new-geometry"))]
 impl TryFrom<geojson::Feature> for Feature {
     type Error = Error;
 
@@ -158,7 +169,6 @@ impl TryFrom<geojson::Feature> for Feature {
     }
 }
 
-#[cfg(not(feature = "new-geometry"))]
 fn from_geojson_object_to_attribute_value_map(
     obj: &geojson::JsonObject,
 ) -> IndexMap<Attribute, AttributeValue> {
@@ -167,8 +177,9 @@ fn from_geojson_object_to_attribute_value_map(
         .collect()
 }
 
-#[cfg(all(test, not(feature = "new-geometry")))]
+#[cfg(test)]
 mod tests {
+    use reearth_flow_geometry::coordinate::EpsgCode;
     use reearth_flow_geometry::types::coordinate::Coordinate3D;
     use reearth_flow_geometry::types::line_string::LineString3D;
     use reearth_flow_geometry::types::polygon::Polygon3D;
@@ -230,19 +241,26 @@ mod tests {
         assert_eq!(values[2], geojson::Value::Point(vec![2.0, 3.0, 4.0]));
     }
 
-    // A feature whose CityGML geometry contains only points converts to a
-    // GeoJSON feature with a Point geometry.
-    #[test]
-    fn feature_with_only_points_yields_at_least_one_geojson_feature() {
+    fn point_geometry_value() -> GeometryValue {
         let gml_geometry = GmlGeometry {
             points: vec![Coordinate3D::new__(137.32, 34.68, 12.5)],
             len: 1,
             ..GmlGeometry::new(GeometryType::Point, Some(0))
         };
-        let citygml_geometry = CityGmlGeometry::new(vec![gml_geometry], Vec::new(), Vec::new());
+        GeometryValue::CityGmlGeometry(CityGmlGeometry::new(
+            vec![gml_geometry],
+            Vec::new(),
+            Vec::new(),
+        ))
+    }
+
+    // A feature whose CityGML geometry contains only points converts to a
+    // GeoJSON feature with a Point geometry.
+    #[test]
+    fn feature_with_only_points_yields_at_least_one_geojson_feature() {
         let feature = Feature::new_with_attributes_and_geometry(
             Attributes::new(),
-            Geometry::with_value(GeometryValue::CityGmlGeometry(citygml_geometry)),
+            Geometry::with_value(point_geometry_value()),
         );
 
         let geojson_features: Vec<geojson::Feature> = feature.try_into().unwrap();
@@ -252,5 +270,34 @@ mod tests {
             geojson_features[0].geometry.as_ref().map(|g| &g.value),
             Some(geojson::Value::Point(_))
         ));
+    }
+
+    // The feature's EPSG code covers the coordinates it writes.
+    #[test]
+    fn written_coordinates_are_covered_by_the_features_epsg_code() {
+        let feature = Feature::new_with_attributes_and_geometry(
+            Attributes::new(),
+            Geometry::new_with(6675, point_geometry_value()),
+        );
+
+        assert_eq!(
+            write_feature(&feature).unwrap().crs,
+            CrsCoverage::Single(EpsgCode::new(6675))
+        );
+    }
+
+    // A feature without geometry still writes a row, which its EPSG code does not
+    // describe: the file carries no coordinate in that CRS.
+    #[test]
+    fn a_row_without_coordinates_is_covered_by_no_crs() {
+        let feature = Feature::new_with_attributes_and_geometry(
+            Attributes::new(),
+            Geometry::new_with(6675, GeometryValue::None),
+        );
+
+        let written = write_feature(&feature).unwrap();
+
+        assert_eq!(written.features.len(), 1);
+        assert_eq!(written.crs, CrsCoverage::NoCoordinates);
     }
 }

--- a/engine/runtime/types/src/conversion/geojson_next.rs
+++ b/engine/runtime/types/src/conversion/geojson_next.rs
@@ -7,14 +7,16 @@
 //! while a CRS frame stores its axes in the order the CRS authority declares, so
 //! reading swaps the horizontal pair and writing swaps it back.
 
-use std::sync::Arc;
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex, OnceLock};
 
+use itertools::Itertools;
 use reearth_flow_geometry::types::conversion::{is_2d_geojson_value, is_3d_geojson_value};
 use reearth_flow_geometry::{
     collection::{Collection2D, Collection3D},
     coordinate::{CoordinateFrame, EpsgCode},
     line_string::{LineString2D, LineString3D},
-    ops::Split,
+    ops::{Split, UnsupportedOperation},
     point::{Point2D, Point3D},
     polygon::{Polygon2D, Polygon3D},
     Euclidean2DGeometry, Euclidean3DGeometry, Geometry, GeometryCollection,
@@ -205,33 +207,72 @@ fn polygon_3d(rings: &[Vec<Vec<f64>>]) -> Polygon3D {
 // ---------------------------------------------------------------------------
 // Feature -> GeoJSON
 // ---------------------------------------------------------------------------
+//
+// Writing is one recursive map, `&Geometry -> Result<Written, Unwritable>`: a
+// geometry either writes to a `Written` or names the reason it cannot be written.
 
 impl TryFrom<Feature> for Vec<geojson::Feature> {
     type Error = Error;
 
     fn try_from(feature: Feature) -> Result<Self> {
-        let properties = attributes_to_geojson_object(&feature.attributes);
-        let features = match &*feature.geometry {
-            // A feature carrying attributes but no geometry still produces a row.
-            Geometry::None => vec![geojson_feature(feature.id, None, properties)],
-            // A cross-dimensional, cross-frame collection has no single GeoJSON
-            // geometry, so each member becomes a feature of its own — as the old
-            // CityGML geometry did. The members share the feature's properties;
-            // per-member attributes stay on the member.
-            Geometry::GeometryCollection(collection) => collection
-                .members()
-                .iter()
-                .filter_map(geometry_to_value)
-                .map(|value| geojson_feature(uuid::Uuid::new_v4(), Some(value), properties.clone()))
-                .collect(),
-            geometry => {
-                let value = geometry_to_value(geometry).ok_or_else(|| {
-                    Error::unsupported_feature("geometry has no GeoJSON counterpart")
-                })?;
-                vec![geojson_feature(feature.id, Some(value), properties)]
+        write_feature(&feature).map(|written| written.features)
+    }
+}
+
+/// What a feature writes to: the GeoJSON features it becomes, and the coordinate
+/// frames their positions came from.
+///
+/// The frames come out of the same pass as the features, so a caller that has to
+/// declare the CRS of what it wrote reads it off here instead of writing every
+/// geometry a second time to recover it.
+pub struct WrittenFeature {
+    pub features: Vec<geojson::Feature>,
+    pub frames: WrittenFrames,
+}
+
+/// What `feature` writes to as GeoJSON.
+pub fn write_feature(feature: &Feature) -> Result<WrittenFeature> {
+    let properties = attributes_to_geojson_object(&feature.attributes);
+    match &*feature.geometry {
+        // A feature carrying attributes but no geometry still produces a row,
+        // stating nothing about the CRS.
+        Geometry::None => Ok(WrittenFeature {
+            features: vec![geojson_feature(feature.id, None, properties)],
+            frames: WrittenFrames::default(),
+        }),
+        // A cross-dimensional, cross-frame collection has no single GeoJSON
+        // geometry, so each member becomes a feature of its own — as the old
+        // CityGML geometry did — sharing the feature's properties.
+        Geometry::GeometryCollection(collection) => {
+            let parts = Parts::of(
+                collection.members(),
+                write_geometry,
+                Unwritable::EmptyCollection,
+            )?;
+            warn_omitted(&parts.omitted);
+            let mut frames = Frames::default();
+            let mut features = Vec::with_capacity(parts.written.len());
+            for member in parts.written {
+                frames = frames.and(member.frames);
+                features.push(geojson_feature(
+                    uuid::Uuid::new_v4(),
+                    Some(member.value),
+                    properties.clone(),
+                ));
             }
-        };
-        Ok(features)
+            Ok(WrittenFeature {
+                features,
+                frames: WrittenFrames(frames),
+            })
+        }
+        geometry => {
+            let written = write_geometry(geometry)?;
+            warn_omitted(&written.omitted);
+            Ok(WrittenFeature {
+                features: vec![geojson_feature(feature.id, Some(written.value), properties)],
+                frames: WrittenFrames(written.frames),
+            })
+        }
     }
 }
 
@@ -256,126 +297,206 @@ fn attributes_to_geojson_object(attributes: &Attributes) -> geojson::JsonObject 
         .collect()
 }
 
-/// The GeoJSON counterpart of `geometry`, or `None` when it has none.
+/// Why a geometry cannot be written as GeoJSON — the `Err` half of what
+/// [`write_geometry`] returns.
 ///
-/// A leaf GeoJSON cannot express (`Solid`, `Csg`, `PointCloud`) is dropped where
-/// it appears rather than failing the geometry around it, so one such member does
-/// not discard its siblings.
-fn geometry_to_value(geometry: &Geometry) -> Option<geojson::Value> {
-    match geometry {
-        Geometry::None => None,
-        Geometry::Euclidean2D(g) => value_2d(g),
-        Geometry::Euclidean3D(g) => value_3d(g),
-        // Nested: only the outermost collection expands into separate features.
-        Geometry::GeometryCollection(c) => Some(geometry_collection(
-            c.members().iter().filter_map(geometry_to_value).collect(),
-        )),
+/// Kept out of [`Error`] while a geometry is being written: within the writer a
+/// reason is a value to compare, collect and warn about, and it turns into a
+/// message only where it crosses the conversion's boundary.
+#[derive(thiserror::Error, Clone, Copy, Debug, PartialEq, Eq)]
+enum Unwritable {
+    /// A geometry asked for where the feature has none. The feature still writes
+    /// a row, with a null geometry.
+    #[error("an absent geometry has no GeoJSON counterpart")]
+    AbsentGeometry,
+    /// GeoJSON has no volume, nor the boolean tree built from volumes.
+    #[error("a Solid has no GeoJSON counterpart")]
+    Solid,
+    #[error("a Csg tree has no GeoJSON counterpart")]
+    Csg,
+    /// A `MultiPoint` could hold one, but that would emit a position per sample.
+    #[error("a PointCloud has no GeoJSON counterpart")]
+    PointCloud,
+    /// A collection with nothing writable under it. Writing it would emit an
+    /// empty geometry that states nothing about the feature.
+    #[error("an empty collection has no GeoJSON counterpart")]
+    EmptyCollection,
+    /// As above, for a mesh, which writes as its faces.
+    #[error("a mesh with no face has no GeoJSON counterpart")]
+    EmptyMesh,
+    /// A mesh whose faces could not be read.
+    #[error(transparent)]
+    Unsplittable(#[from] UnsupportedOperation),
+}
+
+/// A reason becomes a message here, where the writer's error reaches its caller.
+impl From<Unwritable> for Error {
+    fn from(reason: Unwritable) -> Self {
+        Error::unsupported_feature(reason)
     }
 }
 
-fn value_2d(geometry: &Euclidean2DGeometry) -> Option<geojson::Value> {
-    match geometry {
-        Euclidean2DGeometry::Point(p) => Some(geojson::Value::Point(xy(
-            swaps_axes(p.frame()),
-            p.position(),
-        ))),
-        Euclidean2DGeometry::LineString(l) => {
-            let swap = swaps_axes(l.frame());
-            Some(geojson::Value::LineString(
-                l.coords().iter().map(|&c| xy(swap, c)).collect(),
-            ))
-        }
-        Euclidean2DGeometry::Polygon(p) => {
-            let swap = swaps_axes(p.frame());
-            Some(geojson::Value::Polygon(
-                std::iter::once(p.exterior())
-                    .chain(p.interiors())
-                    .map(|ring| closed_ring(ring.iter().map(|&c| xy(swap, c))))
-                    .collect(),
-            ))
-        }
-        Euclidean2DGeometry::PolygonMesh(m) => faces_to_multi_polygon((**m).clone()),
-        Euclidean2DGeometry::TriangularMesh(m) => faces_to_multi_polygon((**m).clone()),
-        Euclidean2DGeometry::Collection(c) => Some(combine(
-            c.members().iter().filter_map(value_2d).collect(),
-            one_frame(c.members(), visit_frames_2d),
-        )),
+/// Report what the writer left out. An omission does not fail the geometry around
+/// it, so this warning is the only trace of it.
+fn warn_omitted(omitted: &[Unwritable]) {
+    for reason in omitted {
+        tracing::warn!(%reason, "omitting a geometry member from the GeoJSON output");
     }
 }
 
-fn value_3d(geometry: &Euclidean3DGeometry) -> Option<geojson::Value> {
-    match geometry {
-        Euclidean3DGeometry::Point(p) => Some(geojson::Value::Point(xyz(
-            swaps_axes(p.frame()),
-            p.position(),
-        ))),
-        Euclidean3DGeometry::LineString(l) => {
-            let swap = swaps_axes(l.frame());
-            Some(geojson::Value::LineString(
-                l.coords().iter().map(|&c| xyz(swap, c)).collect(),
-            ))
-        }
-        Euclidean3DGeometry::Polygon(p) => {
-            let swap = swaps_axes(p.frame());
-            Some(geojson::Value::Polygon(
-                std::iter::once(p.exterior())
-                    .chain(p.interiors())
-                    .map(|ring| closed_ring(ring.iter().map(|&c| xyz(swap, c))))
-                    .collect(),
-            ))
-        }
-        Euclidean3DGeometry::PolygonMesh(m) => faces_to_multi_polygon((**m).clone()),
-        Euclidean3DGeometry::TriangularMesh(m) => faces_to_multi_polygon((**m).clone()),
-        Euclidean3DGeometry::Collection(c) => Some(combine(
-            c.members().iter().filter_map(value_3d).collect(),
-            one_frame(c.members(), visit_frames_3d),
-        )),
-        // A volume has no GeoJSON counterpart, and neither has the boolean tree
-        // built from volumes. A point cloud has one, but expanding it would emit
-        // a position per sample.
-        Euclidean3DGeometry::Solid(_) => unsupported_leaf("Solid"),
-        Euclidean3DGeometry::Csg(_) => unsupported_leaf("Csg"),
-        Euclidean3DGeometry::PointCloud(_) => unsupported_leaf("PointCloud"),
-    }
-}
-
-fn unsupported_leaf(kind: &'static str) -> Option<geojson::Value> {
-    tracing::warn!(
-        geometry = kind,
-        "geometry has no GeoJSON counterpart; omitting it"
-    );
-    None
-}
-
-/// One GeoJSON polygon per mesh face, via the public `Split` op. `Split` takes
-/// `&mut self`, hence the mesh is passed by value; splitting a mesh reads it
-/// rather than emptying it.
-fn faces_to_multi_polygon(mut mesh: impl Split) -> Option<geojson::Value> {
-    let mut polygons = Vec::new();
-    mesh.split(&mut |face, _| {
-        if let Some(geojson::Value::Polygon(rings)) = geometry_to_value(&face) {
-            polygons.push(rings);
-        }
-    })
-    .ok()?;
-    Some(geojson::Value::MultiPolygon(polygons))
-}
-
-/// Present a collection's members as one GeoJSON geometry: a `Multi*` when they
-/// are all of one kind and share a coordinate frame, a `GeometryCollection`
-/// otherwise.
+/// What a geometry writes to: the GeoJSON geometry, the coordinate frames its
+/// positions came from, and the reasons parts of it were left out.
 ///
-/// `Collection2D` / `Collection3D` are the new geometry's `Multi*`, so folding is
-/// the inverse of the `MultiPolygon -> Collection` mapping on the read side.
-/// Folding members that differ in frame would put coordinates from different
-/// reference systems in one geometry, which no single `crs` member can describe.
-fn combine(values: Vec<geojson::Value>, uniform_frame: bool) -> geojson::Value {
-    if !uniform_frame {
-        return geometry_collection(values);
+/// The frames and reasons come out of the same pass as the value, so nothing has
+/// to re-walk the geometry to recover them. Carrying the reasons rather than
+/// logging them where a part is dropped also keeps the recursion a pure map, the
+/// whole geometry's omissions being reported once it is written.
+struct Written {
+    value: geojson::Value,
+    frames: Frames,
+    omitted: Vec<Unwritable>,
+}
+
+impl Written {
+    /// What a leaf writes to: one value, in one frame, leaving nothing out.
+    fn leaf(frame: &CoordinateFrame, value: geojson::Value) -> Self {
+        Self {
+            value,
+            frames: Frames::of(frame),
+            omitted: Vec::new(),
+        }
     }
-    match fold_into_multi(values) {
-        Ok(folded) => folded,
-        Err(values) => geometry_collection(values),
+}
+
+/// What `geometry` writes to, or the reason it cannot be written.
+fn write_geometry(geometry: &Geometry) -> Result<Written, Unwritable> {
+    match geometry {
+        Geometry::None => Err(Unwritable::AbsentGeometry),
+        Geometry::Euclidean2D(g) => write_2d(g),
+        Geometry::Euclidean3D(g) => write_3d(g),
+        // Only the outermost collection expands into separate features; a nested
+        // one stays a GeoJSON `GeometryCollection` whatever its members are, being
+        // the cross-dimensional, cross-frame container no `Multi*` describes.
+        Geometry::GeometryCollection(c) => {
+            Parts::of(c.members(), write_geometry, Unwritable::EmptyCollection)
+                .map(Parts::into_geometry_collection)
+        }
+    }
+}
+
+fn write_2d(geometry: &Euclidean2DGeometry) -> Result<Written, Unwritable> {
+    use Euclidean2DGeometry as G;
+    match geometry {
+        G::Point(p) => Ok(point(p.frame(), p.position())),
+        G::LineString(l) => Ok(curve(l.frame(), l.coords())),
+        G::Polygon(p) => Ok(area(p.frame(), p.exterior(), p.interiors())),
+        G::PolygonMesh(m) => write_faces((**m).clone()),
+        G::TriangularMesh(m) => write_faces((**m).clone()),
+        G::Collection(c) => Parts::of(c.members(), write_2d, Unwritable::EmptyCollection)
+            .map(Parts::into_one_geometry),
+    }
+}
+
+fn write_3d(geometry: &Euclidean3DGeometry) -> Result<Written, Unwritable> {
+    use Euclidean3DGeometry as G;
+    match geometry {
+        G::Point(p) => Ok(point(p.frame(), p.position())),
+        G::LineString(l) => Ok(curve(l.frame(), l.coords())),
+        G::Polygon(p) => Ok(area(p.frame(), p.exterior(), p.interiors())),
+        G::PolygonMesh(m) => write_faces((**m).clone()),
+        G::TriangularMesh(m) => write_faces((**m).clone()),
+        G::Collection(c) => Parts::of(c.members(), write_3d, Unwritable::EmptyCollection)
+            .map(Parts::into_one_geometry),
+        G::Solid(_) => Err(Unwritable::Solid),
+        G::Csg(_) => Err(Unwritable::Csg),
+        G::PointCloud(_) => Err(Unwritable::PointCloud),
+    }
+}
+
+/// A mesh writes as its faces, folding into a `MultiPolygon` the way a collection
+/// writes as its members.
+///
+/// The `Split` op that yields the faces takes `&mut self`, hence the mesh is passed
+/// by value; splitting reads it rather than emptying it, so the geometry it came
+/// from is left intact.
+fn write_faces(mut mesh: impl Split) -> Result<Written, Unwritable> {
+    let mut faces = Vec::new();
+    mesh.split(&mut |face, _| faces.push(face))?;
+    Parts::of(&faces, write_geometry, Unwritable::EmptyMesh).map(Parts::into_one_geometry)
+}
+
+/// The writable parts of a container, and every reason the writer left something
+/// out.
+struct Parts {
+    /// Non-empty: a container with no writable part cannot be written either,
+    /// which [`Parts::of`] reports as an error instead.
+    written: Vec<Written>,
+    omitted: Vec<Unwritable>,
+}
+
+impl Parts {
+    /// Write every part, keeping the writable ones: a part GeoJSON cannot express
+    /// is dropped where it appears rather than failing the geometry around it, so
+    /// it does not discard its siblings. The reasons come out together — the
+    /// dropped parts' and those the survivors collected themselves — so the whole
+    /// geometry's omissions are reported in one place.
+    ///
+    /// `Err` once nothing is left, a container reduced to nothing being unwritable
+    /// too. That error carries out a dropped part's reason, naming what could not
+    /// be written once at the top, or `empty` when there were no parts to drop.
+    fn of<T>(
+        parts: &[T],
+        write: impl Fn(&T) -> Result<Written, Unwritable>,
+        empty: Unwritable,
+    ) -> Result<Self, Unwritable> {
+        let (mut written, mut omitted): (Vec<Written>, Vec<Unwritable>) =
+            parts.iter().map(write).partition_result();
+        if written.is_empty() {
+            return Err(omitted.first().copied().unwrap_or(empty));
+        }
+        for part in &mut written {
+            omitted.append(&mut part.omitted);
+        }
+        Ok(Self { written, omitted })
+    }
+
+    /// The parts as one GeoJSON geometry: a `Multi*` when they are all of one
+    /// kind and share a coordinate frame, a `GeometryCollection` otherwise.
+    ///
+    /// `Collection2D` / `Collection3D` are the new geometry's `Multi*`, so folding
+    /// is the inverse of the read side's `MultiPolygon -> Collection` mapping.
+    /// Parts that differ in frame are not folded: that would put coordinates from
+    /// different reference systems in one geometry, which no single `crs` member
+    /// describes.
+    fn into_one_geometry(self) -> Written {
+        self.present(|values, frames| match ValueKind::uniform(&values) {
+            Some(kind) if frames.uniform() => kind.fold(values),
+            _ => geometry_collection(values),
+        })
+    }
+
+    /// The parts as one GeoJSON `GeometryCollection`, whatever they are.
+    fn into_geometry_collection(self) -> Written {
+        self.present(|values, _| geometry_collection(values))
+    }
+
+    /// The parts as the one geometry `present` builds from their values, carrying
+    /// the frames they were written in and what the writer left out.
+    fn present(
+        self,
+        present: impl FnOnce(Vec<geojson::Value>, &Frames) -> geojson::Value,
+    ) -> Written {
+        let (values, frames): (Vec<_>, Vec<_>) = self
+            .written
+            .into_iter()
+            .map(|part| (part.value, part.frames))
+            .unzip();
+        let frames = frames.into_iter().fold(Frames::default(), Frames::and);
+        Written {
+            value: present(values, &frames),
+            frames,
+            omitted: self.omitted,
+        }
     }
 }
 
@@ -383,52 +504,8 @@ fn geometry_collection(values: Vec<geojson::Value>) -> geojson::Value {
     geojson::Value::GeometryCollection(values.into_iter().map(geojson::Geometry::new).collect())
 }
 
-/// Fold values that are all points, all curves, or all areas into the matching
-/// `Multi*`, handing them back untouched when they are of more than one kind.
-/// A member that is already a `Multi*` is flattened into the result.
-fn fold_into_multi(values: Vec<geojson::Value>) -> Result<geojson::Value, Vec<geojson::Value>> {
-    let Some(kind) = values.first().and_then(value_kind) else {
-        return Err(values);
-    };
-    if !values.iter().all(|v| value_kind(v) == Some(kind)) {
-        return Err(values);
-    }
-    Ok(match kind {
-        ValueKind::Point => geojson::Value::MultiPoint(
-            values
-                .into_iter()
-                .flat_map(|v| match v {
-                    geojson::Value::Point(p) => vec![p],
-                    geojson::Value::MultiPoint(ps) => ps,
-                    _ => Vec::new(),
-                })
-                .collect(),
-        ),
-        ValueKind::Curve => geojson::Value::MultiLineString(
-            values
-                .into_iter()
-                .flat_map(|v| match v {
-                    geojson::Value::LineString(l) => vec![l],
-                    geojson::Value::MultiLineString(ls) => ls,
-                    _ => Vec::new(),
-                })
-                .collect(),
-        ),
-        ValueKind::Area => geojson::Value::MultiPolygon(
-            values
-                .into_iter()
-                .flat_map(|v| match v {
-                    geojson::Value::Polygon(p) => vec![p],
-                    geojson::Value::MultiPolygon(ps) => ps,
-                    _ => Vec::new(),
-                })
-                .collect(),
-        ),
-    })
-}
-
-/// The `Multi*` family a value belongs to; `None` for a `GeometryCollection`,
-/// which has no `Multi*` form to fold into.
+/// The `Multi*` family a GeoJSON geometry belongs to; a `GeometryCollection`
+/// belongs to none, having no `Multi*` form to fold into.
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum ValueKind {
     Point,
@@ -436,67 +513,249 @@ enum ValueKind {
     Area,
 }
 
-fn value_kind(value: &geojson::Value) -> Option<ValueKind> {
-    match value {
-        geojson::Value::Point(_) | geojson::Value::MultiPoint(_) => Some(ValueKind::Point),
-        geojson::Value::LineString(_) | geojson::Value::MultiLineString(_) => {
-            Some(ValueKind::Curve)
+impl ValueKind {
+    fn of(value: &geojson::Value) -> Option<Self> {
+        match value {
+            geojson::Value::Point(_) | geojson::Value::MultiPoint(_) => Some(Self::Point),
+            geojson::Value::LineString(_) | geojson::Value::MultiLineString(_) => Some(Self::Curve),
+            geojson::Value::Polygon(_) | geojson::Value::MultiPolygon(_) => Some(Self::Area),
+            geojson::Value::GeometryCollection(_) => None,
         }
-        geojson::Value::Polygon(_) | geojson::Value::MultiPolygon(_) => Some(ValueKind::Area),
-        geojson::Value::GeometryCollection(_) => None,
     }
+
+    /// The one family every value belongs to, or `None` when they belong to more
+    /// than one, one of them belongs to none, or there are none at all.
+    fn uniform(values: &[geojson::Value]) -> Option<Self> {
+        let kind = Self::of(values.first()?)?;
+        values
+            .iter()
+            .all(|value| Self::of(value) == Some(kind))
+            .then_some(kind)
+    }
+
+    /// Values that all belong to this family, folded into the matching `Multi*`.
+    /// A value that is already a `Multi*` is flattened into the result; one of
+    /// another family cannot occur, [`ValueKind::uniform`] having established a
+    /// single family.
+    fn fold(self, values: Vec<geojson::Value>) -> geojson::Value {
+        match self {
+            Self::Point => geojson::Value::MultiPoint(
+                values
+                    .into_iter()
+                    .flat_map(|value| match value {
+                        geojson::Value::Point(p) => vec![p],
+                        geojson::Value::MultiPoint(ps) => ps,
+                        _ => Vec::new(),
+                    })
+                    .collect(),
+            ),
+            Self::Curve => geojson::Value::MultiLineString(
+                values
+                    .into_iter()
+                    .flat_map(|value| match value {
+                        geojson::Value::LineString(l) => vec![l],
+                        geojson::Value::MultiLineString(ls) => ls,
+                        _ => Vec::new(),
+                    })
+                    .collect(),
+            ),
+            Self::Area => geojson::Value::MultiPolygon(
+                values
+                    .into_iter()
+                    .flat_map(|value| match value {
+                        geojson::Value::Polygon(p) => vec![p],
+                        geojson::Value::MultiPolygon(ps) => ps,
+                        _ => Vec::new(),
+                    })
+                    .collect(),
+            ),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Leaves
+// ---------------------------------------------------------------------------
+//
+// The 2D and 3D leaves differ only in how long a position is, so what turns one
+// into GeoJSON is written once, over `N`-element positions.
+
+fn point<const N: usize>(frame: &CoordinateFrame, position: [f64; N]) -> Written {
+    Written::leaf(
+        frame,
+        geojson::Value::Point(coordinates(swaps_axes(frame), position)),
+    )
+}
+
+fn curve<const N: usize>(frame: &CoordinateFrame, coords: &[[f64; N]]) -> Written {
+    let swap = swaps_axes(frame);
+    Written::leaf(
+        frame,
+        geojson::Value::LineString(coords.iter().map(|&c| coordinates(swap, c)).collect()),
+    )
+}
+
+/// What an area writes to: its exterior ring, then its holes.
+fn area<'a, const N: usize>(
+    frame: &CoordinateFrame,
+    exterior: &'a [[f64; N]],
+    interiors: impl Iterator<Item = &'a [[f64; N]]>,
+) -> Written {
+    let swap = swaps_axes(frame);
+    Written::leaf(
+        frame,
+        geojson::Value::Polygon(
+            std::iter::once(exterior)
+                .chain(interiors)
+                .map(|ring| closed_ring(swap, ring))
+                .collect(),
+        ),
+    )
 }
 
 // GeoJSON positions are `(easting/longitude, northing/latitude[, height])`
 // whatever the CRS declares: RFC 7946 section 3.1.1 fixes that order even for the
-// alternative reference systems its section 4 allows by prior arrangement, and
-// GeoJSON 2008 — the dialect the `crs` member this writer emits comes from —
-// states that a CRS shall not change coordinate ordering.
+// alternative reference systems its section 4 allows, and GeoJSON 2008 — where the
+// `crs` member comes from — states that a CRS shall not change coordinate ordering.
 
-/// Whether a frame stores its horizontal axes reflected from canonical
-/// `(East, North)` order, so that they must be swapped on the way out. A frame
-/// whose order cannot be established is written as stored.
-fn swaps_axes(frame: &CoordinateFrame) -> bool {
-    frame.orientation_sign().is_ok_and(|sign| sign < 0)
-}
-
-fn xy(swap: bool, [x, y]: [f64; 2]) -> Vec<f64> {
+/// A stored coordinate as a GeoJSON position. Only the horizontal pair is
+/// reordered; a height stays where it is.
+fn coordinates<const N: usize>(swap: bool, mut coordinate: [f64; N]) -> Vec<f64> {
     if swap {
-        vec![y, x]
-    } else {
-        vec![x, y]
+        coordinate.swap(0, 1);
     }
-}
-
-fn xyz(swap: bool, [x, y, z]: [f64; 3]) -> Vec<f64> {
-    if swap {
-        vec![y, x, z]
-    } else {
-        vec![x, y, z]
-    }
+    coordinate.to_vec()
 }
 
 /// GeoJSON requires a ring's first and last positions to be equal. The stored
 /// rings carry no such guarantee, so an open one is closed on the way out.
-fn closed_ring(positions: impl Iterator<Item = Vec<f64>>) -> Vec<Vec<f64>> {
-    let mut ring: Vec<Vec<f64>> = positions.collect();
-    let open = match (ring.first(), ring.last()) {
-        (Some(first), Some(last)) => first != last,
-        _ => false,
-    };
-    if open {
-        let first = ring[0].clone();
-        ring.push(first);
+fn closed_ring<const N: usize>(swap: bool, ring: &[[f64; N]]) -> Vec<Vec<f64>> {
+    let mut positions: Vec<Vec<f64>> = ring.iter().map(|&c| coordinates(swap, c)).collect();
+    if positions.first() != positions.last() {
+        let first = positions[0].clone();
+        positions.push(first);
     }
-    ring
+    positions
+}
+
+/// Whether a frame stores its horizontal axes reflected from canonical
+/// `(East, North)` order, so that they must be swapped on the way out.
+///
+/// Only a CRS declares an axis order to swap back to. `Euclidean` coordinates are
+/// east-first by construction, and a `Tangent` frame's are offsets along its own
+/// in-plane axes rather than its base CRS's, so neither is reordered — as
+/// [`epsg_code`] names no CRS for them either.
+///
+/// A CRS whose order cannot be established is written as stored, which reverses
+/// its coordinates if it turns out to declare `(North, East)`, hence the warning.
+fn swaps_axes(frame: &CoordinateFrame) -> bool {
+    let Some(code) = epsg_code(frame) else {
+        return false;
+    };
+    match frame.orientation_sign() {
+        Ok(sign) => sign < 0,
+        Err(error) => {
+            warn_unresolved_axis_order(code, error);
+            false
+        }
+    }
+}
+
+/// Warn about a CRS whose axis order could not be established, once per code: an
+/// axis order is a fixed property of a CRS, so warning per coordinate would repeat
+/// the same line for every feature in the file.
+fn warn_unresolved_axis_order(code: EpsgCode, error: impl std::fmt::Display) {
+    static WARNED: OnceLock<Mutex<HashSet<EpsgCode>>> = OnceLock::new();
+
+    let mut warned = WARNED
+        .get_or_init(Mutex::default)
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if warned.insert(code) {
+        tracing::warn!(
+            %error,
+            "cannot establish the axis order of EPSG:{code}; writing its \
+             coordinates in the order they are stored, which reverses them if \
+             the CRS declares (northing, easting)"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------
 // Coordinate frames of what gets written
 // ---------------------------------------------------------------------------
 
+/// The coordinate frames the positions written for a geometry came from: the
+/// first one, and the first one after it that differs.
+///
+/// Decides whether written parts may fold into a `Multi*`, and is what
+/// [`WrittenFrames`] carries out to the caller of a write.
+#[derive(Clone, Debug, Default, PartialEq)]
+struct Frames {
+    /// `None` only for the frames of nothing at all: the identity of
+    /// [`Frames::and`].
+    first: Option<CoordinateFrame>,
+    differing: Option<CoordinateFrame>,
+}
+
+impl Frames {
+    /// The frames of a leaf: one.
+    fn of(frame: &CoordinateFrame) -> Self {
+        Self {
+            first: Some(frame.clone()),
+            differing: None,
+        }
+    }
+
+    /// The frames of two written parts, together.
+    fn and(self, other: Self) -> Self {
+        let Some(first) = self.first else {
+            return other;
+        };
+        let Self {
+            first: other_first,
+            differing: other_differing,
+        } = other;
+        Self {
+            differing: self
+                .differing
+                .or_else(|| other_first.filter(|frame| *frame != first))
+                .or(other_differing),
+            first: Some(first),
+        }
+    }
+
+    /// Whether one frame covers every written position.
+    fn uniform(&self) -> bool {
+        self.first.is_some() && self.differing.is_none()
+    }
+
+    /// Which CRS the written positions are expressed in.
+    fn crs(&self) -> WrittenCrs {
+        let Some(first) = self.first.as_ref().and_then(epsg_code) else {
+            return WrittenCrs::Unknown;
+        };
+        match self.differing.as_ref() {
+            None => WrittenCrs::Single(first),
+            // Coordinates outside any CRS leave the CRS unstated rather than
+            // mixed: the code the others carry does not cover them either.
+            Some(other) => epsg_code(other).map_or(WrittenCrs::Unknown, |other| {
+                WrittenCrs::Mixed { first, other }
+            }),
+        }
+    }
+}
+
+/// The EPSG code a frame names, if it names one.
+fn epsg_code(frame: &CoordinateFrame) -> Option<EpsgCode> {
+    match frame {
+        CoordinateFrame::Crs(code) => Some(*code),
+        CoordinateFrame::Euclidean | CoordinateFrame::Tangent(_) => None,
+    }
+}
+
 /// Which coordinate reference system the coordinates written for a set of
-/// features share. Reported by [`written_crs`].
+/// features share. Reported by [`WrittenFrames::crs`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum WrittenCrs {
     /// Every written coordinate is expressed in this one CRS.
@@ -509,111 +768,38 @@ pub enum WrittenCrs {
     Unknown,
 }
 
-/// The CRS the coordinates written for `features` are expressed in.
+/// What the coordinates written for one or more features are expressed in, as a
+/// caller writing them accumulates it.
 ///
-/// Only leaves that reach the output are counted, so the answer describes exactly
-/// the coordinates in the file — a `Solid` that is dropped contributes no CRS.
-pub fn written_crs(features: &[Feature]) -> WrittenCrs {
-    let mut single: Option<EpsgCode> = None;
-    let mut mixed: Option<(EpsgCode, EpsgCode)> = None;
-    let mut non_crs = false;
+/// Opaque: a caller combines what each write hands back with [`and`](Self::and)
+/// and asks the result for its CRS, so the rule deciding whether one CRS covers a
+/// set of coordinates stays in one place. Since it is read off what the writer
+/// produces, the answer describes exactly the coordinates in the file — a dropped
+/// `Solid` contributes no CRS.
+///
+/// [`default`](Default::default) is what nothing written says: the identity of
+/// `and`, distinct from a written coordinate whose frame names no CRS even though
+/// both report [`WrittenCrs::Unknown`].
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct WrittenFrames(Frames);
 
-    for feature in features {
-        visit_frames(&feature.geometry, &mut |frame| {
-            let CoordinateFrame::Crs(code) = frame else {
-                non_crs = true;
-                return;
-            };
-            match single {
-                None => single = Some(*code),
-                Some(seen) if seen != *code => {
-                    mixed.get_or_insert((seen, *code));
-                }
-                Some(_) => {}
-            }
-        });
+impl WrittenFrames {
+    /// What two writes, together, were expressed in.
+    pub fn and(self, other: Self) -> Self {
+        Self(self.0.and(other.0))
     }
 
-    match (mixed, single) {
-        (Some((first, other)), _) => WrittenCrs::Mixed { first, other },
-        (None, Some(code)) if !non_crs => WrittenCrs::Single(code),
-        _ => WrittenCrs::Unknown,
+    /// The CRS covering every coordinate accumulated so far.
+    pub fn crs(&self) -> WrittenCrs {
+        self.0.crs()
     }
-}
-
-/// Visit the coordinate frame of every leaf that reaches the GeoJSON output, in
-/// order. Leaves with no GeoJSON counterpart contribute nothing, matching what
-/// [`geometry_to_value`] writes.
-fn visit_frames<'a>(geometry: &'a Geometry, visit: &mut dyn FnMut(&'a CoordinateFrame)) {
-    match geometry {
-        Geometry::None => {}
-        Geometry::Euclidean2D(g) => visit_frames_2d(g, visit),
-        Geometry::Euclidean3D(g) => visit_frames_3d(g, visit),
-        Geometry::GeometryCollection(c) => {
-            for member in c.members() {
-                visit_frames(member, visit);
-            }
-        }
-    }
-}
-
-fn visit_frames_2d<'a>(
-    geometry: &'a Euclidean2DGeometry,
-    visit: &mut dyn FnMut(&'a CoordinateFrame),
-) {
-    match geometry {
-        Euclidean2DGeometry::Point(p) => visit(p.frame()),
-        Euclidean2DGeometry::LineString(l) => visit(l.frame()),
-        Euclidean2DGeometry::Polygon(p) => visit(p.frame()),
-        Euclidean2DGeometry::PolygonMesh(m) => visit(m.frame()),
-        Euclidean2DGeometry::TriangularMesh(m) => visit(m.frame()),
-        Euclidean2DGeometry::Collection(c) => {
-            for member in c.members() {
-                visit_frames_2d(member, visit);
-            }
-        }
-    }
-}
-
-fn visit_frames_3d<'a>(
-    geometry: &'a Euclidean3DGeometry,
-    visit: &mut dyn FnMut(&'a CoordinateFrame),
-) {
-    match geometry {
-        Euclidean3DGeometry::Point(p) => visit(p.frame()),
-        Euclidean3DGeometry::LineString(l) => visit(l.frame()),
-        Euclidean3DGeometry::Polygon(p) => visit(p.frame()),
-        Euclidean3DGeometry::PolygonMesh(m) => visit(m.frame()),
-        Euclidean3DGeometry::TriangularMesh(m) => visit(m.frame()),
-        Euclidean3DGeometry::Collection(c) => {
-            for member in c.members() {
-                visit_frames_3d(member, visit);
-            }
-        }
-        // Nothing of these reaches the output, so they name no frame.
-        Euclidean3DGeometry::Solid(_)
-        | Euclidean3DGeometry::Csg(_)
-        | Euclidean3DGeometry::PointCloud(_) => {}
-    }
-}
-
-/// Whether every written leaf under `members` shares one coordinate frame.
-fn one_frame<'a, T>(
-    members: &'a [T],
-    visit_frames: fn(&'a T, &mut dyn FnMut(&'a CoordinateFrame)),
-) -> bool {
-    let mut frames: Vec<&CoordinateFrame> = Vec::new();
-    for member in members {
-        visit_frames(member, &mut |frame| frames.push(frame));
-    }
-    frames.windows(2).all(|pair| pair[0] == pair[1])
 }
 
 #[cfg(test)]
 mod tests {
     use reearth_flow_geometry::{
         collection::{Collection2D, Collection3D},
-        coordinate::{CoordinateFrame, EpsgCode},
+        coordinate::{BaseFrame, CoordinateFrame, EpsgCode, TangentPlane},
         line_string::{LineString2D, LineString3D},
         point::{Point2D, Point3D},
         polygon::{Polygon2D, Polygon3D},
@@ -1087,6 +1273,23 @@ mod tests {
         assert_eq!(value, geojson::Value::Point(vec![1.0, 2.0]));
     }
 
+    // A Tangent frame's coordinates are offsets along its own in-plane axes, not
+    // its base CRS's, so they are written as stored even though that base CRS
+    // (EPSG:6675) declares (northing, easting).
+    #[test]
+    fn tangent_frame_is_written_as_stored() {
+        let frame = CoordinateFrame::Tangent(Box::new(TangentPlane {
+            base: BaseFrame::Crs(EpsgCode::new(6675)),
+            origin: [0.0, 0.0, 0.0],
+            u: [1.0, 0.0, 0.0],
+            v: [0.0, 1.0, 0.0],
+        }));
+
+        let value = written_value(point_2d_in(frame, [1.0, 2.0]));
+
+        assert_eq!(value, geojson::Value::Point(vec![1.0, 2.0]));
+    }
+
     // z is carried through unchanged; only the horizontal pair is reordered.
     #[test]
     fn a_3d_point_keeps_its_height() {
@@ -1097,8 +1300,8 @@ mod tests {
         assert_eq!(value, geojson::Value::Point(vec![139.7, 35.6, 12.5]));
     }
 
-    // A 2.5D leaf's single elevation is not written: the old world's 2D geometry
-    // was two-element too.
+    // A 2.5D leaf's single elevation is not written; its positions stay
+    // two-element, as the old world's 2D geometry was.
     #[test]
     fn a_2d_line_string_at_an_elevation_is_written_without_it() {
         let value = written_value(Geometry::Euclidean2D(Euclidean2DGeometry::LineString(
@@ -1254,8 +1457,7 @@ mod tests {
         );
     }
 
-    // A cross-dimensional collection has no single GeoJSON geometry, so its
-    // members become features of their own, sharing the feature's properties.
+    // Members become features of their own, sharing the feature's properties.
     #[test]
     fn a_geometry_collection_expands_into_one_feature_per_member() {
         let mut attributes = Attributes::new();
@@ -1312,7 +1514,7 @@ mod tests {
 
     // --- meshes ---
 
-    // A mesh has no GeoJSON counterpart of its own, so its faces are written.
+    // A mesh writes as its faces, having no GeoJSON geometry of its own.
     #[test]
     fn a_polygon_mesh_writes_one_polygon_per_face() {
         let mesh = PolygonMesh3D::new(CoordinateFrame::Euclidean, quad_mesh_data());
@@ -1370,30 +1572,56 @@ mod tests {
 
     // --- geometries with no GeoJSON counterpart ---
 
-    #[test]
-    fn a_solid_is_rejected_rather_than_panicking() {
-        let solid = Solid::from_exterior(CoordinateFrame::Euclidean, quad_mesh_data());
-        let feature = feature_with(Geometry::Euclidean3D(Euclidean3DGeometry::Solid(Box::new(
-            solid,
-        ))));
+    fn solid_in(frame: CoordinateFrame) -> Euclidean3DGeometry {
+        Euclidean3DGeometry::Solid(Box::new(Solid::from_exterior(frame, quad_mesh_data())))
+    }
 
-        let result: Result<Vec<geojson::Feature>> = feature.try_into();
-
-        assert!(result.is_err());
+    /// The reason `geometry` cannot be written.
+    fn rejection(geometry: Geometry) -> Unwritable {
+        write_geometry(&geometry)
+            .err()
+            .expect("expected an unwritable geometry")
     }
 
     #[test]
+    fn a_solid_is_rejected_rather_than_panicking() {
+        assert_eq!(
+            rejection(Geometry::Euclidean3D(solid_in(CoordinateFrame::Euclidean))),
+            Unwritable::Solid
+        );
+    }
+
+    // The reason names the leaf, so the writer's warning says what it omitted.
+    #[test]
     fn a_csg_tree_and_a_point_cloud_are_rejected_rather_than_panicking() {
         let solid = || Solid::from_exterior(CoordinateFrame::Euclidean, quad_mesh_data());
-        for geometry in [
-            Geometry::Euclidean3D(Euclidean3DGeometry::Csg(Csg::union(solid(), solid()))),
-            Geometry::Euclidean3D(Euclidean3DGeometry::PointCloud(Box::new(
-                PointCloud::from_positions(CoordinateFrame::Euclidean, [[0.0, 0.0, 0.0]]),
-            ))),
+        for (geometry, reason) in [
+            (
+                Geometry::Euclidean3D(Euclidean3DGeometry::Csg(Csg::union(solid(), solid()))),
+                Unwritable::Csg,
+            ),
+            (
+                Geometry::Euclidean3D(Euclidean3DGeometry::PointCloud(Box::new(
+                    PointCloud::from_positions(CoordinateFrame::Euclidean, [[0.0, 0.0, 0.0]]),
+                ))),
+                Unwritable::PointCloud,
+            ),
         ] {
-            let result: Result<Vec<geojson::Feature>> = feature_with(geometry).try_into();
-            assert!(result.is_err());
+            assert_eq!(rejection(geometry), reason);
         }
+    }
+
+    // A reason becomes a message where it leaves the conversion.
+    #[test]
+    fn a_reason_reaches_the_caller_as_an_error() {
+        let feature = feature_with(Geometry::Euclidean3D(solid_in(CoordinateFrame::Euclidean)));
+
+        let result: Result<Vec<geojson::Feature>> = feature.try_into();
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Unsupported feature: a Solid has no GeoJSON counterpart"
+        );
     }
 
     // One member with no counterpart does not discard its siblings.
@@ -1426,9 +1654,44 @@ mod tests {
         );
     }
 
+    // Dropping every member leaves nothing to write, reported as the leaf case is —
+    // carrying the member's reason out — rather than passing with no features.
+    #[test]
+    fn a_collection_of_only_unwritable_members_is_rejected() {
+        for geometry in [
+            Geometry::Euclidean3D(Euclidean3DGeometry::Collection(Collection3D::new([
+                solid_in(CoordinateFrame::Euclidean),
+            ]))),
+            Geometry::GeometryCollection(GeometryCollection::new([Geometry::Euclidean3D(
+                solid_in(CoordinateFrame::Euclidean),
+            )])),
+        ] {
+            assert_eq!(rejection(geometry), Unwritable::Solid);
+        }
+    }
+
+    // An unwritable member writes no empty geometry of its own, and does not take
+    // its siblings with it.
+    #[test]
+    fn an_unwritable_member_of_a_geometry_collection_is_dropped() {
+        let geometry = Geometry::GeometryCollection(GeometryCollection::new([
+            Geometry::Euclidean3D(Euclidean3DGeometry::Collection(Collection3D::new([
+                solid_in(CoordinateFrame::Euclidean),
+            ]))),
+            point_2d_in(CoordinateFrame::Euclidean, [0.0, 0.0]),
+        ]));
+
+        let features = written(geometry);
+
+        assert_eq!(features.len(), 1);
+        assert_eq!(
+            features[0].geometry.as_ref().map(|g| &g.value),
+            Some(&geojson::Value::Point(vec![0.0, 0.0]))
+        );
+    }
+
     // --- features without geometry ---
 
-    // An attribute-only row survives as a feature with a null geometry.
     #[test]
     fn a_feature_without_geometry_writes_a_null_geometry() {
         let features = written(Geometry::None);
@@ -1459,6 +1722,21 @@ mod tests {
 
     // --- the CRS of what gets written ---
 
+    /// What the coordinates written for `features` are expressed in, accumulated
+    /// as a caller writing them all does it. A feature that writes nothing states
+    /// nothing about the CRS.
+    fn written_crs(features: &[Feature]) -> WrittenCrs {
+        features
+            .iter()
+            .map(|feature| {
+                write_feature(feature)
+                    .map(|written| written.frames)
+                    .unwrap_or_default()
+            })
+            .fold(WrittenFrames::default(), WrittenFrames::and)
+            .crs()
+    }
+
     #[test]
     fn written_crs_reports_the_shared_epsg_code() {
         let features = [
@@ -1488,6 +1766,19 @@ mod tests {
         );
     }
 
+    // Neither code covers what the `Euclidean` frame carries, so naming both would
+    // describe the file no better than naming none.
+    #[test]
+    fn written_crs_is_unknown_when_a_frame_names_no_crs_among_two_that_do() {
+        let features = [
+            feature_with(point_2d_in(crs(6675), [0.0; 2])),
+            feature_with(point_2d_in(CoordinateFrame::Euclidean, [1.0; 2])),
+            feature_with(point_2d_in(crs(6669), [2.0; 2])),
+        ];
+
+        assert_eq!(written_crs(&features), WrittenCrs::Unknown);
+    }
+
     #[test]
     fn written_crs_is_unknown_without_a_crs_frame() {
         let features = [
@@ -1498,7 +1789,7 @@ mod tests {
         assert_eq!(written_crs(&features), WrittenCrs::Unknown);
     }
 
-    // A leaf that is dropped names no CRS, so the answer describes exactly the
+    // A leaf that is dropped names no CRS, the answer describing exactly the
     // coordinates in the file.
     #[test]
     fn written_crs_ignores_geometry_that_is_not_written() {

--- a/engine/runtime/types/src/conversion/geojson_next.rs
+++ b/engine/runtime/types/src/conversion/geojson_next.rs
@@ -1,6 +1,11 @@
-//! GeoJSON -> `Feature` conversion for the new-geometry world. Builds
+//! GeoJSON <-> `Feature` conversion for the new-geometry world. Builds
 //! `reearth_flow_geometry::Geometry` (per-leaf `CoordinateFrame`) rather than the
 //! old `GeometryValue` wrapper.
+//!
+//! Both directions live here so the axis-order convention stays one invariant:
+//! GeoJSON positions are always `(easting/longitude, northing/latitude[, height])`,
+//! while a CRS frame stores its axes in the order the CRS authority declares, so
+//! reading swaps the horizontal pair and writing swaps it back.
 
 use std::sync::Arc;
 
@@ -9,6 +14,7 @@ use reearth_flow_geometry::{
     collection::{Collection2D, Collection3D},
     coordinate::{CoordinateFrame, EpsgCode},
     line_string::{LineString2D, LineString3D},
+    ops::Split,
     point::{Point2D, Point3D},
     polygon::{Polygon2D, Polygon3D},
     Euclidean2DGeometry, Euclidean3DGeometry, Geometry, GeometryCollection,
@@ -194,6 +200,413 @@ fn polygon_3d(rings: &[Vec<Vec<f64>>]) -> Polygon3D {
         .map(|r| r.iter().map(|c| [c[1], c[0], c[2]]).collect::<Vec<_>>());
     let exterior = rings.next().unwrap_or_default();
     Polygon3D::from_rings(wgs84_3d(), exterior, rings)
+}
+
+// ---------------------------------------------------------------------------
+// Feature -> GeoJSON
+// ---------------------------------------------------------------------------
+
+impl TryFrom<Feature> for Vec<geojson::Feature> {
+    type Error = Error;
+
+    fn try_from(feature: Feature) -> Result<Self> {
+        let properties = attributes_to_geojson_object(&feature.attributes);
+        let features = match &*feature.geometry {
+            // A feature carrying attributes but no geometry still produces a row.
+            Geometry::None => vec![geojson_feature(feature.id, None, properties)],
+            // A cross-dimensional, cross-frame collection has no single GeoJSON
+            // geometry, so each member becomes a feature of its own — as the old
+            // CityGML geometry did. The members share the feature's properties;
+            // per-member attributes stay on the member.
+            Geometry::GeometryCollection(collection) => collection
+                .members()
+                .iter()
+                .filter_map(geometry_to_value)
+                .map(|value| geojson_feature(uuid::Uuid::new_v4(), Some(value), properties.clone()))
+                .collect(),
+            geometry => {
+                let value = geometry_to_value(geometry).ok_or_else(|| {
+                    Error::unsupported_feature("geometry has no GeoJSON counterpart")
+                })?;
+                vec![geojson_feature(feature.id, Some(value), properties)]
+            }
+        };
+        Ok(features)
+    }
+}
+
+fn geojson_feature(
+    id: uuid::Uuid,
+    value: Option<geojson::Value>,
+    properties: geojson::JsonObject,
+) -> geojson::Feature {
+    geojson::Feature {
+        bbox: None,
+        geometry: value.map(geojson::Geometry::new),
+        id: Some(geojson::feature::Id::String(id.to_string())),
+        properties: Some(properties),
+        foreign_members: None,
+    }
+}
+
+fn attributes_to_geojson_object(attributes: &Attributes) -> geojson::JsonObject {
+    attributes
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.clone().into()))
+        .collect()
+}
+
+/// The GeoJSON counterpart of `geometry`, or `None` when it has none.
+///
+/// A leaf GeoJSON cannot express (`Solid`, `Csg`, `PointCloud`) is dropped where
+/// it appears rather than failing the geometry around it, so one such member does
+/// not discard its siblings.
+fn geometry_to_value(geometry: &Geometry) -> Option<geojson::Value> {
+    match geometry {
+        Geometry::None => None,
+        Geometry::Euclidean2D(g) => value_2d(g),
+        Geometry::Euclidean3D(g) => value_3d(g),
+        // Nested: only the outermost collection expands into separate features.
+        Geometry::GeometryCollection(c) => Some(geometry_collection(
+            c.members().iter().filter_map(geometry_to_value).collect(),
+        )),
+    }
+}
+
+fn value_2d(geometry: &Euclidean2DGeometry) -> Option<geojson::Value> {
+    match geometry {
+        Euclidean2DGeometry::Point(p) => Some(geojson::Value::Point(xy(
+            swaps_axes(p.frame()),
+            p.position(),
+        ))),
+        Euclidean2DGeometry::LineString(l) => {
+            let swap = swaps_axes(l.frame());
+            Some(geojson::Value::LineString(
+                l.coords().iter().map(|&c| xy(swap, c)).collect(),
+            ))
+        }
+        Euclidean2DGeometry::Polygon(p) => {
+            let swap = swaps_axes(p.frame());
+            Some(geojson::Value::Polygon(
+                std::iter::once(p.exterior())
+                    .chain(p.interiors())
+                    .map(|ring| closed_ring(ring.iter().map(|&c| xy(swap, c))))
+                    .collect(),
+            ))
+        }
+        Euclidean2DGeometry::PolygonMesh(m) => faces_to_multi_polygon((**m).clone()),
+        Euclidean2DGeometry::TriangularMesh(m) => faces_to_multi_polygon((**m).clone()),
+        Euclidean2DGeometry::Collection(c) => Some(combine(
+            c.members().iter().filter_map(value_2d).collect(),
+            one_frame(c.members(), visit_frames_2d),
+        )),
+    }
+}
+
+fn value_3d(geometry: &Euclidean3DGeometry) -> Option<geojson::Value> {
+    match geometry {
+        Euclidean3DGeometry::Point(p) => Some(geojson::Value::Point(xyz(
+            swaps_axes(p.frame()),
+            p.position(),
+        ))),
+        Euclidean3DGeometry::LineString(l) => {
+            let swap = swaps_axes(l.frame());
+            Some(geojson::Value::LineString(
+                l.coords().iter().map(|&c| xyz(swap, c)).collect(),
+            ))
+        }
+        Euclidean3DGeometry::Polygon(p) => {
+            let swap = swaps_axes(p.frame());
+            Some(geojson::Value::Polygon(
+                std::iter::once(p.exterior())
+                    .chain(p.interiors())
+                    .map(|ring| closed_ring(ring.iter().map(|&c| xyz(swap, c))))
+                    .collect(),
+            ))
+        }
+        Euclidean3DGeometry::PolygonMesh(m) => faces_to_multi_polygon((**m).clone()),
+        Euclidean3DGeometry::TriangularMesh(m) => faces_to_multi_polygon((**m).clone()),
+        Euclidean3DGeometry::Collection(c) => Some(combine(
+            c.members().iter().filter_map(value_3d).collect(),
+            one_frame(c.members(), visit_frames_3d),
+        )),
+        // A volume has no GeoJSON counterpart, and neither has the boolean tree
+        // built from volumes. A point cloud has one, but expanding it would emit
+        // a position per sample.
+        Euclidean3DGeometry::Solid(_) => unsupported_leaf("Solid"),
+        Euclidean3DGeometry::Csg(_) => unsupported_leaf("Csg"),
+        Euclidean3DGeometry::PointCloud(_) => unsupported_leaf("PointCloud"),
+    }
+}
+
+fn unsupported_leaf(kind: &'static str) -> Option<geojson::Value> {
+    tracing::warn!(
+        geometry = kind,
+        "geometry has no GeoJSON counterpart; omitting it"
+    );
+    None
+}
+
+/// One GeoJSON polygon per mesh face, via the public `Split` op. `Split` takes
+/// `&mut self`, hence the mesh is passed by value; splitting a mesh reads it
+/// rather than emptying it.
+fn faces_to_multi_polygon(mut mesh: impl Split) -> Option<geojson::Value> {
+    let mut polygons = Vec::new();
+    mesh.split(&mut |face, _| {
+        if let Some(geojson::Value::Polygon(rings)) = geometry_to_value(&face) {
+            polygons.push(rings);
+        }
+    })
+    .ok()?;
+    Some(geojson::Value::MultiPolygon(polygons))
+}
+
+/// Present a collection's members as one GeoJSON geometry: a `Multi*` when they
+/// are all of one kind and share a coordinate frame, a `GeometryCollection`
+/// otherwise.
+///
+/// `Collection2D` / `Collection3D` are the new geometry's `Multi*`, so folding is
+/// the inverse of the `MultiPolygon -> Collection` mapping on the read side.
+/// Folding members that differ in frame would put coordinates from different
+/// reference systems in one geometry, which no single `crs` member can describe.
+fn combine(values: Vec<geojson::Value>, uniform_frame: bool) -> geojson::Value {
+    if !uniform_frame {
+        return geometry_collection(values);
+    }
+    match fold_into_multi(values) {
+        Ok(folded) => folded,
+        Err(values) => geometry_collection(values),
+    }
+}
+
+fn geometry_collection(values: Vec<geojson::Value>) -> geojson::Value {
+    geojson::Value::GeometryCollection(values.into_iter().map(geojson::Geometry::new).collect())
+}
+
+/// Fold values that are all points, all curves, or all areas into the matching
+/// `Multi*`, handing them back untouched when they are of more than one kind.
+/// A member that is already a `Multi*` is flattened into the result.
+fn fold_into_multi(values: Vec<geojson::Value>) -> Result<geojson::Value, Vec<geojson::Value>> {
+    let Some(kind) = values.first().and_then(value_kind) else {
+        return Err(values);
+    };
+    if !values.iter().all(|v| value_kind(v) == Some(kind)) {
+        return Err(values);
+    }
+    Ok(match kind {
+        ValueKind::Point => geojson::Value::MultiPoint(
+            values
+                .into_iter()
+                .flat_map(|v| match v {
+                    geojson::Value::Point(p) => vec![p],
+                    geojson::Value::MultiPoint(ps) => ps,
+                    _ => Vec::new(),
+                })
+                .collect(),
+        ),
+        ValueKind::Curve => geojson::Value::MultiLineString(
+            values
+                .into_iter()
+                .flat_map(|v| match v {
+                    geojson::Value::LineString(l) => vec![l],
+                    geojson::Value::MultiLineString(ls) => ls,
+                    _ => Vec::new(),
+                })
+                .collect(),
+        ),
+        ValueKind::Area => geojson::Value::MultiPolygon(
+            values
+                .into_iter()
+                .flat_map(|v| match v {
+                    geojson::Value::Polygon(p) => vec![p],
+                    geojson::Value::MultiPolygon(ps) => ps,
+                    _ => Vec::new(),
+                })
+                .collect(),
+        ),
+    })
+}
+
+/// The `Multi*` family a value belongs to; `None` for a `GeometryCollection`,
+/// which has no `Multi*` form to fold into.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ValueKind {
+    Point,
+    Curve,
+    Area,
+}
+
+fn value_kind(value: &geojson::Value) -> Option<ValueKind> {
+    match value {
+        geojson::Value::Point(_) | geojson::Value::MultiPoint(_) => Some(ValueKind::Point),
+        geojson::Value::LineString(_) | geojson::Value::MultiLineString(_) => {
+            Some(ValueKind::Curve)
+        }
+        geojson::Value::Polygon(_) | geojson::Value::MultiPolygon(_) => Some(ValueKind::Area),
+        geojson::Value::GeometryCollection(_) => None,
+    }
+}
+
+// GeoJSON positions are `(easting/longitude, northing/latitude[, height])`
+// whatever the CRS declares: RFC 7946 section 3.1.1 fixes that order even for the
+// alternative reference systems its section 4 allows by prior arrangement, and
+// GeoJSON 2008 — the dialect the `crs` member this writer emits comes from —
+// states that a CRS shall not change coordinate ordering.
+
+/// Whether a frame stores its horizontal axes reflected from canonical
+/// `(East, North)` order, so that they must be swapped on the way out. A frame
+/// whose order cannot be established is written as stored.
+fn swaps_axes(frame: &CoordinateFrame) -> bool {
+    frame.orientation_sign().is_ok_and(|sign| sign < 0)
+}
+
+fn xy(swap: bool, [x, y]: [f64; 2]) -> Vec<f64> {
+    if swap {
+        vec![y, x]
+    } else {
+        vec![x, y]
+    }
+}
+
+fn xyz(swap: bool, [x, y, z]: [f64; 3]) -> Vec<f64> {
+    if swap {
+        vec![y, x, z]
+    } else {
+        vec![x, y, z]
+    }
+}
+
+/// GeoJSON requires a ring's first and last positions to be equal. The stored
+/// rings carry no such guarantee, so an open one is closed on the way out.
+fn closed_ring(positions: impl Iterator<Item = Vec<f64>>) -> Vec<Vec<f64>> {
+    let mut ring: Vec<Vec<f64>> = positions.collect();
+    let open = match (ring.first(), ring.last()) {
+        (Some(first), Some(last)) => first != last,
+        _ => false,
+    };
+    if open {
+        let first = ring[0].clone();
+        ring.push(first);
+    }
+    ring
+}
+
+// ---------------------------------------------------------------------------
+// Coordinate frames of what gets written
+// ---------------------------------------------------------------------------
+
+/// Which coordinate reference system the coordinates written for a set of
+/// features share. Reported by [`written_crs`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WrittenCrs {
+    /// Every written coordinate is expressed in this one CRS.
+    Single(EpsgCode),
+    /// Written coordinates are expressed in more than one CRS.
+    Mixed { first: EpsgCode, other: EpsgCode },
+    /// No single CRS covers what is written: some frame is not a CRS at all
+    /// (`Euclidean`, or a `Tangent` plane whose in-plane coordinates are not its
+    /// base CRS's), or nothing carrying coordinates is written.
+    Unknown,
+}
+
+/// The CRS the coordinates written for `features` are expressed in.
+///
+/// Only leaves that reach the output are counted, so the answer describes exactly
+/// the coordinates in the file — a `Solid` that is dropped contributes no CRS.
+pub fn written_crs(features: &[Feature]) -> WrittenCrs {
+    let mut single: Option<EpsgCode> = None;
+    let mut mixed: Option<(EpsgCode, EpsgCode)> = None;
+    let mut non_crs = false;
+
+    for feature in features {
+        visit_frames(&feature.geometry, &mut |frame| {
+            let CoordinateFrame::Crs(code) = frame else {
+                non_crs = true;
+                return;
+            };
+            match single {
+                None => single = Some(*code),
+                Some(seen) if seen != *code => {
+                    mixed.get_or_insert((seen, *code));
+                }
+                Some(_) => {}
+            }
+        });
+    }
+
+    match (mixed, single) {
+        (Some((first, other)), _) => WrittenCrs::Mixed { first, other },
+        (None, Some(code)) if !non_crs => WrittenCrs::Single(code),
+        _ => WrittenCrs::Unknown,
+    }
+}
+
+/// Visit the coordinate frame of every leaf that reaches the GeoJSON output, in
+/// order. Leaves with no GeoJSON counterpart contribute nothing, matching what
+/// [`geometry_to_value`] writes.
+fn visit_frames<'a>(geometry: &'a Geometry, visit: &mut dyn FnMut(&'a CoordinateFrame)) {
+    match geometry {
+        Geometry::None => {}
+        Geometry::Euclidean2D(g) => visit_frames_2d(g, visit),
+        Geometry::Euclidean3D(g) => visit_frames_3d(g, visit),
+        Geometry::GeometryCollection(c) => {
+            for member in c.members() {
+                visit_frames(member, visit);
+            }
+        }
+    }
+}
+
+fn visit_frames_2d<'a>(
+    geometry: &'a Euclidean2DGeometry,
+    visit: &mut dyn FnMut(&'a CoordinateFrame),
+) {
+    match geometry {
+        Euclidean2DGeometry::Point(p) => visit(p.frame()),
+        Euclidean2DGeometry::LineString(l) => visit(l.frame()),
+        Euclidean2DGeometry::Polygon(p) => visit(p.frame()),
+        Euclidean2DGeometry::PolygonMesh(m) => visit(m.frame()),
+        Euclidean2DGeometry::TriangularMesh(m) => visit(m.frame()),
+        Euclidean2DGeometry::Collection(c) => {
+            for member in c.members() {
+                visit_frames_2d(member, visit);
+            }
+        }
+    }
+}
+
+fn visit_frames_3d<'a>(
+    geometry: &'a Euclidean3DGeometry,
+    visit: &mut dyn FnMut(&'a CoordinateFrame),
+) {
+    match geometry {
+        Euclidean3DGeometry::Point(p) => visit(p.frame()),
+        Euclidean3DGeometry::LineString(l) => visit(l.frame()),
+        Euclidean3DGeometry::Polygon(p) => visit(p.frame()),
+        Euclidean3DGeometry::PolygonMesh(m) => visit(m.frame()),
+        Euclidean3DGeometry::TriangularMesh(m) => visit(m.frame()),
+        Euclidean3DGeometry::Collection(c) => {
+            for member in c.members() {
+                visit_frames_3d(member, visit);
+            }
+        }
+        // Nothing of these reaches the output, so they name no frame.
+        Euclidean3DGeometry::Solid(_)
+        | Euclidean3DGeometry::Csg(_)
+        | Euclidean3DGeometry::PointCloud(_) => {}
+    }
+}
+
+/// Whether every written leaf under `members` shares one coordinate frame.
+fn one_frame<'a, T>(
+    members: &'a [T],
+    visit_frames: fn(&'a T, &mut dyn FnMut(&'a CoordinateFrame)),
+) -> bool {
+    let mut frames: Vec<&CoordinateFrame> = Vec::new();
+    for member in members {
+        visit_frames(member, &mut |frame| frames.push(frame));
+    }
+    frames.windows(2).all(|pair| pair[0] == pair[1])
 }
 
 #[cfg(test)]
@@ -572,5 +985,632 @@ mod tests {
         let feature: Feature = gj.try_into().unwrap();
 
         assert_eq!(feature.id, uuid::Uuid::parse_str(id).unwrap());
+    }
+
+    // -----------------------------------------------------------------------
+    // Feature -> GeoJSON
+    // -----------------------------------------------------------------------
+
+    use reearth_flow_geometry::{
+        csg::Csg,
+        point_cloud::PointCloud,
+        polygon_mesh::{PolygonMesh3D, PolygonMesh3DData},
+        solid::Solid,
+        triangular_mesh::{TriangularMesh2D, TriangularMesh3D},
+    };
+
+    fn feature_with(geometry: Geometry) -> Feature {
+        Feature::new_with_attributes_and_geometry(Attributes::new(), geometry)
+    }
+
+    fn written(geometry: Geometry) -> Vec<geojson::Feature> {
+        feature_with(geometry).try_into().unwrap()
+    }
+
+    /// The single GeoJSON geometry `geometry` writes to.
+    fn written_value(geometry: Geometry) -> geojson::Value {
+        let mut features = written(geometry);
+        assert_eq!(features.len(), 1, "expected exactly one GeoJSON feature");
+        features
+            .remove(0)
+            .geometry
+            .expect("geometry expected")
+            .value
+    }
+
+    fn point_2d_in(frame: CoordinateFrame, position: [f64; 2]) -> Geometry {
+        Geometry::Euclidean2D(Euclidean2DGeometry::Point(Point2D::new(frame, position)))
+    }
+
+    fn polygon_2d_in(frame: CoordinateFrame, ring: Vec<[f64; 2]>) -> Euclidean2DGeometry {
+        Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings(
+            frame,
+            ring,
+            std::iter::empty::<Vec<[f64; 2]>>(),
+        )))
+    }
+
+    fn triangle_mesh_3d(frame: CoordinateFrame) -> TriangularMesh3D {
+        TriangularMesh3D::from_parts(
+            frame,
+            vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            [0u32, 1, 2],
+        )
+        .unwrap()
+    }
+
+    fn quad_mesh_data() -> PolygonMesh3DData {
+        PolygonMesh3DData::from_parts(
+            vec![
+                [0.0, 0.0, 0.0],
+                [2.0, 0.0, 0.0],
+                [2.0, 2.0, 0.0],
+                [0.0, 2.0, 0.0],
+            ],
+            vec![vec![0u32, 1, 2, 3]],
+        )
+        .unwrap()
+    }
+
+    // --- axis order ---
+
+    // EPSG:4326 declares (lat, lon), so the stored pair is swapped back to the
+    // (lon, lat) GeoJSON always uses.
+    #[test]
+    fn north_first_geographic_crs_swaps_the_horizontal_pair() {
+        let value = written_value(point_2d_in(crs(4326), [35.6, 139.7]));
+
+        assert_eq!(value, geojson::Value::Point(vec![139.7, 35.6]));
+    }
+
+    // EPSG:6675 declares (northing, easting): the same swap applies to a
+    // projected CRS, matching the quality-check error GeoJSON files.
+    #[test]
+    fn north_first_projected_crs_swaps_the_horizontal_pair() {
+        let value = written_value(point_2d_in(crs(6675), [71805.43, -10191.37]));
+
+        assert_eq!(value, geojson::Value::Point(vec![-10191.37, 71805.43]));
+    }
+
+    // EPSG:3857 is already (easting, northing).
+    #[test]
+    fn east_first_crs_is_written_as_stored() {
+        let value = written_value(point_2d_in(crs(3857), [1.0, 2.0]));
+
+        assert_eq!(value, geojson::Value::Point(vec![1.0, 2.0]));
+    }
+
+    #[test]
+    fn euclidean_frame_is_written_as_stored() {
+        let value = written_value(point_2d_in(CoordinateFrame::Euclidean, [1.0, 2.0]));
+
+        assert_eq!(value, geojson::Value::Point(vec![1.0, 2.0]));
+    }
+
+    // z is carried through unchanged; only the horizontal pair is reordered.
+    #[test]
+    fn a_3d_point_keeps_its_height() {
+        let value = written_value(Geometry::Euclidean3D(Euclidean3DGeometry::Point(
+            Point3D::new(crs(4979), [35.6, 139.7, 12.5]),
+        )));
+
+        assert_eq!(value, geojson::Value::Point(vec![139.7, 35.6, 12.5]));
+    }
+
+    // A 2.5D leaf's single elevation is not written: the old world's 2D geometry
+    // was two-element too.
+    #[test]
+    fn a_2d_line_string_at_an_elevation_is_written_without_it() {
+        let value = written_value(Geometry::Euclidean2D(Euclidean2DGeometry::LineString(
+            LineString2D::from_coords_at_elevation(
+                CoordinateFrame::Euclidean,
+                [[0.0, 0.0], [2.0, 1.0]],
+                5.0,
+            ),
+        )));
+
+        assert_eq!(
+            value,
+            geojson::Value::LineString(vec![vec![0.0, 0.0], vec![2.0, 1.0]])
+        );
+    }
+
+    // --- rings ---
+
+    #[test]
+    fn a_polygon_writes_its_exterior_then_its_holes() {
+        let polygon = Polygon2D::from_rings(
+            CoordinateFrame::Euclidean,
+            [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 0.0]],
+            [[[1.0, 1.0], [2.0, 1.0], [1.0, 2.0], [1.0, 1.0]]],
+        );
+
+        let value = written_value(Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(
+            Box::new(polygon),
+        )));
+
+        assert_eq!(
+            value,
+            geojson::Value::Polygon(vec![
+                vec![
+                    vec![0.0, 0.0],
+                    vec![4.0, 0.0],
+                    vec![4.0, 4.0],
+                    vec![0.0, 0.0]
+                ],
+                vec![
+                    vec![1.0, 1.0],
+                    vec![2.0, 1.0],
+                    vec![1.0, 2.0],
+                    vec![1.0, 1.0]
+                ],
+            ])
+        );
+    }
+
+    // Stored rings carry no closure guarantee, but GeoJSON requires one.
+    #[test]
+    fn an_open_ring_is_closed_on_the_way_out() {
+        let polygon = Polygon2D::from_rings(
+            CoordinateFrame::Euclidean,
+            [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0]],
+            std::iter::empty::<Vec<[f64; 2]>>(),
+        );
+
+        let value = written_value(Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(
+            Box::new(polygon),
+        )));
+
+        assert_eq!(
+            value,
+            geojson::Value::Polygon(vec![vec![
+                vec![0.0, 0.0],
+                vec![4.0, 0.0],
+                vec![4.0, 4.0],
+                vec![0.0, 0.0],
+            ]])
+        );
+    }
+
+    // --- collections ---
+
+    #[test]
+    fn a_collection_of_polygons_folds_into_a_multi_polygon() {
+        let collection = Collection2D::new([
+            polygon_2d_in(
+                CoordinateFrame::Euclidean,
+                vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 0.0]],
+            ),
+            polygon_2d_in(
+                CoordinateFrame::Euclidean,
+                vec![[2.0, 2.0], [3.0, 2.0], [2.0, 3.0], [2.0, 2.0]],
+            ),
+        ]);
+
+        let value = written_value(Geometry::Euclidean2D(Euclidean2DGeometry::Collection(
+            collection,
+        )));
+
+        assert!(
+            matches!(&value, geojson::Value::MultiPolygon(polygons) if polygons.len() == 2),
+            "got: {value:?}"
+        );
+    }
+
+    #[test]
+    fn a_collection_of_points_folds_into_a_multi_point() {
+        let collection = Collection2D::new([
+            Euclidean2DGeometry::Point(Point2D::new(CoordinateFrame::Euclidean, [0.0, 0.0])),
+            Euclidean2DGeometry::Point(Point2D::new(CoordinateFrame::Euclidean, [1.0, 1.0])),
+        ]);
+
+        let value = written_value(Geometry::Euclidean2D(Euclidean2DGeometry::Collection(
+            collection,
+        )));
+
+        assert_eq!(
+            value,
+            geojson::Value::MultiPoint(vec![vec![0.0, 0.0], vec![1.0, 1.0]])
+        );
+    }
+
+    // Members of different kinds have no common `Multi*`.
+    #[test]
+    fn a_collection_of_mixed_kinds_becomes_a_geometry_collection() {
+        let collection = Collection2D::new([
+            Euclidean2DGeometry::Point(Point2D::new(CoordinateFrame::Euclidean, [0.0, 0.0])),
+            polygon_2d_in(
+                CoordinateFrame::Euclidean,
+                vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 0.0]],
+            ),
+        ]);
+
+        let value = written_value(Geometry::Euclidean2D(Euclidean2DGeometry::Collection(
+            collection,
+        )));
+
+        assert!(
+            matches!(&value, geojson::Value::GeometryCollection(members) if members.len() == 2),
+            "got: {value:?}"
+        );
+    }
+
+    // Folding members that differ in frame would put coordinates from two
+    // reference systems in one geometry, which one `crs` member cannot describe.
+    #[test]
+    fn a_collection_of_mixed_frames_becomes_a_geometry_collection() {
+        let collection = Collection2D::new([
+            Euclidean2DGeometry::Point(Point2D::new(crs(3857), [0.0, 0.0])),
+            Euclidean2DGeometry::Point(Point2D::new(CoordinateFrame::Euclidean, [1.0, 1.0])),
+        ]);
+
+        let value = written_value(Geometry::Euclidean2D(Euclidean2DGeometry::Collection(
+            collection,
+        )));
+
+        assert!(
+            matches!(&value, geojson::Value::GeometryCollection(members) if members.len() == 2),
+            "got: {value:?}"
+        );
+    }
+
+    // A cross-dimensional collection has no single GeoJSON geometry, so its
+    // members become features of their own, sharing the feature's properties.
+    #[test]
+    fn a_geometry_collection_expands_into_one_feature_per_member() {
+        let mut attributes = Attributes::new();
+        attributes.insert(
+            Attribute::new("name"),
+            AttributeValue::String("bldg-1".to_string()),
+        );
+        let geometry = Geometry::GeometryCollection(GeometryCollection::new([
+            point_2d_in(CoordinateFrame::Euclidean, [0.0, 0.0]),
+            Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
+                CoordinateFrame::Euclidean,
+                [1.0, 1.0, 1.0],
+            ))),
+        ]));
+
+        let features: Vec<geojson::Feature> =
+            Feature::new_with_attributes_and_geometry(attributes, geometry)
+                .try_into()
+                .unwrap();
+
+        assert_eq!(features.len(), 2);
+        assert_eq!(
+            features[0].geometry.as_ref().map(|g| &g.value),
+            Some(&geojson::Value::Point(vec![0.0, 0.0]))
+        );
+        assert_eq!(
+            features[1].geometry.as_ref().map(|g| &g.value),
+            Some(&geojson::Value::Point(vec![1.0, 1.0, 1.0]))
+        );
+        for feature in &features {
+            assert_eq!(feature.properties.as_ref().unwrap()["name"], "bldg-1");
+        }
+        assert_ne!(features[0].id, features[1].id);
+    }
+
+    // Only the outermost collection expands; a nested one stays a geometry.
+    #[test]
+    fn a_nested_geometry_collection_stays_one_geojson_geometry() {
+        let inner = Geometry::GeometryCollection(GeometryCollection::new([point_2d_in(
+            CoordinateFrame::Euclidean,
+            [3.0, 4.0],
+        )]));
+        let geometry = Geometry::GeometryCollection(GeometryCollection::new([inner]));
+
+        let value = written_value(geometry);
+
+        assert_eq!(
+            value,
+            geojson::Value::GeometryCollection(vec![geojson::Geometry::new(
+                geojson::Value::Point(vec![3.0, 4.0])
+            )])
+        );
+    }
+
+    // --- meshes ---
+
+    // A mesh has no GeoJSON counterpart of its own, so its faces are written.
+    #[test]
+    fn a_polygon_mesh_writes_one_polygon_per_face() {
+        let mesh = PolygonMesh3D::new(CoordinateFrame::Euclidean, quad_mesh_data());
+
+        let value = written_value(Geometry::Euclidean3D(Euclidean3DGeometry::PolygonMesh(
+            Box::new(mesh),
+        )));
+
+        assert_eq!(
+            value,
+            geojson::Value::MultiPolygon(vec![vec![vec![
+                vec![0.0, 0.0, 0.0],
+                vec![2.0, 0.0, 0.0],
+                vec![2.0, 2.0, 0.0],
+                vec![0.0, 2.0, 0.0],
+                vec![0.0, 0.0, 0.0],
+            ]]])
+        );
+    }
+
+    #[test]
+    fn a_triangular_mesh_writes_one_polygon_per_triangle() {
+        let value = written_value(Geometry::Euclidean3D(Euclidean3DGeometry::TriangularMesh(
+            Box::new(triangle_mesh_3d(CoordinateFrame::Euclidean)),
+        )));
+
+        assert_eq!(
+            value,
+            geojson::Value::MultiPolygon(vec![vec![vec![
+                vec![0.0, 0.0, 0.0],
+                vec![1.0, 0.0, 0.0],
+                vec![0.0, 1.0, 0.0],
+                vec![0.0, 0.0, 0.0],
+            ]]])
+        );
+    }
+
+    // Splitting reads the mesh; the geometry it was taken from is left intact.
+    #[test]
+    fn writing_a_mesh_leaves_the_geometry_unchanged() {
+        let geometry = Geometry::Euclidean2D(Euclidean2DGeometry::TriangularMesh(Box::new(
+            TriangularMesh2D::from_parts(
+                CoordinateFrame::Euclidean,
+                vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
+                [0u32, 1, 2],
+            )
+            .unwrap(),
+        )));
+        let feature = feature_with(geometry.clone());
+
+        let _: Vec<geojson::Feature> = feature.clone().try_into().unwrap();
+
+        assert_eq!(*feature.geometry, geometry);
+    }
+
+    // --- geometries with no GeoJSON counterpart ---
+
+    #[test]
+    fn a_solid_is_rejected_rather_than_panicking() {
+        let solid = Solid::from_exterior(CoordinateFrame::Euclidean, quad_mesh_data());
+        let feature = feature_with(Geometry::Euclidean3D(Euclidean3DGeometry::Solid(Box::new(
+            solid,
+        ))));
+
+        let result: Result<Vec<geojson::Feature>> = feature.try_into();
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn a_csg_tree_and_a_point_cloud_are_rejected_rather_than_panicking() {
+        let solid = || Solid::from_exterior(CoordinateFrame::Euclidean, quad_mesh_data());
+        for geometry in [
+            Geometry::Euclidean3D(Euclidean3DGeometry::Csg(Csg::union(solid(), solid()))),
+            Geometry::Euclidean3D(Euclidean3DGeometry::PointCloud(Box::new(
+                PointCloud::from_positions(CoordinateFrame::Euclidean, [[0.0, 0.0, 0.0]]),
+            ))),
+        ] {
+            let result: Result<Vec<geojson::Feature>> = feature_with(geometry).try_into();
+            assert!(result.is_err());
+        }
+    }
+
+    // One member with no counterpart does not discard its siblings.
+    #[test]
+    fn a_solid_among_polygons_is_dropped_and_the_rest_survive() {
+        let collection = Collection3D::new([
+            Euclidean3DGeometry::Solid(Box::new(Solid::from_exterior(
+                CoordinateFrame::Euclidean,
+                quad_mesh_data(),
+            ))),
+            Euclidean3DGeometry::Polygon(Box::new(Polygon3D::from_rings(
+                CoordinateFrame::Euclidean,
+                [
+                    [0.0, 0.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0],
+                    [0.0, 0.0, 0.0],
+                ],
+                std::iter::empty::<Vec<[f64; 3]>>(),
+            ))),
+        ]);
+
+        let value = written_value(Geometry::Euclidean3D(Euclidean3DGeometry::Collection(
+            collection,
+        )));
+
+        assert!(
+            matches!(&value, geojson::Value::MultiPolygon(polygons) if polygons.len() == 1),
+            "got: {value:?}"
+        );
+    }
+
+    // --- features without geometry ---
+
+    // An attribute-only row survives as a feature with a null geometry.
+    #[test]
+    fn a_feature_without_geometry_writes_a_null_geometry() {
+        let features = written(Geometry::None);
+
+        assert_eq!(features.len(), 1);
+        assert!(features[0].geometry.is_none());
+    }
+
+    #[test]
+    fn attributes_and_id_carry_over() {
+        let mut attributes = Attributes::new();
+        attributes.insert(
+            Attribute::new("city"),
+            AttributeValue::String("Tokyo".to_string()),
+        );
+        let feature =
+            Feature::new_with_attributes_and_geometry(attributes, point_2d_in(crs(3857), [0.0; 2]));
+        let id = feature.id;
+
+        let features: Vec<geojson::Feature> = feature.try_into().unwrap();
+
+        assert_eq!(features[0].properties.as_ref().unwrap()["city"], "Tokyo");
+        assert_eq!(
+            features[0].id,
+            Some(geojson::feature::Id::String(id.to_string()))
+        );
+    }
+
+    // --- the CRS of what gets written ---
+
+    #[test]
+    fn written_crs_reports_the_shared_epsg_code() {
+        let features = [
+            feature_with(point_2d_in(crs(6675), [0.0; 2])),
+            feature_with(point_2d_in(crs(6675), [1.0; 2])),
+        ];
+
+        assert_eq!(
+            written_crs(&features),
+            WrittenCrs::Single(EpsgCode::new(6675))
+        );
+    }
+
+    #[test]
+    fn written_crs_reports_differing_epsg_codes() {
+        let features = [
+            feature_with(point_2d_in(crs(6675), [0.0; 2])),
+            feature_with(point_2d_in(crs(6669), [1.0; 2])),
+        ];
+
+        assert_eq!(
+            written_crs(&features),
+            WrittenCrs::Mixed {
+                first: EpsgCode::new(6675),
+                other: EpsgCode::new(6669),
+            }
+        );
+    }
+
+    #[test]
+    fn written_crs_is_unknown_without_a_crs_frame() {
+        let features = [
+            feature_with(point_2d_in(CoordinateFrame::Euclidean, [0.0; 2])),
+            feature_with(Geometry::None),
+        ];
+
+        assert_eq!(written_crs(&features), WrittenCrs::Unknown);
+    }
+
+    // A leaf that is dropped names no CRS, so the answer describes exactly the
+    // coordinates in the file.
+    #[test]
+    fn written_crs_ignores_geometry_that_is_not_written() {
+        let features = [feature_with(Geometry::Euclidean3D(
+            Euclidean3DGeometry::Solid(Box::new(Solid::from_exterior(
+                CoordinateFrame::Crs(EpsgCode::new(6675)),
+                quad_mesh_data(),
+            ))),
+        ))];
+
+        assert_eq!(written_crs(&features), WrittenCrs::Unknown);
+    }
+
+    // --- round trips ---
+
+    // Reading then writing returns the GeoJSON that was read: the axis swap on
+    // the way in is undone on the way out.
+    #[test]
+    fn reading_then_writing_returns_the_original_geometry() {
+        let values = [
+            geojson::Value::Point(vec![139.7, 35.6]),
+            geojson::Value::Point(vec![139.7, 35.6, 12.5]),
+            geojson::Value::LineString(vec![vec![0.0, 0.0], vec![1.0, 2.0]]),
+            geojson::Value::Polygon(vec![
+                vec![
+                    vec![0.0, 0.0],
+                    vec![4.0, 0.0],
+                    vec![4.0, 4.0],
+                    vec![0.0, 0.0],
+                ],
+                vec![
+                    vec![1.0, 1.0],
+                    vec![2.0, 1.0],
+                    vec![1.0, 2.0],
+                    vec![1.0, 1.0],
+                ],
+            ]),
+            geojson::Value::MultiPoint(vec![vec![0.0, 0.0], vec![1.0, 1.0]]),
+            geojson::Value::MultiLineString(vec![
+                vec![vec![0.0, 0.0], vec![1.0, 1.0]],
+                vec![vec![2.0, 2.0], vec![3.0, 3.0]],
+            ]),
+            geojson::Value::MultiPolygon(vec![vec![vec![
+                vec![0.0, 0.0],
+                vec![1.0, 0.0],
+                vec![0.0, 1.0],
+                vec![0.0, 0.0],
+            ]]]),
+        ];
+
+        for value in values {
+            let feature: Feature = geojson_feature(value.clone()).try_into().unwrap();
+            assert_eq!(written_value((*feature.geometry).clone()), value);
+        }
+    }
+
+    // The one asymmetry: a top-level GeometryCollection is read as one feature
+    // and written back as one feature per member, so what round-trips is the
+    // set of member geometries rather than the collection.
+    #[test]
+    fn a_geometry_collection_round_trips_as_its_members() {
+        let members = vec![
+            geojson::Geometry::new(geojson::Value::Point(vec![3.0, 4.0])),
+            geojson::Geometry::new(geojson::Value::Point(vec![5.0, 6.0, 7.0])),
+        ];
+        let feature: Feature = geojson_feature(geojson::Value::GeometryCollection(members.clone()))
+            .try_into()
+            .unwrap();
+
+        let written: Vec<geojson::Feature> = feature.try_into().unwrap();
+
+        let values: Vec<_> = written
+            .into_iter()
+            .map(|f| f.geometry.expect("geometry expected").value)
+            .collect();
+        assert_eq!(
+            values,
+            members.into_iter().map(|g| g.value).collect::<Vec<_>>()
+        );
+    }
+
+    // The quality-check error GeoJSON files declare EPSG:6675 and carry easting
+    // first. New-geometry workflow tests do not run, so the shape those files
+    // depend on is pinned here.
+    #[test]
+    fn quality_check_error_geometry_keeps_its_stored_coordinates() {
+        // As stored in EPSG:6675's declared (northing, easting) order.
+        let ring = vec![
+            [71805.43986040869, -10191.374874677815],
+            [71804.88506036208, -10191.375533456288],
+            [71804.88452953615, -10190.928471234001],
+            [71805.43932955855, -10190.927812483467],
+            [71805.43986040869, -10191.374874677815],
+        ];
+        let collection = Collection2D::new([polygon_2d_in(crs(6675), ring)]);
+        let feature = feature_with(Geometry::Euclidean2D(Euclidean2DGeometry::Collection(
+            collection,
+        )));
+
+        assert_eq!(
+            written_crs(std::slice::from_ref(&feature)),
+            WrittenCrs::Single(EpsgCode::new(6675))
+        );
+        assert_eq!(
+            written_value((*feature.geometry).clone()),
+            geojson::Value::MultiPolygon(vec![vec![vec![
+                vec![-10191.374874677815, 71805.43986040869],
+                vec![-10191.375533456288, 71804.88506036208],
+                vec![-10190.928471234001, 71804.88452953615],
+                vec![-10190.927812483467, 71805.43932955855],
+                vec![-10191.374874677815, 71805.43986040869],
+            ]]])
+        );
     }
 }

--- a/engine/runtime/types/src/conversion/geojson_next.rs
+++ b/engine/runtime/types/src/conversion/geojson_next.rs
@@ -27,6 +27,8 @@ use crate::{
     Attribute, Attributes, Feature,
 };
 
+pub use super::geojson_shared::{CrsCoverage, WrittenFeature};
+
 // WGS84 geographic CRS codes, defined here so this new-geometry module carries no
 // dependency on nusamai-projection (which is slated for removal after the migration).
 const EPSG_WGS84_GEOGRAPHIC_2D: u16 = 4326;
@@ -208,8 +210,9 @@ fn polygon_3d(rings: &[Vec<Vec<f64>>]) -> Polygon3D {
 // Feature -> GeoJSON
 // ---------------------------------------------------------------------------
 //
-// Writing is one recursive map, `&Geometry -> Result<Written, Unwritable>`: a
-// geometry either writes to a `Written` or names the reason it cannot be written.
+// Writing is one recursive map, `&Geometry -> Result<WrittenGeometry, Unwritable>`:
+// a geometry either writes to a `WrittenGeometry` or names the reason it cannot be
+// written.
 
 impl TryFrom<Feature> for Vec<geojson::Feature> {
     type Error = Error;
@@ -217,17 +220,6 @@ impl TryFrom<Feature> for Vec<geojson::Feature> {
     fn try_from(feature: Feature) -> Result<Self> {
         write_feature(&feature).map(|written| written.features)
     }
-}
-
-/// What a feature writes to: the GeoJSON features it becomes, and the coordinate
-/// frames their positions came from.
-///
-/// The frames come out of the same pass as the features, so a caller that has to
-/// declare the CRS of what it wrote reads it off here instead of writing every
-/// geometry a second time to recover it.
-pub struct WrittenFeature {
-    pub features: Vec<geojson::Feature>,
-    pub frames: WrittenFrames,
 }
 
 /// What `feature` writes to as GeoJSON.
@@ -238,7 +230,7 @@ pub fn write_feature(feature: &Feature) -> Result<WrittenFeature> {
         // stating nothing about the CRS.
         Geometry::None => Ok(WrittenFeature {
             features: vec![geojson_feature(feature.id, None, properties)],
-            frames: WrittenFrames::default(),
+            crs: CrsCoverage::NoCoordinates,
         }),
         // A cross-dimensional, cross-frame collection has no single GeoJSON
         // geometry, so each member becomes a feature of its own — as the old
@@ -250,7 +242,7 @@ pub fn write_feature(feature: &Feature) -> Result<WrittenFeature> {
                 Unwritable::EmptyCollection,
             )?;
             warn_omitted(&parts.omitted);
-            let mut frames = Frames::default();
+            let mut frames = Frames::Nothing;
             let mut features = Vec::with_capacity(parts.written.len());
             for member in parts.written {
                 frames = frames.and(member.frames);
@@ -262,7 +254,7 @@ pub fn write_feature(feature: &Feature) -> Result<WrittenFeature> {
             }
             Ok(WrittenFeature {
                 features,
-                frames: WrittenFrames(frames),
+                crs: frames.coverage(),
             })
         }
         geometry => {
@@ -270,7 +262,7 @@ pub fn write_feature(feature: &Feature) -> Result<WrittenFeature> {
             warn_omitted(&written.omitted);
             Ok(WrittenFeature {
                 features: vec![geojson_feature(feature.id, Some(written.value), properties)],
-                frames: WrittenFrames(written.frames),
+                crs: written.frames.coverage(),
             })
         }
     }
@@ -329,7 +321,6 @@ enum Unwritable {
     Unsplittable(#[from] UnsupportedOperation),
 }
 
-/// A reason becomes a message here, where the writer's error reaches its caller.
 impl From<Unwritable> for Error {
     fn from(reason: Unwritable) -> Self {
         Error::unsupported_feature(reason)
@@ -351,13 +342,13 @@ fn warn_omitted(omitted: &[Unwritable]) {
 /// to re-walk the geometry to recover them. Carrying the reasons rather than
 /// logging them where a part is dropped also keeps the recursion a pure map, the
 /// whole geometry's omissions being reported once it is written.
-struct Written {
+struct WrittenGeometry {
     value: geojson::Value,
     frames: Frames,
     omitted: Vec<Unwritable>,
 }
 
-impl Written {
+impl WrittenGeometry {
     /// What a leaf writes to: one value, in one frame, leaving nothing out.
     fn leaf(frame: &CoordinateFrame, value: geojson::Value) -> Self {
         Self {
@@ -369,7 +360,7 @@ impl Written {
 }
 
 /// What `geometry` writes to, or the reason it cannot be written.
-fn write_geometry(geometry: &Geometry) -> Result<Written, Unwritable> {
+fn write_geometry(geometry: &Geometry) -> Result<WrittenGeometry, Unwritable> {
     match geometry {
         Geometry::None => Err(Unwritable::AbsentGeometry),
         Geometry::Euclidean2D(g) => write_2d(g),
@@ -384,32 +375,32 @@ fn write_geometry(geometry: &Geometry) -> Result<Written, Unwritable> {
     }
 }
 
-fn write_2d(geometry: &Euclidean2DGeometry) -> Result<Written, Unwritable> {
-    use Euclidean2DGeometry as G;
+fn write_2d(geometry: &Euclidean2DGeometry) -> Result<WrittenGeometry, Unwritable> {
+    use Euclidean2DGeometry::*;
     match geometry {
-        G::Point(p) => Ok(point(p.frame(), p.position())),
-        G::LineString(l) => Ok(curve(l.frame(), l.coords())),
-        G::Polygon(p) => Ok(area(p.frame(), p.exterior(), p.interiors())),
-        G::PolygonMesh(m) => write_faces((**m).clone()),
-        G::TriangularMesh(m) => write_faces((**m).clone()),
-        G::Collection(c) => Parts::of(c.members(), write_2d, Unwritable::EmptyCollection)
+        Point(p) => Ok(point(p.frame(), p.position())),
+        LineString(l) => Ok(curve(l.frame(), l.coords())),
+        Polygon(p) => Ok(area(p.frame(), p.exterior(), p.interiors())),
+        PolygonMesh(m) => write_faces((**m).clone()),
+        TriangularMesh(m) => write_faces((**m).clone()),
+        Collection(c) => Parts::of(c.members(), write_2d, Unwritable::EmptyCollection)
             .map(Parts::into_one_geometry),
     }
 }
 
-fn write_3d(geometry: &Euclidean3DGeometry) -> Result<Written, Unwritable> {
-    use Euclidean3DGeometry as G;
+fn write_3d(geometry: &Euclidean3DGeometry) -> Result<WrittenGeometry, Unwritable> {
+    use Euclidean3DGeometry::*;
     match geometry {
-        G::Point(p) => Ok(point(p.frame(), p.position())),
-        G::LineString(l) => Ok(curve(l.frame(), l.coords())),
-        G::Polygon(p) => Ok(area(p.frame(), p.exterior(), p.interiors())),
-        G::PolygonMesh(m) => write_faces((**m).clone()),
-        G::TriangularMesh(m) => write_faces((**m).clone()),
-        G::Collection(c) => Parts::of(c.members(), write_3d, Unwritable::EmptyCollection)
+        Point(p) => Ok(point(p.frame(), p.position())),
+        LineString(l) => Ok(curve(l.frame(), l.coords())),
+        Polygon(p) => Ok(area(p.frame(), p.exterior(), p.interiors())),
+        PolygonMesh(m) => write_faces((**m).clone()),
+        TriangularMesh(m) => write_faces((**m).clone()),
+        Collection(c) => Parts::of(c.members(), write_3d, Unwritable::EmptyCollection)
             .map(Parts::into_one_geometry),
-        G::Solid(_) => Err(Unwritable::Solid),
-        G::Csg(_) => Err(Unwritable::Csg),
-        G::PointCloud(_) => Err(Unwritable::PointCloud),
+        Solid(_) => Err(Unwritable::Solid),
+        Csg(_) => Err(Unwritable::Csg),
+        PointCloud(_) => Err(Unwritable::PointCloud),
     }
 }
 
@@ -419,7 +410,7 @@ fn write_3d(geometry: &Euclidean3DGeometry) -> Result<Written, Unwritable> {
 /// The `Split` op that yields the faces takes `&mut self`, hence the mesh is passed
 /// by value; splitting reads it rather than emptying it, so the geometry it came
 /// from is left intact.
-fn write_faces(mut mesh: impl Split) -> Result<Written, Unwritable> {
+fn write_faces(mut mesh: impl Split) -> Result<WrittenGeometry, Unwritable> {
     let mut faces = Vec::new();
     mesh.split(&mut |face, _| faces.push(face))?;
     Parts::of(&faces, write_geometry, Unwritable::EmptyMesh).map(Parts::into_one_geometry)
@@ -430,7 +421,7 @@ fn write_faces(mut mesh: impl Split) -> Result<Written, Unwritable> {
 struct Parts {
     /// Non-empty: a container with no writable part cannot be written either,
     /// which [`Parts::of`] reports as an error instead.
-    written: Vec<Written>,
+    written: Vec<WrittenGeometry>,
     omitted: Vec<Unwritable>,
 }
 
@@ -446,10 +437,10 @@ impl Parts {
     /// be written once at the top, or `empty` when there were no parts to drop.
     fn of<T>(
         parts: &[T],
-        write: impl Fn(&T) -> Result<Written, Unwritable>,
+        write: impl Fn(&T) -> Result<WrittenGeometry, Unwritable>,
         empty: Unwritable,
     ) -> Result<Self, Unwritable> {
-        let (mut written, mut omitted): (Vec<Written>, Vec<Unwritable>) =
+        let (mut written, mut omitted): (Vec<WrittenGeometry>, Vec<Unwritable>) =
             parts.iter().map(write).partition_result();
         if written.is_empty() {
             return Err(omitted.first().copied().unwrap_or(empty));
@@ -468,7 +459,7 @@ impl Parts {
     /// Parts that differ in frame are not folded: that would put coordinates from
     /// different reference systems in one geometry, which no single `crs` member
     /// describes.
-    fn into_one_geometry(self) -> Written {
+    fn into_one_geometry(self) -> WrittenGeometry {
         self.present(|values, frames| match ValueKind::uniform(&values) {
             Some(kind) if frames.uniform() => kind.fold(values),
             _ => geometry_collection(values),
@@ -476,7 +467,7 @@ impl Parts {
     }
 
     /// The parts as one GeoJSON `GeometryCollection`, whatever they are.
-    fn into_geometry_collection(self) -> Written {
+    fn into_geometry_collection(self) -> WrittenGeometry {
         self.present(|values, _| geometry_collection(values))
     }
 
@@ -485,14 +476,14 @@ impl Parts {
     fn present(
         self,
         present: impl FnOnce(Vec<geojson::Value>, &Frames) -> geojson::Value,
-    ) -> Written {
+    ) -> WrittenGeometry {
         let (values, frames): (Vec<_>, Vec<_>) = self
             .written
             .into_iter()
             .map(|part| (part.value, part.frames))
             .unzip();
-        let frames = frames.into_iter().fold(Frames::default(), Frames::and);
-        Written {
+        let frames = frames.into_iter().fold(Frames::Nothing, Frames::and);
+        WrittenGeometry {
             value: present(values, &frames),
             frames,
             omitted: self.omitted,
@@ -580,16 +571,16 @@ impl ValueKind {
 // The 2D and 3D leaves differ only in how long a position is, so what turns one
 // into GeoJSON is written once, over `N`-element positions.
 
-fn point<const N: usize>(frame: &CoordinateFrame, position: [f64; N]) -> Written {
-    Written::leaf(
+fn point<const N: usize>(frame: &CoordinateFrame, position: [f64; N]) -> WrittenGeometry {
+    WrittenGeometry::leaf(
         frame,
         geojson::Value::Point(coordinates(swaps_axes(frame), position)),
     )
 }
 
-fn curve<const N: usize>(frame: &CoordinateFrame, coords: &[[f64; N]]) -> Written {
+fn curve<const N: usize>(frame: &CoordinateFrame, coords: &[[f64; N]]) -> WrittenGeometry {
     let swap = swaps_axes(frame);
-    Written::leaf(
+    WrittenGeometry::leaf(
         frame,
         geojson::Value::LineString(coords.iter().map(|&c| coordinates(swap, c)).collect()),
     )
@@ -600,9 +591,9 @@ fn area<'a, const N: usize>(
     frame: &CoordinateFrame,
     exterior: &'a [[f64; N]],
     interiors: impl Iterator<Item = &'a [[f64; N]]>,
-) -> Written {
+) -> WrittenGeometry {
     let swap = swaps_axes(frame);
-    Written::leaf(
+    WrittenGeometry::leaf(
         frame,
         geojson::Value::Polygon(
             std::iter::once(exterior)
@@ -688,110 +679,71 @@ fn warn_unresolved_axis_order(code: EpsgCode, error: impl std::fmt::Display) {
 /// The coordinate frames the positions written for a geometry came from: the
 /// first one, and the first one after it that differs.
 ///
-/// Decides whether written parts may fold into a `Multi*`, and is what
-/// [`WrittenFrames`] carries out to the caller of a write.
-#[derive(Clone, Debug, Default, PartialEq)]
-struct Frames {
-    /// `None` only for the frames of nothing at all: the identity of
-    /// [`Frames::and`].
-    first: Option<CoordinateFrame>,
-    differing: Option<CoordinateFrame>,
+/// Decides whether written parts may fold into a `Multi*` — which needs frame
+/// identity, two `Euclidean` parts folding even though neither names a CRS — and
+/// answers what the write was expressed in as a [`CrsCoverage`].
+#[derive(Clone, Debug, PartialEq)]
+enum Frames {
+    /// Nothing carrying coordinates was written: the identity of [`Frames::and`].
+    Nothing,
+    One(CoordinateFrame),
+    Mixed {
+        first: CoordinateFrame,
+        other: CoordinateFrame,
+    },
 }
 
 impl Frames {
     /// The frames of a leaf: one.
     fn of(frame: &CoordinateFrame) -> Self {
-        Self {
-            first: Some(frame.clone()),
-            differing: None,
-        }
+        Self::One(frame.clone())
     }
 
-    /// The frames of two written parts, together.
+    /// The frames of two written parts, together. Keeps the first frame written
+    /// and the first one after it that differs; further frames add nothing, two
+    /// already ruling out both folding and a single CRS.
     fn and(self, other: Self) -> Self {
-        let Some(first) = self.first else {
-            return other;
-        };
-        let Self {
-            first: other_first,
-            differing: other_differing,
-        } = other;
-        Self {
-            differing: self
-                .differing
-                .or_else(|| other_first.filter(|frame| *frame != first))
-                .or(other_differing),
-            first: Some(first),
+        match (self, other) {
+            (Self::Nothing, frames) | (frames, Self::Nothing) => frames,
+            (mixed @ Self::Mixed { .. }, _) => mixed,
+            (Self::One(first), Self::Mixed { first: a, other: b }) => {
+                let other = if first == a { b } else { a };
+                Self::Mixed { first, other }
+            }
+            (Self::One(first), Self::One(other)) if first != other => Self::Mixed { first, other },
+            (one @ Self::One(_), Self::One(_)) => one,
         }
     }
 
     /// Whether one frame covers every written position.
     fn uniform(&self) -> bool {
-        self.first.is_some() && self.differing.is_none()
+        matches!(self, Self::One(_))
     }
 
-    /// Which CRS the written positions are expressed in.
-    fn crs(&self) -> WrittenCrs {
-        let Some(first) = self.first.as_ref().and_then(epsg_code) else {
-            return WrittenCrs::Unknown;
-        };
-        match self.differing.as_ref() {
-            None => WrittenCrs::Single(first),
-            // Coordinates outside any CRS leave the CRS unstated rather than
-            // mixed: the code the others carry does not cover them either.
-            Some(other) => epsg_code(other).map_or(WrittenCrs::Unknown, |other| {
-                WrittenCrs::Mixed { first, other }
-            }),
+    /// How far one CRS covers the written positions.
+    fn coverage(&self) -> CrsCoverage {
+        match self {
+            Self::Nothing => CrsCoverage::NoCoordinates,
+            Self::One(frame) => match epsg_code(frame) {
+                Some(code) => CrsCoverage::Single(code),
+                None => CrsCoverage::OutsideAnyCrs,
+            },
+            Self::Mixed { first, other } => match (epsg_code(first), epsg_code(other)) {
+                (Some(first), Some(other)) => CrsCoverage::Mixed { first, other },
+                // A frame naming no CRS is not covered by the code the other
+                // carries, so no code covers the pair.
+                _ => CrsCoverage::OutsideAnyCrs,
+            },
         }
     }
 }
 
-/// The EPSG code a frame names, if it names one.
+/// The EPSG code a frame names, if it names one. `Euclidean` names none, and a
+/// `Tangent` plane's in-plane coordinates are not its base CRS's.
 fn epsg_code(frame: &CoordinateFrame) -> Option<EpsgCode> {
     match frame {
         CoordinateFrame::Crs(code) => Some(*code),
         CoordinateFrame::Euclidean | CoordinateFrame::Tangent(_) => None,
-    }
-}
-
-/// Which coordinate reference system the coordinates written for a set of
-/// features share. Reported by [`WrittenFrames::crs`].
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum WrittenCrs {
-    /// Every written coordinate is expressed in this one CRS.
-    Single(EpsgCode),
-    /// Written coordinates are expressed in more than one CRS.
-    Mixed { first: EpsgCode, other: EpsgCode },
-    /// No single CRS covers what is written: some frame is not a CRS at all
-    /// (`Euclidean`, or a `Tangent` plane whose in-plane coordinates are not its
-    /// base CRS's), or nothing carrying coordinates is written.
-    Unknown,
-}
-
-/// What the coordinates written for one or more features are expressed in, as a
-/// caller writing them accumulates it.
-///
-/// Opaque: a caller combines what each write hands back with [`and`](Self::and)
-/// and asks the result for its CRS, so the rule deciding whether one CRS covers a
-/// set of coordinates stays in one place. Since it is read off what the writer
-/// produces, the answer describes exactly the coordinates in the file — a dropped
-/// `Solid` contributes no CRS.
-///
-/// [`default`](Default::default) is what nothing written says: the identity of
-/// `and`, distinct from a written coordinate whose frame names no CRS even though
-/// both report [`WrittenCrs::Unknown`].
-#[derive(Clone, Debug, Default, PartialEq)]
-pub struct WrittenFrames(Frames);
-
-impl WrittenFrames {
-    /// What two writes, together, were expressed in.
-    pub fn and(self, other: Self) -> Self {
-        Self(self.0.and(other.0))
-    }
-
-    /// The CRS covering every coordinate accumulated so far.
-    pub fn crs(&self) -> WrittenCrs {
-        self.0.crs()
     }
 }
 
@@ -1722,44 +1674,43 @@ mod tests {
 
     // --- the CRS of what gets written ---
 
-    /// What the coordinates written for `features` are expressed in, accumulated
-    /// as a caller writing them all does it. A feature that writes nothing states
-    /// nothing about the CRS.
-    fn written_crs(features: &[Feature]) -> WrittenCrs {
+    /// How far one CRS covers the coordinates written for `features`, accumulated
+    /// as a caller writing them all does it. A feature that writes nothing
+    /// contributes no coordinates.
+    fn coverage(features: &[Feature]) -> CrsCoverage {
         features
             .iter()
             .map(|feature| {
                 write_feature(feature)
-                    .map(|written| written.frames)
+                    .map(|written| written.crs)
                     .unwrap_or_default()
             })
-            .fold(WrittenFrames::default(), WrittenFrames::and)
-            .crs()
+            .fold(CrsCoverage::default(), CrsCoverage::and)
     }
 
     #[test]
-    fn written_crs_reports_the_shared_epsg_code() {
+    fn coverage_reports_the_shared_epsg_code() {
         let features = [
             feature_with(point_2d_in(crs(6675), [0.0; 2])),
             feature_with(point_2d_in(crs(6675), [1.0; 2])),
         ];
 
         assert_eq!(
-            written_crs(&features),
-            WrittenCrs::Single(EpsgCode::new(6675))
+            coverage(&features),
+            CrsCoverage::Single(EpsgCode::new(6675))
         );
     }
 
     #[test]
-    fn written_crs_reports_differing_epsg_codes() {
+    fn coverage_reports_differing_epsg_codes() {
         let features = [
             feature_with(point_2d_in(crs(6675), [0.0; 2])),
             feature_with(point_2d_in(crs(6669), [1.0; 2])),
         ];
 
         assert_eq!(
-            written_crs(&features),
-            WrittenCrs::Mixed {
+            coverage(&features),
+            CrsCoverage::Mixed {
                 first: EpsgCode::new(6675),
                 other: EpsgCode::new(6669),
             }
@@ -1769,30 +1720,30 @@ mod tests {
     // Neither code covers what the `Euclidean` frame carries, so naming both would
     // describe the file no better than naming none.
     #[test]
-    fn written_crs_is_unknown_when_a_frame_names_no_crs_among_two_that_do() {
+    fn coverage_breaks_when_a_frame_names_no_crs_among_two_that_do() {
         let features = [
             feature_with(point_2d_in(crs(6675), [0.0; 2])),
             feature_with(point_2d_in(CoordinateFrame::Euclidean, [1.0; 2])),
             feature_with(point_2d_in(crs(6669), [2.0; 2])),
         ];
 
-        assert_eq!(written_crs(&features), WrittenCrs::Unknown);
+        assert_eq!(coverage(&features), CrsCoverage::OutsideAnyCrs);
     }
 
     #[test]
-    fn written_crs_is_unknown_without_a_crs_frame() {
+    fn coverage_breaks_without_a_crs_frame() {
         let features = [
             feature_with(point_2d_in(CoordinateFrame::Euclidean, [0.0; 2])),
             feature_with(Geometry::None),
         ];
 
-        assert_eq!(written_crs(&features), WrittenCrs::Unknown);
+        assert_eq!(coverage(&features), CrsCoverage::OutsideAnyCrs);
     }
 
-    // A leaf that is dropped names no CRS, the answer describing exactly the
-    // coordinates in the file.
+    // A geometry that is dropped contributes no coordinates, the answer describing
+    // exactly what is in the file — here nothing, rather than a CRS-less write.
     #[test]
-    fn written_crs_ignores_geometry_that_is_not_written() {
+    fn coverage_ignores_geometry_that_is_not_written() {
         let features = [feature_with(Geometry::Euclidean3D(
             Euclidean3DGeometry::Solid(Box::new(Solid::from_exterior(
                 CoordinateFrame::Crs(EpsgCode::new(6675)),
@@ -1800,7 +1751,22 @@ mod tests {
             ))),
         ))];
 
-        assert_eq!(written_crs(&features), WrittenCrs::Unknown);
+        assert_eq!(coverage(&features), CrsCoverage::NoCoordinates);
+    }
+
+    // A feature with attributes but no geometry writes a row, which says nothing
+    // about the CRS rather than breaking the coverage of its neighbours.
+    #[test]
+    fn coverage_survives_a_feature_without_geometry() {
+        let features = [
+            feature_with(point_2d_in(crs(6675), [0.0; 2])),
+            feature_with(Geometry::None),
+        ];
+
+        assert_eq!(
+            coverage(&features),
+            CrsCoverage::Single(EpsgCode::new(6675))
+        );
     }
 
     // --- round trips ---
@@ -1890,8 +1856,8 @@ mod tests {
         )));
 
         assert_eq!(
-            written_crs(std::slice::from_ref(&feature)),
-            WrittenCrs::Single(EpsgCode::new(6675))
+            coverage(std::slice::from_ref(&feature)),
+            CrsCoverage::Single(EpsgCode::new(6675))
         );
         assert_eq!(
             written_value((*feature.geometry).clone()),

--- a/engine/runtime/types/src/conversion/geojson_next.rs
+++ b/engine/runtime/types/src/conversion/geojson_next.rs
@@ -222,7 +222,10 @@ impl TryFrom<Feature> for Vec<geojson::Feature> {
     }
 }
 
-/// What `feature` writes to as GeoJSON.
+/// What `feature` writes to as GeoJSON: one feature, keeping its id and
+/// attributes, inverting the read. Unlike the old world's writer, a
+/// `GeometryCollection` stays one feature rather than expanding into one per
+/// member.
 pub fn write_feature(feature: &Feature) -> Result<WrittenFeature> {
     let properties = attributes_to_geojson_object(&feature.attributes);
     match &*feature.geometry {
@@ -232,31 +235,6 @@ pub fn write_feature(feature: &Feature) -> Result<WrittenFeature> {
             features: vec![geojson_feature(feature.id, None, properties)],
             crs: CrsCoverage::NoCoordinates,
         }),
-        // A cross-dimensional, cross-frame collection has no single GeoJSON
-        // geometry, so each member becomes a feature of its own — as the old
-        // CityGML geometry did — sharing the feature's properties.
-        Geometry::GeometryCollection(collection) => {
-            let parts = Parts::of(
-                collection.members(),
-                write_geometry,
-                Unwritable::EmptyCollection,
-            )?;
-            warn_omitted(&parts.omitted);
-            let mut frames = Frames::Nothing;
-            let mut features = Vec::with_capacity(parts.written.len());
-            for member in parts.written {
-                frames = frames.and(member.frames);
-                features.push(geojson_feature(
-                    uuid::Uuid::new_v4(),
-                    Some(member.value),
-                    properties.clone(),
-                ));
-            }
-            Ok(WrittenFeature {
-                features,
-                crs: frames.coverage(),
-            })
-        }
         geometry => {
             let written = write_geometry(geometry)?;
             warn_omitted(&written.omitted);
@@ -365,9 +343,9 @@ fn write_geometry(geometry: &Geometry) -> Result<WrittenGeometry, Unwritable> {
         Geometry::None => Err(Unwritable::AbsentGeometry),
         Geometry::Euclidean2D(g) => write_2d(g),
         Geometry::Euclidean3D(g) => write_3d(g),
-        // Only the outermost collection expands into separate features; a nested
-        // one stays a GeoJSON `GeometryCollection` whatever its members are, being
-        // the cross-dimensional, cross-frame container no `Multi*` describes.
+        // A collection stays a GeoJSON `GeometryCollection` whatever its members
+        // are, being the cross-dimensional, cross-frame container no `Multi*`
+        // describes.
         Geometry::GeometryCollection(c) => {
             Parts::of(c.members(), write_geometry, Unwritable::EmptyCollection)
                 .map(Parts::into_geometry_collection)
@@ -1409,9 +1387,10 @@ mod tests {
         );
     }
 
-    // Members become features of their own, sharing the feature's properties.
+    // A collection writes as one feature holding a GeoJSON `GeometryCollection`,
+    // keeping the feature's id and attributes, whatever its members are.
     #[test]
-    fn a_geometry_collection_expands_into_one_feature_per_member() {
+    fn a_geometry_collection_writes_one_feature_holding_all_its_members() {
         let mut attributes = Attributes::new();
         attributes.insert(
             Attribute::new("name"),
@@ -1424,30 +1403,30 @@ mod tests {
                 [1.0, 1.0, 1.0],
             ))),
         ]));
+        let feature = Feature::new_with_attributes_and_geometry(attributes, geometry);
+        let id = feature.id;
 
-        let features: Vec<geojson::Feature> =
-            Feature::new_with_attributes_and_geometry(attributes, geometry)
-                .try_into()
-                .unwrap();
+        let features: Vec<geojson::Feature> = feature.try_into().unwrap();
 
-        assert_eq!(features.len(), 2);
+        assert_eq!(features.len(), 1);
         assert_eq!(
             features[0].geometry.as_ref().map(|g| &g.value),
-            Some(&geojson::Value::Point(vec![0.0, 0.0]))
+            Some(&geojson::Value::GeometryCollection(vec![
+                geojson::Geometry::new(geojson::Value::Point(vec![0.0, 0.0])),
+                geojson::Geometry::new(geojson::Value::Point(vec![1.0, 1.0, 1.0])),
+            ]))
         );
+        assert_eq!(features[0].properties.as_ref().unwrap()["name"], "bldg-1");
         assert_eq!(
-            features[1].geometry.as_ref().map(|g| &g.value),
-            Some(&geojson::Value::Point(vec![1.0, 1.0, 1.0]))
+            features[0].id,
+            Some(geojson::feature::Id::String(id.to_string()))
         );
-        for feature in &features {
-            assert_eq!(feature.properties.as_ref().unwrap()["name"], "bldg-1");
-        }
-        assert_ne!(features[0].id, features[1].id);
     }
 
-    // Only the outermost collection expands; a nested one stays a geometry.
+    // Nesting is kept as it is stored, the members of an inner collection not
+    // being lifted into the outer one.
     #[test]
-    fn a_nested_geometry_collection_stays_one_geojson_geometry() {
+    fn a_nested_geometry_collection_stays_nested() {
         let inner = Geometry::GeometryCollection(GeometryCollection::new([point_2d_in(
             CoordinateFrame::Euclidean,
             [3.0, 4.0],
@@ -1459,7 +1438,9 @@ mod tests {
         assert_eq!(
             value,
             geojson::Value::GeometryCollection(vec![geojson::Geometry::new(
-                geojson::Value::Point(vec![3.0, 4.0])
+                geojson::Value::GeometryCollection(vec![geojson::Geometry::new(
+                    geojson::Value::Point(vec![3.0, 4.0])
+                )])
             )])
         );
     }
@@ -1622,6 +1603,17 @@ mod tests {
         }
     }
 
+    // Nor does a collection with no member at all write an empty geometry.
+    #[test]
+    fn a_collection_with_no_member_is_rejected() {
+        for geometry in [
+            Geometry::Euclidean2D(Euclidean2DGeometry::Collection(Collection2D::new([]))),
+            Geometry::GeometryCollection(GeometryCollection::new([])),
+        ] {
+            assert_eq!(rejection(geometry), Unwritable::EmptyCollection);
+        }
+    }
+
     // An unwritable member writes no empty geometry of its own, and does not take
     // its siblings with it.
     #[test]
@@ -1633,12 +1625,13 @@ mod tests {
             point_2d_in(CoordinateFrame::Euclidean, [0.0, 0.0]),
         ]));
 
-        let features = written(geometry);
+        let value = written_value(geometry);
 
-        assert_eq!(features.len(), 1);
         assert_eq!(
-            features[0].geometry.as_ref().map(|g| &g.value),
-            Some(&geojson::Value::Point(vec![0.0, 0.0]))
+            value,
+            geojson::Value::GeometryCollection(vec![geojson::Geometry::new(
+                geojson::Value::Point(vec![0.0, 0.0])
+            )])
         );
     }
 
@@ -1769,6 +1762,33 @@ mod tests {
         );
     }
 
+    // The coverage describes every coordinate a feature writes, so a collection
+    // written as one feature answers what its members answer between them —
+    // whether they agree on a CRS or not.
+    #[test]
+    fn coverage_reaches_into_a_geometry_collection() {
+        let shared = feature_with(Geometry::GeometryCollection(GeometryCollection::new([
+            point_2d_in(crs(6675), [0.0; 2]),
+            point_2d_in(crs(6675), [1.0; 2]),
+        ])));
+        let mixed = feature_with(Geometry::GeometryCollection(GeometryCollection::new([
+            point_2d_in(crs(6675), [0.0; 2]),
+            point_2d_in(crs(6669), [1.0; 2]),
+        ])));
+
+        assert_eq!(
+            coverage(std::slice::from_ref(&shared)),
+            CrsCoverage::Single(EpsgCode::new(6675))
+        );
+        assert_eq!(
+            coverage(std::slice::from_ref(&mixed)),
+            CrsCoverage::Mixed {
+                first: EpsgCode::new(6675),
+                other: EpsgCode::new(6669),
+            }
+        );
+    }
+
     // --- round trips ---
 
     // Reading then writing returns the GeoJSON that was read: the axis swap on
@@ -1804,6 +1824,18 @@ mod tests {
                 vec![0.0, 1.0],
                 vec![0.0, 0.0],
             ]]]),
+            // Cross-dimensional members, and a nested collection: neither the
+            // members nor the nesting is flattened on the way through.
+            geojson::Value::GeometryCollection(vec![
+                geojson::Geometry::new(geojson::Value::Point(vec![3.0, 4.0])),
+                geojson::Geometry::new(geojson::Value::Point(vec![5.0, 6.0, 7.0])),
+                geojson::Geometry::new(geojson::Value::GeometryCollection(vec![
+                    geojson::Geometry::new(geojson::Value::LineString(vec![
+                        vec![0.0, 0.0],
+                        vec![1.0, 2.0],
+                    ])),
+                ])),
+            ]),
         ];
 
         for value in values {
@@ -1812,29 +1844,23 @@ mod tests {
         }
     }
 
-    // The one asymmetry: a top-level GeometryCollection is read as one feature
-    // and written back as one feature per member, so what round-trips is the
-    // set of member geometries rather than the collection.
+    // A feature keeps its id through a round trip, a GeometryCollection included:
+    // one GeoJSON feature is read as one `Feature` and written back as one.
     #[test]
-    fn a_geometry_collection_round_trips_as_its_members() {
-        let members = vec![
+    fn reading_then_writing_keeps_the_feature_and_its_id() {
+        let id = "550e8400-e29b-41d4-a716-446655440000";
+        let mut gj = geojson_feature(geojson::Value::GeometryCollection(vec![
             geojson::Geometry::new(geojson::Value::Point(vec![3.0, 4.0])),
             geojson::Geometry::new(geojson::Value::Point(vec![5.0, 6.0, 7.0])),
-        ];
-        let feature: Feature = geojson_feature(geojson::Value::GeometryCollection(members.clone()))
-            .try_into()
-            .unwrap();
+        ]));
+        gj.id = Some(geojson::feature::Id::String(id.to_string()));
+        let feature: Feature = gj.clone().try_into().unwrap();
 
         let written: Vec<geojson::Feature> = feature.try_into().unwrap();
 
-        let values: Vec<_> = written
-            .into_iter()
-            .map(|f| f.geometry.expect("geometry expected").value)
-            .collect();
-        assert_eq!(
-            values,
-            members.into_iter().map(|g| g.value).collect::<Vec<_>>()
-        );
+        assert_eq!(written.len(), 1);
+        assert_eq!(written[0].geometry, gj.geometry);
+        assert_eq!(written[0].id, gj.id);
     }
 
     // The quality-check error GeoJSON files declare EPSG:6675 and carry easting

--- a/engine/runtime/types/src/conversion/geojson_shared.rs
+++ b/engine/runtime/types/src/conversion/geojson_shared.rs
@@ -1,0 +1,127 @@
+//! What writing a `Feature` as GeoJSON returns, in the form both geometry worlds
+//! share, so a caller writes one code path whatever `Feature::geometry` is.
+//!
+//! Re-exported from `conversion::geojson` in both worlds; the module exists only
+//! while there are two of them, and folds into the surviving one afterwards.
+
+use std::fmt;
+
+use reearth_flow_geometry::coordinate::EpsgCode;
+
+/// What one feature writes to: the GeoJSON features it becomes, and what the
+/// coordinates they carry are expressed in.
+///
+/// The coverage comes out of the same pass as the features, so a caller that has
+/// to declare the CRS of what it wrote reads it off here instead of walking every
+/// geometry a second time to recover it.
+pub struct WrittenFeature {
+    pub features: Vec<geojson::Feature>,
+    pub crs: CrsCoverage,
+}
+
+/// How far one coordinate reference system covers the coordinates written so far.
+///
+/// A GeoJSON `FeatureCollection` can name one CRS for all of its coordinates or
+/// none, so a caller writing that member needs to know whether a single code
+/// covers them. Since the coverage is accumulated as the coordinates are written,
+/// it describes exactly what reached the file: a geometry the writer dropped
+/// contributes nothing.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum CrsCoverage {
+    /// Nothing carrying coordinates has been written: the identity of
+    /// [`and`](Self::and), and distinct from coordinates that name no CRS.
+    #[default]
+    NoCoordinates,
+    /// Every written coordinate is expressed in this one CRS.
+    Single(EpsgCode),
+    /// Written coordinates are expressed in more than one CRS.
+    Mixed { first: EpsgCode, other: EpsgCode },
+    /// A written coordinate is expressed outside any CRS, so no code covers the
+    /// rest either.
+    OutsideAnyCrs,
+}
+
+impl CrsCoverage {
+    /// The coverage of two writes, together. Associative, with
+    /// [`NoCoordinates`](Self::NoCoordinates) as its identity, so a caller folds
+    /// over features in any grouping and gets the same answer.
+    pub fn and(self, other: Self) -> Self {
+        use CrsCoverage::*;
+        match (self, other) {
+            // A coordinate outside every CRS is not covered by the code the
+            // others carry, so nothing covers the whole.
+            (OutsideAnyCrs, _) | (_, OutsideAnyCrs) => OutsideAnyCrs,
+            (NoCoordinates, coverage) | (coverage, NoCoordinates) => coverage,
+            // Two codes already name the mixture; further ones add nothing.
+            (mixed @ Mixed { .. }, _) => mixed,
+            (Single(first), Mixed { first: a, other: b }) => Mixed {
+                first,
+                other: if first == a { b } else { a },
+            },
+            (Single(first), Single(other)) if first != other => Mixed { first, other },
+            (single @ Single(_), Single(_)) => single,
+        }
+    }
+}
+
+impl fmt::Display for CrsCoverage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoCoordinates => write!(f, "no coordinate was written"),
+            Self::Single(code) => write!(f, "every written coordinate is in EPSG:{code}"),
+            Self::Mixed { first, other } => write!(
+                f,
+                "written coordinates are in both EPSG:{first} and EPSG:{other}"
+            ),
+            Self::OutsideAnyCrs => write!(f, "a written coordinate is outside any CRS"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn epsg(code: u16) -> EpsgCode {
+        EpsgCode::new(code)
+    }
+
+    // Accumulating over features: nothing written, then one code, then the same
+    // code again, then a second one, after which further codes add nothing.
+    #[test]
+    fn accumulating_narrows_to_one_code_and_then_to_a_mixture() {
+        let mut coverage = CrsCoverage::default();
+        assert_eq!(coverage, CrsCoverage::NoCoordinates);
+
+        coverage = coverage.and(CrsCoverage::Single(epsg(6675)));
+        assert_eq!(coverage, CrsCoverage::Single(epsg(6675)));
+
+        coverage = coverage.and(CrsCoverage::Single(epsg(6675)));
+        assert_eq!(coverage, CrsCoverage::Single(epsg(6675)));
+
+        // A feature writing no coordinates says nothing about the CRS.
+        coverage = coverage.and(CrsCoverage::NoCoordinates);
+        assert_eq!(coverage, CrsCoverage::Single(epsg(6675)));
+
+        let mixed = CrsCoverage::Mixed {
+            first: epsg(6675),
+            other: epsg(6669),
+        };
+        coverage = coverage.and(CrsCoverage::Single(epsg(6669)));
+        assert_eq!(coverage, mixed);
+
+        coverage = coverage.and(CrsCoverage::Single(epsg(3857)));
+        assert_eq!(coverage, mixed);
+    }
+
+    // Coordinates outside any CRS are not covered by the code the others carry, so
+    // they leave the whole uncovered whatever is folded in afterwards.
+    #[test]
+    fn coordinates_outside_any_crs_leave_nothing_covered() {
+        let mut coverage = CrsCoverage::Single(epsg(6675)).and(CrsCoverage::OutsideAnyCrs);
+        assert_eq!(coverage, CrsCoverage::OutsideAnyCrs);
+
+        coverage = coverage.and(CrsCoverage::Single(epsg(6675)));
+        assert_eq!(coverage, CrsCoverage::OutsideAnyCrs);
+    }
+}

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -3974,6 +3974,12 @@
                 "type": "string"
               }
             }
+          },
+          "writeCrs": {
+            "title": "Write CRS",
+            "description": "Whether to declare the coordinate reference system of the written coordinates in a legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates are not WGS84 longitude / latitude and the consumer reads that member.",
+            "default": false,
+            "type": "boolean"
           }
         }
       },
@@ -5135,6 +5141,12 @@
             "items": {
               "$ref": "#/definitions/Attribute"
             }
+          },
+          "writeCrs": {
+            "title": "Write CRS",
+            "description": "Whether to declare the coordinate reference system of the written coordinates in a legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates are not WGS84 longitude / latitude and the consumer reads that member.",
+            "default": false,
+            "type": "boolean"
           }
         },
         "definitions": {

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -3974,6 +3974,12 @@
                 "type": "string"
               }
             }
+          },
+          "writeCrs": {
+            "title": "Write CRS",
+            "description": "Whether to declare the coordinate reference system of the written coordinates in a legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates are not WGS84 longitude / latitude and the consumer reads that member.",
+            "default": false,
+            "type": "boolean"
           }
         }
       },
@@ -5135,6 +5141,12 @@
             "items": {
               "$ref": "#/definitions/Attribute"
             }
+          },
+          "writeCrs": {
+            "title": "Write CRS",
+            "description": "Whether to declare the coordinate reference system of the written coordinates in a legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates are not WGS84 longitude / latitude and the consumer reads that member.",
+            "default": false,
+            "type": "boolean"
           }
         },
         "definitions": {

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -3974,6 +3974,12 @@
                 "type": "string"
               }
             }
+          },
+          "writeCrs": {
+            "title": "Write CRS",
+            "description": "Whether to declare the coordinate reference system of the written coordinates in a legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates are not WGS84 longitude / latitude and the consumer reads that member.",
+            "default": false,
+            "type": "boolean"
           }
         }
       },
@@ -5135,6 +5141,12 @@
             "items": {
               "$ref": "#/definitions/Attribute"
             }
+          },
+          "writeCrs": {
+            "title": "Write CRS",
+            "description": "Whether to declare the coordinate reference system of the written coordinates in a legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates are not WGS84 longitude / latitude and the consumer reads that member.",
+            "default": false,
+            "type": "boolean"
           }
         },
         "definitions": {

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -3974,6 +3974,12 @@
                 "type": "string"
               }
             }
+          },
+          "writeCrs": {
+            "title": "Write CRS",
+            "description": "Whether to declare the coordinate reference system of the written coordinates in a legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates are not WGS84 longitude / latitude and the consumer reads that member.",
+            "default": false,
+            "type": "boolean"
           }
         }
       },
@@ -5135,6 +5141,12 @@
             "items": {
               "$ref": "#/definitions/Attribute"
             }
+          },
+          "writeCrs": {
+            "title": "Write CRS",
+            "description": "Whether to declare the coordinate reference system of the written coordinates in a legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates are not WGS84 longitude / latitude and the consumer reads that member.",
+            "default": false,
+            "type": "boolean"
           }
         },
         "definitions": {

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -3974,6 +3974,12 @@
                 "type": "string"
               }
             }
+          },
+          "writeCrs": {
+            "title": "Write CRS",
+            "description": "Whether to declare the coordinate reference system of the written coordinates in a legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates are not WGS84 longitude / latitude and the consumer reads that member.",
+            "default": false,
+            "type": "boolean"
           }
         }
       },
@@ -5135,6 +5141,12 @@
             "items": {
               "$ref": "#/definitions/Attribute"
             }
+          },
+          "writeCrs": {
+            "title": "Write CRS",
+            "description": "Whether to declare the coordinate reference system of the written coordinates in a legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates are not WGS84 longitude / latitude and the consumer reads that member.",
+            "default": false,
+            "type": "boolean"
           }
         },
         "definitions": {

--- a/engine/schema/i18n/actions/es.json
+++ b/engine/schema/i18n/actions/es.json
@@ -1329,6 +1329,10 @@
         "output": {
           "title": "Output",
           "description": "Path (or expression evaluated per feature) of the GeoJSON file to write. Features sharing a resolved path are written to the same file, so the expression can split features across files by attribute value."
+        },
+        "writeCrs": {
+          "title": "Write CRS",
+          "description": "Whether to declare the coordinate reference system of the written coordinates in a legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates are not WGS84 longitude / latitude and the consumer reads that member."
         }
       }
     },
@@ -1578,6 +1582,10 @@
         "output": {
           "title": "Output File",
           "description": "Output path or expression for the GeoJSON file to create"
+        },
+        "writeCrs": {
+          "title": "Write CRS",
+          "description": "Whether to declare the coordinate reference system of the written coordinates in a legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates are not WGS84 longitude / latitude and the consumer reads that member."
         }
       }
     },

--- a/engine/schema/i18n/actions/fr.json
+++ b/engine/schema/i18n/actions/fr.json
@@ -1329,6 +1329,10 @@
         "output": {
           "title": "Output",
           "description": "Path (or expression evaluated per feature) of the GeoJSON file to write. Features sharing a resolved path are written to the same file, so the expression can split features across files by attribute value."
+        },
+        "writeCrs": {
+          "title": "Write CRS",
+          "description": "Whether to declare the coordinate reference system of the written coordinates in a legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates are not WGS84 longitude / latitude and the consumer reads that member."
         }
       }
     },
@@ -1578,6 +1582,10 @@
         "output": {
           "title": "Output File",
           "description": "Output path or expression for the GeoJSON file to create"
+        },
+        "writeCrs": {
+          "title": "Write CRS",
+          "description": "Whether to declare the coordinate reference system of the written coordinates in a legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates are not WGS84 longitude / latitude and the consumer reads that member."
         }
       }
     },

--- a/engine/schema/i18n/actions/ja.json
+++ b/engine/schema/i18n/actions/ja.json
@@ -1329,6 +1329,10 @@
         "output": {
           "title": "Output",
           "description": "Path (or expression evaluated per feature) of the GeoJSON file to write. Features sharing a resolved path are written to the same file, so the expression can split features across files by attribute value."
+        },
+        "writeCrs": {
+          "title": "Write CRS",
+          "description": "Whether to declare the coordinate reference system of the written coordinates in a legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates are not WGS84 longitude / latitude and the consumer reads that member."
         }
       }
     },
@@ -1578,6 +1582,10 @@
         "output": {
           "title": "出力ファイル",
           "description": "作成するGeoJSONファイルの出力パスまたは式"
+        },
+        "writeCrs": {
+          "title": "Write CRS",
+          "description": "Whether to declare the coordinate reference system of the written coordinates in a legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates are not WGS84 longitude / latitude and the consumer reads that member."
         }
       }
     },

--- a/engine/schema/i18n/actions/zh.json
+++ b/engine/schema/i18n/actions/zh.json
@@ -1329,6 +1329,10 @@
         "output": {
           "title": "Output",
           "description": "Path (or expression evaluated per feature) of the GeoJSON file to write. Features sharing a resolved path are written to the same file, so the expression can split features across files by attribute value."
+        },
+        "writeCrs": {
+          "title": "Write CRS",
+          "description": "Whether to declare the coordinate reference system of the written coordinates in a legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates are not WGS84 longitude / latitude and the consumer reads that member."
         }
       }
     },
@@ -1578,6 +1582,10 @@
         "output": {
           "title": "Output File",
           "description": "Output path or expression for the GeoJSON file to create"
+        },
+        "writeCrs": {
+          "title": "Write CRS",
+          "description": "Whether to declare the coordinate reference system of the written coordinates in a legacy GeoJSON 2008 `crs` member. Defaults to false; enable it when the coordinates are not WGS84 longitude / latitude and the consumer reads that member."
         }
       }
     },

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.107"
+version = "0.2.108"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.297"
+version = "0.1.298"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
# Overview

Ports `GeoJSON Writer` (sink) and `Feature GeoJSON Writer` (processor) to the new geometry world, and makes the legacy GeoJSON 2008 `crs` member opt-in via a new `writeCrs` parameter.

## What I've done

- Added the `Feature -> GeoJSON` direction to `conversion/geojson_next.rs` and removed the `not(new-geometry)` gates from both writers, so they work in either geometry world. Both directions now share one axis-order invariant: GeoJSON positions are always `(easting/longitude, northing/latitude[, height])`, so a north-first CRS frame has its horizontal pair swapped on the way out.
- Added `writeCrs` (default `false`) to both actions. When enabled, the `crs` member is a named EPSG CRS if one code covers every written coordinate, and an explicit `null` otherwise — an absent member would claim WGS84 for coordinates that are not in it. `writeCrs: true` is set on the two error-geometry outputs in `quality-check/plateau6/02-bldg/building_checks.yml`, the only in-repo nodes that need it.
- Moved `feature/geojson_writer.rs` to `feature/writer/geojson.rs`.

## What I haven't done

## How I tested

Added unit tests for the write direction and the `crs` member, running in both geometry worlds.

## Screenshot

## Which point I want you to review particularly

- Writing `"crs": null` rather than omitting the member when the CRS is unknown or mixed.
- The collection folding rules in `combine` / `fold_into_multi`, especially requiring a uniform coordinate frame.

## Memo

- **CRS**: a named CRS only when one EPSG code covers *every written* coordinate — coverage accumulates during the write, so a dropped geometry contributes nothing. Anything else (mixed codes, a frame naming no CRS, nothing written) is an explicit `"crs": null`, since an omitted member would claim the GeoJSON 2008 default, WGS84 lon/lat. That member is a GeoJSON 2008 extension RFC 7946 dropped, hence opt-in.
- **Axis order**: RFC 7946 3.1.1 fixes positions to (easting/longitude, northing/latitude), while a `Crs` frame stores axes in the authority's declared order — so writing swaps the horizontal pair back. `Euclidean` and `Tangent` frames are written as stored.
- **Solid / Csg / PointCloud** have no GeoJSON counterpart: dropped with a warning where they appear so they don't discard their siblings, though a container left with nothing writable is an error. Meshes write as their faces.
- **Collections**: a `GeometryCollection` stays one GeoJSON `GeometryCollection` on one feature, at any depth — not the old world's expansion into one feature per member. Reading builds one `Feature` from one GeoJSON feature, so writing one back makes the two directions inverses, ids and all. Parts fold into a `Multi*` only when they share a kind and a frame — folding across frames would put two reference systems under one `crs`.