### PR TITLE
fix(api): authorize the document/websocket GraphQL operations

### DIFF
--- a/server/api/e2e/gql_document_permission_test.go
+++ b/server/api/e2e/gql_document_permission_test.go
@@ -1,0 +1,185 @@
+package e2e
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/gavv/httpexpect/v2"
+	usermockrepo "github.com/reearth/reearth-accounts/server/pkg/gqlclient/user/mockrepo"
+	accountsuser "github.com/reearth/reearth-accounts/server/pkg/user"
+	"github.com/reearth/reearth-flow/api/internal/app/config"
+	"github.com/reearth/reearth-flow/api/internal/testutil/factory"
+	"github.com/reearth/reearth-flow/api/internal/usecase/repo"
+	"github.com/reearth/reearth-flow/api/pkg/project"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// The document/websocket operations used to be the one GraphQL surface with no
+// authorization: interfaces.Container.Websocket held the bare HTTP client, so any
+// authenticated user could act on any project in any workspace. rollbackProject
+// was the worst of it, because it prunes a project's update log.
+//
+// These tests pin the WIRING, which the interactor unit tests cannot reach. Those
+// prove the interactor denies; only booting the real server proves
+// Container.Websocket actually points at the interactor and not the raw client.
+// Re-pointing it would leave every unit test green.
+//
+// Memory-backed on purpose (useMongo = false) so this runs anywhere rather than
+// only where a database is available.
+//
+// Note the pre-existing TestDocumentOperations is not comparable coverage: its
+// interceptor answers the GraphQL request itself with canned JSON, so it never
+// reaches the resolvers, the container, or the client.
+
+// startDocumentPermissionServer boots the real server with permissions either
+// enforced or granted, and returns the expect client plus the project repo.
+func startDocumentPermissionServer(t *testing.T, allowPermission bool) (*httpexpect.Expect, repo.Project) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+
+	workspace := factory.NewWorkspace()
+	userEntity := factory.NewUser(func(b *accountsuser.Builder) {
+		b.Workspace(workspace.ID())
+		b.Auths([]accountsuser.Auth{{Provider: "auth0", Sub: "auth0|doc-perm-test"}})
+	})
+
+	mockUserRepo := usermockrepo.NewMockRepo(ctrl)
+	// AnyTimes: the table below issues one request per operation.
+	mockUserRepo.EXPECT().FindMe(gomock.Any()).Return(userEntity, nil).AnyTimes()
+
+	cfg := &config.Config{
+		Origins:         []string{"https://example.com"},
+		AuthSrv:         config.AuthSrvConfig{Disabled: true},
+		AccountsApiHost: "http://localhost:8080",
+	}
+	exp, repos, _ := StartServerAndRepos(t, cfg, false, allowPermission, &TestMocks{UserRepo: mockUserRepo})
+	return exp, repos.Project
+}
+
+// documentOps is every operation the schema exposes. Table-driven so a new
+// operation added without authorization shows up as a missing row rather than
+// passing unnoticed.
+var documentOps = []struct {
+	name  string
+	query string
+	vars  func(projectID string) map[string]any
+}{
+	{
+		name:  "latestProjectSnapshot",
+		query: `query($projectId: ID!) { latestProjectSnapshot(projectId: $projectId) { version } }`,
+		vars:  func(p string) map[string]any { return map[string]any{"projectId": p} },
+	},
+	{
+		name:  "projectHistory",
+		query: `query($projectId: ID!) { projectHistory(projectId: $projectId) { version } }`,
+		vars:  func(p string) map[string]any { return map[string]any{"projectId": p} },
+	},
+	{
+		name:  "projectSnapshot",
+		query: `query($projectId: ID!, $version: Int!) { projectSnapshot(projectId: $projectId, version: $version) { version } }`,
+		vars: func(p string) map[string]any {
+			return map[string]any{"projectId": p, "version": 1}
+		},
+	},
+	{
+		name:  "rollbackProject",
+		query: `mutation($projectId: ID!, $version: Int!) { rollbackProject(projectId: $projectId, version: $version) { version } }`,
+		vars: func(p string) map[string]any {
+			return map[string]any{"projectId": p, "version": 1}
+		},
+	},
+	{
+		name:  "saveSnapshot",
+		query: `mutation($projectId: ID!) { saveSnapshot(projectId: $projectId) }`,
+		vars:  func(p string) map[string]any { return map[string]any{"projectId": p} },
+	},
+	{
+		name:  "previewSnapshot",
+		query: `mutation($projectId: ID!, $version: Int!) { previewSnapshot(projectId: $projectId, version: $version) { version } }`,
+		vars: func(p string) map[string]any {
+			return map[string]any{"projectId": p, "version": 1}
+		},
+	},
+	{
+		name:  "importProject",
+		query: `mutation($projectId: ID!, $data: Bytes!) { importProject(projectId: $projectId, data: $data) }`,
+		vars: func(p string) map[string]any {
+			// Bytes is a number array (Uint8Array), NOT base64: a string here fails
+			// scalar coercion before the resolver runs, so the row would assert nothing.
+			return map[string]any{"projectId": p, "data": []int{1, 2, 3}}
+		},
+	},
+}
+
+// TestDocumentOperations_DeniedWithoutPermission: with the permission checker
+// refusing, every operation must return a GraphQL error.
+//
+// This is what pins the authorizing wrapper in place. If Container.Websocket were
+// re-pointed at the raw client, the request would instead reach a websocket server
+// that is not running, which is a different failure and a real bypass.
+func TestDocumentOperations_DeniedWithoutPermission(t *testing.T) {
+	e, projectRepo := startDocumentPermissionServer(t, false)
+
+	prj := project.New().NewID().Workspace(project.NewWorkspaceID()).MustBuild()
+	require.NoError(t, projectRepo.Save(context.Background(), prj))
+
+	for _, op := range documentOps {
+		t.Run(op.name, func(t *testing.T) {
+			res := e.POST("/api/graphql").
+				WithHeader("Origin", "https://example.com").
+				WithHeader("authorization", "Bearer test").
+				WithHeader("Content-Type", "application/json").
+				WithJSON(map[string]any{
+					"query":     op.query,
+					"variables": op.vars(prj.ID().String()),
+				}).
+				Expect().
+				Status(http.StatusOK).
+				JSON().Object()
+
+			// Assert the SPECIFIC error. "an error occurred" is not enough: with the
+			// bare client wired in, the request reaches a websocket server that is not
+			// running and fails with `server returned non-200 status: 404`, so a test
+			// that only checks for the presence of errors passes under the very bypass
+			// it is meant to catch. (Verified: it does.) Only the message distinguishes
+			// authorization from a transport failure.
+			res.ContainsKey("errors")
+			msg := res.Value("errors").Array().Value(0).Object().Value("message").String()
+			msg.Contains("operation denied")
+			msg.NotContains("server returned")
+		})
+	}
+}
+
+// TestDocumentOperations_UnknownProjectIsDenied: authorization resolves the
+// project to a workspace, so an id that does not resolve must fail closed rather
+// than skip the check. Permissions are GRANTED here, so the only thing that can
+// produce an error is the resolution step refusing.
+func TestDocumentOperations_UnknownProjectIsDenied(t *testing.T) {
+	e, _ := startDocumentPermissionServer(t, true)
+
+	for _, projectID := range []string{"not-a-valid-id", project.NewID().String()} {
+		t.Run(projectID, func(t *testing.T) {
+			res := e.POST("/api/graphql").
+				WithHeader("Origin", "https://example.com").
+				WithHeader("authorization", "Bearer test").
+				WithHeader("Content-Type", "application/json").
+				WithJSON(map[string]any{
+					"query":     `query($projectId: ID!) { projectHistory(projectId: $projectId) { version } }`,
+					"variables": map[string]any{"projectId": projectID},
+				}).
+				Expect().
+				Status(http.StatusOK).
+				JSON().Object()
+
+			// Same reasoning as above, via the negative: permissions are granted here,
+			// so the request must be stopped by project resolution BEFORE the client is
+			// reached. "server returned" in the message would mean it went through.
+			res.ContainsKey("errors")
+			msg := res.Value("errors").Array().Value(0).Object().Value("message").String()
+			msg.NotContains("server returned")
+		})
+	}
+}

--- a/server/api/e2e/gql_document_permission_test.go
+++ b/server/api/e2e/gql_document_permission_test.go
@@ -58,74 +58,23 @@ func startDocumentPermissionServer(t *testing.T, allowPermission bool) (*httpexp
 	return exp, repos.Project
 }
 
-// documentOps is every operation document.graphql exposes: three queries
-// (latestProjectSnapshot, projectHistory, projectSnapshot) and five mutations
-// (rollbackProject, saveSnapshot, previewSnapshot, importProject, copyProject).
-// Table-driven so a new operation added without authorization shows up as a
-// missing row rather than passing unnoticed.
-var documentOps = []struct {
-	// vars first: keeping the pointer-bearing field at the front shortens the
-	// range the GC has to scan (govet fieldalignment).
-	//
-	// It takes a second project id so copyProject, the one operation addressing
-	// two projects, can be covered by the same table rather than sitting outside
-	// it where a coverage gap is easy to miss.
-	vars  func(projectID, otherProjectID string) map[string]any
-	name  string
-	query string
-}{
-	{
-		name:  "latestProjectSnapshot",
-		query: `query($projectId: ID!) { latestProjectSnapshot(projectId: $projectId) { version } }`,
-		vars:  func(p, _ string) map[string]any { return map[string]any{"projectId": p} },
-	},
-	{
-		name:  "projectHistory",
-		query: `query($projectId: ID!) { projectHistory(projectId: $projectId) { version } }`,
-		vars:  func(p, _ string) map[string]any { return map[string]any{"projectId": p} },
-	},
-	{
-		name:  "projectSnapshot",
-		query: `query($projectId: ID!, $version: Int!) { projectSnapshot(projectId: $projectId, version: $version) { version } }`,
-		vars: func(p, _ string) map[string]any {
-			return map[string]any{"projectId": p, "version": 1}
-		},
-	},
-	{
-		name:  "rollbackProject",
-		query: `mutation($projectId: ID!, $version: Int!) { rollbackProject(projectId: $projectId, version: $version) { version } }`,
-		vars: func(p, _ string) map[string]any {
-			return map[string]any{"projectId": p, "version": 1}
-		},
-	},
-	{
-		name:  "saveSnapshot",
-		query: `mutation($projectId: ID!) { saveSnapshot(projectId: $projectId) }`,
-		vars:  func(p, _ string) map[string]any { return map[string]any{"projectId": p} },
-	},
-	{
-		name:  "previewSnapshot",
-		query: `mutation($projectId: ID!, $version: Int!) { previewSnapshot(projectId: $projectId, version: $version) { version } }`,
-		vars: func(p, _ string) map[string]any {
-			return map[string]any{"projectId": p, "version": 1}
-		},
-	},
-	{
-		name:  "importProject",
-		query: `mutation($projectId: ID!, $data: Bytes!) { importProject(projectId: $projectId, data: $data) }`,
-		vars: func(p, _ string) map[string]any {
-			// Bytes is a number array (Uint8Array), NOT base64: a string here fails
-			// scalar coercion before the resolver runs, so the row would assert nothing.
-			return map[string]any{"projectId": p, "data": []int{1, 2, 3}}
-		},
-	},
-	{
-		name:  "copyProject",
-		query: `mutation($projectId: ID!, $source: ID!) { copyProject(projectId: $projectId, source: $source) }`,
-		vars: func(p, other string) map[string]any {
-			return map[string]any{"projectId": p, "source": other}
-		},
-	},
+// assertDenied posts one operation and requires the SPECIFIC authorization
+// error. "an error occurred" is not enough: with the bare client wired in the
+// request reaches a websocket server that is not running and fails with
+// `server returned non-200 status: 404`, which passes that weaker check.
+func assertDenied(t *testing.T, e *httpexpect.Expect, name, query string, vars map[string]any) {
+	t.Helper()
+	res := e.POST("/api/graphql").
+		WithHeader("Origin", "https://example.com").
+		WithHeader("authorization", "Bearer test").
+		WithHeader("Content-Type", "application/json").
+		WithJSON(map[string]any{"query": query, "variables": vars}).
+		Expect().Status(http.StatusOK).JSON().Object()
+
+	res.ContainsKey("errors")
+	msg := res.Value("errors").Array().Value(0).Object().Value("message").String()
+	msg.Contains("operation denied")
+	msg.NotContains("server returned")
 }
 
 // TestDocumentOperations_DeniedWithoutPermission: with the permission checker
@@ -137,39 +86,40 @@ var documentOps = []struct {
 func TestDocumentOperations_DeniedWithoutPermission(t *testing.T) {
 	e, projectRepo := startDocumentPermissionServer(t, false)
 
-	// Two projects in DIFFERENT workspaces: copyProject addresses both, and using
-	// one project for each end would let a destination-only check look correct.
+	// Two projects in DIFFERENT workspaces: copyProject addresses both, and one
+	// project for each end would let a destination-only check look correct.
 	prj := project.New().NewID().Workspace(project.NewWorkspaceID()).MustBuild()
 	require.NoError(t, projectRepo.Save(context.Background(), prj))
 	other := project.New().NewID().Workspace(project.NewWorkspaceID()).MustBuild()
 	require.NoError(t, projectRepo.Save(context.Background(), other))
+	p, o := prj.ID().String(), other.ID().String()
 
-	for _, op := range documentOps {
-		t.Run(op.name, func(t *testing.T) {
-			res := e.POST("/api/graphql").
-				WithHeader("Origin", "https://example.com").
-				WithHeader("authorization", "Bearer test").
-				WithHeader("Content-Type", "application/json").
-				WithJSON(map[string]any{
-					"query":     op.query,
-					"variables": op.vars(prj.ID().String(), other.ID().String()),
-				}).
-				Expect().
-				Status(http.StatusOK).
-				JSON().Object()
-
-			// Assert the SPECIFIC error. "an error occurred" is not enough: with the
-			// bare client wired in, the request reaches a websocket server that is not
-			// running and fails with `server returned non-200 status: 404`, so a test
-			// that only checks for the presence of errors passes under the very bypass
-			// it is meant to catch. (Verified: it does.) Only the message distinguishes
-			// authorization from a transport failure.
-			res.ContainsKey("errors")
-			msg := res.Value("errors").Array().Value(0).Object().Value("message").String()
-			msg.Contains("operation denied")
-			msg.NotContains("server returned")
-		})
-	}
+	assertDenied(t, e, "latestProjectSnapshot",
+		`query($projectId: ID!) { latestProjectSnapshot(projectId: $projectId) { version } }`,
+		map[string]any{"projectId": p})
+	assertDenied(t, e, "projectHistory",
+		`query($projectId: ID!) { projectHistory(projectId: $projectId) { version } }`,
+		map[string]any{"projectId": p})
+	assertDenied(t, e, "projectSnapshot",
+		`query($projectId: ID!, $version: Int!) { projectSnapshot(projectId: $projectId, version: $version) { version } }`,
+		map[string]any{"projectId": p, "version": 1})
+	assertDenied(t, e, "rollbackProject",
+		`mutation($projectId: ID!, $version: Int!) { rollbackProject(projectId: $projectId, version: $version) { version } }`,
+		map[string]any{"projectId": p, "version": 1})
+	assertDenied(t, e, "saveSnapshot",
+		`mutation($projectId: ID!) { saveSnapshot(projectId: $projectId) }`,
+		map[string]any{"projectId": p})
+	assertDenied(t, e, "previewSnapshot",
+		`mutation($projectId: ID!, $version: Int!) { previewSnapshot(projectId: $projectId, version: $version) { version } }`,
+		map[string]any{"projectId": p, "version": 1})
+	// Bytes is a number array (Uint8Array), not base64: a string fails scalar
+	// coercion before the resolver runs, so the case would assert nothing.
+	assertDenied(t, e, "importProject",
+		`mutation($projectId: ID!, $data: Bytes!) { importProject(projectId: $projectId, data: $data) }`,
+		map[string]any{"projectId": p, "data": []int{1, 2, 3}})
+	assertDenied(t, e, "copyProject",
+		`mutation($projectId: ID!, $source: ID!) { copyProject(projectId: $projectId, source: $source) }`,
+		map[string]any{"projectId": p, "source": o})
 }
 
 // TestDocumentOperations_UnknownProjectIsDenied: authorization resolves the

--- a/server/api/e2e/gql_document_permission_test.go
+++ b/server/api/e2e/gql_document_permission_test.go
@@ -62,9 +62,11 @@ func startDocumentPermissionServer(t *testing.T, allowPermission bool) (*httpexp
 // operation added without authorization shows up as a missing row rather than
 // passing unnoticed.
 var documentOps = []struct {
+	// vars first: keeping the pointer-bearing field at the front shortens the
+	// range the GC has to scan (govet fieldalignment).
+	vars  func(projectID string) map[string]any
 	name  string
 	query string
-	vars  func(projectID string) map[string]any
 }{
 	{
 		name:  "latestProjectSnapshot",

--- a/server/api/e2e/gql_document_permission_test.go
+++ b/server/api/e2e/gql_document_permission_test.go
@@ -58,59 +58,72 @@ func startDocumentPermissionServer(t *testing.T, allowPermission bool) (*httpexp
 	return exp, repos.Project
 }
 
-// documentOps is every operation the schema exposes. Table-driven so a new
-// operation added without authorization shows up as a missing row rather than
-// passing unnoticed.
+// documentOps is every operation document.graphql exposes: three queries
+// (latestProjectSnapshot, projectHistory, projectSnapshot) and five mutations
+// (rollbackProject, saveSnapshot, previewSnapshot, importProject, copyProject).
+// Table-driven so a new operation added without authorization shows up as a
+// missing row rather than passing unnoticed.
 var documentOps = []struct {
 	// vars first: keeping the pointer-bearing field at the front shortens the
 	// range the GC has to scan (govet fieldalignment).
-	vars  func(projectID string) map[string]any
+	//
+	// It takes a second project id so copyProject, the one operation addressing
+	// two projects, can be covered by the same table rather than sitting outside
+	// it where a coverage gap is easy to miss.
+	vars  func(projectID, otherProjectID string) map[string]any
 	name  string
 	query string
 }{
 	{
 		name:  "latestProjectSnapshot",
 		query: `query($projectId: ID!) { latestProjectSnapshot(projectId: $projectId) { version } }`,
-		vars:  func(p string) map[string]any { return map[string]any{"projectId": p} },
+		vars:  func(p, _ string) map[string]any { return map[string]any{"projectId": p} },
 	},
 	{
 		name:  "projectHistory",
 		query: `query($projectId: ID!) { projectHistory(projectId: $projectId) { version } }`,
-		vars:  func(p string) map[string]any { return map[string]any{"projectId": p} },
+		vars:  func(p, _ string) map[string]any { return map[string]any{"projectId": p} },
 	},
 	{
 		name:  "projectSnapshot",
 		query: `query($projectId: ID!, $version: Int!) { projectSnapshot(projectId: $projectId, version: $version) { version } }`,
-		vars: func(p string) map[string]any {
+		vars: func(p, _ string) map[string]any {
 			return map[string]any{"projectId": p, "version": 1}
 		},
 	},
 	{
 		name:  "rollbackProject",
 		query: `mutation($projectId: ID!, $version: Int!) { rollbackProject(projectId: $projectId, version: $version) { version } }`,
-		vars: func(p string) map[string]any {
+		vars: func(p, _ string) map[string]any {
 			return map[string]any{"projectId": p, "version": 1}
 		},
 	},
 	{
 		name:  "saveSnapshot",
 		query: `mutation($projectId: ID!) { saveSnapshot(projectId: $projectId) }`,
-		vars:  func(p string) map[string]any { return map[string]any{"projectId": p} },
+		vars:  func(p, _ string) map[string]any { return map[string]any{"projectId": p} },
 	},
 	{
 		name:  "previewSnapshot",
 		query: `mutation($projectId: ID!, $version: Int!) { previewSnapshot(projectId: $projectId, version: $version) { version } }`,
-		vars: func(p string) map[string]any {
+		vars: func(p, _ string) map[string]any {
 			return map[string]any{"projectId": p, "version": 1}
 		},
 	},
 	{
 		name:  "importProject",
 		query: `mutation($projectId: ID!, $data: Bytes!) { importProject(projectId: $projectId, data: $data) }`,
-		vars: func(p string) map[string]any {
+		vars: func(p, _ string) map[string]any {
 			// Bytes is a number array (Uint8Array), NOT base64: a string here fails
 			// scalar coercion before the resolver runs, so the row would assert nothing.
 			return map[string]any{"projectId": p, "data": []int{1, 2, 3}}
+		},
+	},
+	{
+		name:  "copyProject",
+		query: `mutation($projectId: ID!, $source: ID!) { copyProject(projectId: $projectId, source: $source) }`,
+		vars: func(p, other string) map[string]any {
+			return map[string]any{"projectId": p, "source": other}
 		},
 	},
 }
@@ -124,8 +137,12 @@ var documentOps = []struct {
 func TestDocumentOperations_DeniedWithoutPermission(t *testing.T) {
 	e, projectRepo := startDocumentPermissionServer(t, false)
 
+	// Two projects in DIFFERENT workspaces: copyProject addresses both, and using
+	// one project for each end would let a destination-only check look correct.
 	prj := project.New().NewID().Workspace(project.NewWorkspaceID()).MustBuild()
 	require.NoError(t, projectRepo.Save(context.Background(), prj))
+	other := project.New().NewID().Workspace(project.NewWorkspaceID()).MustBuild()
+	require.NoError(t, projectRepo.Save(context.Background(), other))
 
 	for _, op := range documentOps {
 		t.Run(op.name, func(t *testing.T) {
@@ -135,7 +152,7 @@ func TestDocumentOperations_DeniedWithoutPermission(t *testing.T) {
 				WithHeader("Content-Type", "application/json").
 				WithJSON(map[string]any{
 					"query":     op.query,
-					"variables": op.vars(prj.ID().String()),
+					"variables": op.vars(prj.ID().String(), other.ID().String()),
 				}).
 				Expect().
 				Status(http.StatusOK).

--- a/server/api/internal/rbac/definitions.go
+++ b/server/api/internal/rbac/definitions.go
@@ -10,22 +10,23 @@ const (
 )
 
 const (
-	ResourceAsset         = "asset"
-	ResourceCMSAsset      = "cms_asset"
-	ResourceCMSItem       = "cms_item"
-	ResourceCMSModel      = "cms_model"
-	ResourceCMSProject    = "cms_project"
-	ResourceDeployment    = "deployment"
-	ResourceEdge          = "edge"
-	ResourceJob           = "job"
-	ResourceLog           = "log"
-	ResourceNode          = "Node"
-	ResourceParameter     = "parameter"
-	ResourceProject       = "project"
-	ResourceProjectAccess = "projectAccess"
-	ResourceTrigger       = "trigger"
-	ResourceUser          = "user"
-	ResourceWorkspace     = "workspace"
+	ResourceAsset           = "asset"
+	ResourceCMSAsset        = "cms_asset"
+	ResourceCMSItem         = "cms_item"
+	ResourceCMSModel        = "cms_model"
+	ResourceCMSProject      = "cms_project"
+	ResourceDeployment      = "deployment"
+	ResourceEdge            = "edge"
+	ResourceJob             = "job"
+	ResourceLog             = "log"
+	ResourceNode            = "Node"
+	ResourceParameter       = "parameter"
+	ResourceProject         = "project"
+	ResourceProjectAccess   = "projectAccess"
+	ResourceProjectDocument = "projectDocument"
+	ResourceTrigger         = "trigger"
+	ResourceUser            = "user"
+	ResourceWorkspace       = "workspace"
 )
 
 const (
@@ -88,6 +89,11 @@ func DefineResources() []generator.ResourceRule {
 			ActionAny:    {Roles: []string{roleReader, roleWriter, roleOwner, roleMaintainer}},
 		}},
 		{Resource: ResourceProjectAccess, Actions: maintainerOwner},
+		{Resource: ResourceProjectDocument, Actions: map[string]generator.ActionRule{
+			ActionRead:   {Roles: []string{roleReader, roleWriter, roleMaintainer, roleOwner}},
+			ActionEdit:   {Roles: []string{roleWriter, roleMaintainer, roleOwner}},
+			ActionDelete: {Roles: []string{roleMaintainer, roleOwner}},
+		}},
 		{Resource: ResourceTrigger, Actions: map[string]generator.ActionRule{
 			ActionCreate: {Roles: []string{roleMaintainer, roleOwner}},
 			ActionEdit:   {Roles: []string{roleMaintainer, roleOwner}},

--- a/server/api/internal/rbac/definitions_test.go
+++ b/server/api/internal/rbac/definitions_test.go
@@ -1,0 +1,64 @@
+package rbac
+
+import (
+	"testing"
+
+	"github.com/reearth/reearthx/cerbos/generator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// actionsFor returns the declared action rules for one resource.
+func actionsFor(t *testing.T, resource string) map[string]generator.ActionRule {
+	t.Helper()
+	for _, r := range DefineResources() {
+		if r.Resource == resource {
+			return r.Actions
+		}
+	}
+	t.Fatalf("resource %q is not declared in DefineResources", resource)
+	return nil
+}
+
+// TestProjectDocumentPolicy pins the rules the document operations depend on.
+//
+// This is the check that was missing. The interactor tests use a mock permission
+// checker, so they prove the right resource and action are REQUESTED; only the
+// policy decides whether that request can ever be granted. An action with no rule
+// is denied by default, so a read operation checking an undeclared action would
+// fail for every user including owners, and no unit test would notice.
+func TestProjectDocumentPolicy(t *testing.T) {
+	actions := actionsFor(t, ResourceProjectDocument)
+
+	// Every action the Websocket interactor checks must have a rule.
+	for _, action := range []string{ActionRead, ActionEdit, ActionDelete} {
+		require.Contains(t, actions, action,
+			"interactor.Websocket checks %q on %s; without a rule it is denied for everyone",
+			action, ResourceProjectDocument)
+	}
+
+	// Reading version history is for anyone who can see the project.
+	assert.ElementsMatch(t, []string{roleReader, roleWriter, roleMaintainer, roleOwner},
+		actions[ActionRead].Roles)
+
+	// Editing the document is content work, so writers are included. Excluding
+	// them would stop the people doing the collaborative editing from saving a
+	// version, rolling back, importing or copying.
+	assert.Contains(t, actions[ActionEdit].Roles, roleWriter,
+		"writers must be able to mutate a project's document")
+	assert.NotContains(t, actions[ActionEdit].Roles, roleReader,
+		"readers must not be able to mutate a project's document")
+
+	// Destroying all of a project's document data stays privileged.
+	assert.ElementsMatch(t, []string{roleMaintainer, roleOwner}, actions[ActionDelete].Roles)
+}
+
+// TestProjectPolicyUnchangedByDocumentSplit guards the reason the document
+// operations got their own resource: ResourceProject's edit is project SETTINGS
+// (rename, configure) and is deliberately maintainer and owner only. Adding
+// writers there to unblock document editing would have widened that too.
+func TestProjectPolicyUnchangedByDocumentSplit(t *testing.T) {
+	actions := actionsFor(t, ResourceProject)
+	assert.NotContains(t, actions[ActionEdit].Roles, roleWriter,
+		"project settings edit must stay maintainer/owner; document editing lives on %s", ResourceProjectDocument)
+}

--- a/server/api/internal/usecase/interactor/common.go
+++ b/server/api/internal/usecase/interactor/common.go
@@ -57,13 +57,8 @@ func NewContainer(r *repo.Container, g *gateway.Container,
 		Trigger:       NewTrigger(r, g, job, permissionChecker),
 		User:          NewUser(GQLClient.UserRepo),
 		UserFacingLog: NewUserFacingLogInteractor(g.Redis, r.Job, permissionChecker),
-		// The GraphQL surface gets the authorizing wrapper, not the bare client:
-		// every document operation is addressed by project id and must be checked
-		// against that project's workspace. NewProject above keeps the raw client
-		// on purpose, so project deletion (already permission-checked) does not
-		// re-resolve a project that is mid-delete.
-		Websocket:    NewWebsocket(client, r.Project, permissionChecker),
-		WorkerConfig: NewWorkerConfig(r, permissionChecker),
+		Websocket:     NewWebsocket(client, r.Project, permissionChecker),
+		WorkerConfig:  NewWorkerConfig(r, permissionChecker),
 	}
 }
 

--- a/server/api/internal/usecase/interactor/common.go
+++ b/server/api/internal/usecase/interactor/common.go
@@ -57,8 +57,13 @@ func NewContainer(r *repo.Container, g *gateway.Container,
 		Trigger:       NewTrigger(r, g, job, permissionChecker),
 		User:          NewUser(GQLClient.UserRepo),
 		UserFacingLog: NewUserFacingLogInteractor(g.Redis, r.Job, permissionChecker),
-		Websocket:     client,
-		WorkerConfig:  NewWorkerConfig(r, permissionChecker),
+		// The GraphQL surface gets the authorizing wrapper, not the bare client:
+		// every document operation is addressed by project id and must be checked
+		// against that project's workspace. NewProject above keeps the raw client
+		// on purpose, so project deletion (already permission-checked) does not
+		// re-resolve a project that is mid-delete.
+		Websocket:    NewWebsocket(client, r.Project, permissionChecker),
+		WorkerConfig: NewWorkerConfig(r, permissionChecker),
 	}
 }
 

--- a/server/api/internal/usecase/interactor/websocket.go
+++ b/server/api/internal/usecase/interactor/websocket.go
@@ -12,12 +12,22 @@ import (
 	"github.com/reearth/reearthx/rerror"
 )
 
+<<<<<<< HEAD
+=======
+// Websocket authorizes the document operations against the owning workspace of
+// the project they address, then delegates to the client. Internal callers stay
+// on the raw client: ProjectDeleter already checks ActionDelete.
+>>>>>>> 8061c0ea6 (refactor(api): trim comments, replace table-driven tests with explicit calls)
 type Websocket struct {
 	client            interfaces.WebsocketClient
 	projectRepo       repo.Project
 	permissionChecker gateway.PermissionChecker
 }
 
+<<<<<<< HEAD
+=======
+// NewWebsocket wraps client with workspace authorization.
+>>>>>>> 8061c0ea6 (refactor(api): trim comments, replace table-driven tests with explicit calls)
 func NewWebsocket(client interfaces.WebsocketClient, projectRepo repo.Project, permissionChecker gateway.PermissionChecker) *Websocket {
 	return &Websocket{
 		client:            client,
@@ -26,6 +36,11 @@ func NewWebsocket(client interfaces.WebsocketClient, projectRepo repo.Project, p
 	}
 }
 
+<<<<<<< HEAD
+=======
+// authorize checks action against the workspace owning docID's project. Fails
+// closed at every step, so a malformed id cannot skip the check.
+>>>>>>> 8061c0ea6 (refactor(api): trim comments, replace table-driven tests with explicit calls)
 func (i *Websocket) authorize(ctx context.Context, docID string, action string) error {
 	pid, err := id.ProjectIDFrom(docID)
 	if err != nil {
@@ -69,6 +84,7 @@ func (i *Websocket) GetHistoryMetadata(ctx context.Context, docID string) ([]*ws
 	return i.client.GetHistoryMetadata(ctx, docID)
 }
 
+<<<<<<< HEAD
 func (i *Websocket) GetNamedSnapshots(ctx context.Context, docID string) ([]*ws.SnapshotMetadata, error) {
 	if err := i.authorize(ctx, docID, rbac.ActionRead); err != nil {
 		return nil, err
@@ -84,6 +100,10 @@ func (i *Websocket) SaveNamedSnapshot(ctx context.Context, docID, label string) 
 }
 
 // Rollback prunes every update above the target clock.
+=======
+// Rollback prunes every update above the target clock, so an unauthorized call
+// would permanently truncate history.
+>>>>>>> 8061c0ea6 (refactor(api): trim comments, replace table-driven tests with explicit calls)
 func (i *Websocket) Rollback(ctx context.Context, docID string, version int) (*ws.Document, error) {
 	if err := i.authorize(ctx, docID, rbac.ActionEdit); err != nil {
 		return nil, err
@@ -98,7 +118,12 @@ func (i *Websocket) FlushToGCS(ctx context.Context, docID string) error {
 	return i.client.FlushToGCS(ctx, docID)
 }
 
+<<<<<<< HEAD
 // CreateSnapshot backs previewSnapshot and does not write, so ActionRead is correct.
+=======
+// CreateSnapshot backs previewSnapshot and does not write despite the name, so
+// ActionRead is correct.
+>>>>>>> 8061c0ea6 (refactor(api): trim comments, replace table-driven tests with explicit calls)
 func (i *Websocket) CreateSnapshot(ctx context.Context, docID string, version int, name string) (*ws.Document, error) {
 	if err := i.authorize(ctx, docID, rbac.ActionRead); err != nil {
 		return nil, err
@@ -106,7 +131,12 @@ func (i *Websocket) CreateSnapshot(ctx context.Context, docID string, version in
 	return i.client.CreateSnapshot(ctx, docID, version, name)
 }
 
+<<<<<<< HEAD
 // CopyDocument needs edit on the destination and read on the source.
+=======
+// CopyDocument needs edit on the destination AND read on the source, or a caller
+// could pull another workspace's document into a project they own.
+>>>>>>> 8061c0ea6 (refactor(api): trim comments, replace table-driven tests with explicit calls)
 func (i *Websocket) CopyDocument(ctx context.Context, docID string, source string) error {
 	if err := i.authorize(ctx, docID, rbac.ActionEdit); err != nil {
 		return err
@@ -131,6 +161,10 @@ func (i *Websocket) DeleteDocument(ctx context.Context, docID string) error {
 	return i.client.DeleteDocument(ctx, docID)
 }
 
+<<<<<<< HEAD
+=======
+// Close is connection lifecycle, so it carries no permission check.
+>>>>>>> 8061c0ea6 (refactor(api): trim comments, replace table-driven tests with explicit calls)
 func (i *Websocket) Close() error {
 	return i.client.Close()
 }

--- a/server/api/internal/usecase/interactor/websocket.go
+++ b/server/api/internal/usecase/interactor/websocket.go
@@ -12,22 +12,12 @@ import (
 	"github.com/reearth/reearthx/rerror"
 )
 
-<<<<<<< HEAD
-=======
-// Websocket authorizes the document operations against the owning workspace of
-// the project they address, then delegates to the client. Internal callers stay
-// on the raw client: ProjectDeleter already checks ActionDelete.
->>>>>>> 8061c0ea6 (refactor(api): trim comments, replace table-driven tests with explicit calls)
 type Websocket struct {
 	client            interfaces.WebsocketClient
 	projectRepo       repo.Project
 	permissionChecker gateway.PermissionChecker
 }
 
-<<<<<<< HEAD
-=======
-// NewWebsocket wraps client with workspace authorization.
->>>>>>> 8061c0ea6 (refactor(api): trim comments, replace table-driven tests with explicit calls)
 func NewWebsocket(client interfaces.WebsocketClient, projectRepo repo.Project, permissionChecker gateway.PermissionChecker) *Websocket {
 	return &Websocket{
 		client:            client,
@@ -36,11 +26,6 @@ func NewWebsocket(client interfaces.WebsocketClient, projectRepo repo.Project, p
 	}
 }
 
-<<<<<<< HEAD
-=======
-// authorize checks action against the workspace owning docID's project. Fails
-// closed at every step, so a malformed id cannot skip the check.
->>>>>>> 8061c0ea6 (refactor(api): trim comments, replace table-driven tests with explicit calls)
 func (i *Websocket) authorize(ctx context.Context, docID string, action string) error {
 	pid, err := id.ProjectIDFrom(docID)
 	if err != nil {
@@ -84,7 +69,6 @@ func (i *Websocket) GetHistoryMetadata(ctx context.Context, docID string) ([]*ws
 	return i.client.GetHistoryMetadata(ctx, docID)
 }
 
-<<<<<<< HEAD
 func (i *Websocket) GetNamedSnapshots(ctx context.Context, docID string) ([]*ws.SnapshotMetadata, error) {
 	if err := i.authorize(ctx, docID, rbac.ActionRead); err != nil {
 		return nil, err
@@ -100,10 +84,6 @@ func (i *Websocket) SaveNamedSnapshot(ctx context.Context, docID, label string) 
 }
 
 // Rollback prunes every update above the target clock.
-=======
-// Rollback prunes every update above the target clock, so an unauthorized call
-// would permanently truncate history.
->>>>>>> 8061c0ea6 (refactor(api): trim comments, replace table-driven tests with explicit calls)
 func (i *Websocket) Rollback(ctx context.Context, docID string, version int) (*ws.Document, error) {
 	if err := i.authorize(ctx, docID, rbac.ActionEdit); err != nil {
 		return nil, err
@@ -118,12 +98,7 @@ func (i *Websocket) FlushToGCS(ctx context.Context, docID string) error {
 	return i.client.FlushToGCS(ctx, docID)
 }
 
-<<<<<<< HEAD
 // CreateSnapshot backs previewSnapshot and does not write, so ActionRead is correct.
-=======
-// CreateSnapshot backs previewSnapshot and does not write despite the name, so
-// ActionRead is correct.
->>>>>>> 8061c0ea6 (refactor(api): trim comments, replace table-driven tests with explicit calls)
 func (i *Websocket) CreateSnapshot(ctx context.Context, docID string, version int, name string) (*ws.Document, error) {
 	if err := i.authorize(ctx, docID, rbac.ActionRead); err != nil {
 		return nil, err
@@ -131,12 +106,7 @@ func (i *Websocket) CreateSnapshot(ctx context.Context, docID string, version in
 	return i.client.CreateSnapshot(ctx, docID, version, name)
 }
 
-<<<<<<< HEAD
 // CopyDocument needs edit on the destination and read on the source.
-=======
-// CopyDocument needs edit on the destination AND read on the source, or a caller
-// could pull another workspace's document into a project they own.
->>>>>>> 8061c0ea6 (refactor(api): trim comments, replace table-driven tests with explicit calls)
 func (i *Websocket) CopyDocument(ctx context.Context, docID string, source string) error {
 	if err := i.authorize(ctx, docID, rbac.ActionEdit); err != nil {
 		return err
@@ -161,10 +131,6 @@ func (i *Websocket) DeleteDocument(ctx context.Context, docID string) error {
 	return i.client.DeleteDocument(ctx, docID)
 }
 
-<<<<<<< HEAD
-=======
-// Close is connection lifecycle, so it carries no permission check.
->>>>>>> 8061c0ea6 (refactor(api): trim comments, replace table-driven tests with explicit calls)
 func (i *Websocket) Close() error {
 	return i.client.Close()
 }

--- a/server/api/internal/usecase/interactor/websocket.go
+++ b/server/api/internal/usecase/interactor/websocket.go
@@ -3,57 +3,132 @@ package interactor
 import (
 	"context"
 
+	"github.com/reearth/reearth-flow/api/internal/rbac"
+	"github.com/reearth/reearth-flow/api/internal/usecase/gateway"
 	"github.com/reearth/reearth-flow/api/internal/usecase/interfaces"
+	"github.com/reearth/reearth-flow/api/internal/usecase/repo"
+	"github.com/reearth/reearth-flow/api/pkg/id"
 	ws "github.com/reearth/reearth-flow/api/pkg/websocket"
+	"github.com/reearth/reearthx/rerror"
 )
 
-// TODO(2026-09): delete this file, it is unreachable. See reearth-flow#2334.
 type Websocket struct {
-	client interfaces.WebsocketClient
+	client            interfaces.WebsocketClient
+	projectRepo       repo.Project
+	permissionChecker gateway.PermissionChecker
 }
 
-func NewWebsocket(client interfaces.WebsocketClient) *Websocket {
-	return &Websocket{client: client}
+func NewWebsocket(client interfaces.WebsocketClient, projectRepo repo.Project, permissionChecker gateway.PermissionChecker) *Websocket {
+	return &Websocket{
+		client:            client,
+		projectRepo:       projectRepo,
+		permissionChecker: permissionChecker,
+	}
 }
 
-func (i *Websocket) GetLatest(ctx context.Context, id string) (*ws.Document, error) {
-	return i.client.GetLatest(ctx, id)
+func (i *Websocket) authorize(ctx context.Context, docID string, action string) error {
+	pid, err := id.ProjectIDFrom(docID)
+	if err != nil {
+		return rerror.ErrNotFound
+	}
+	proj, err := i.projectRepo.FindByID(ctx, pid)
+	if err != nil {
+		return err
+	}
+	if proj == nil {
+		return rerror.ErrNotFound
+	}
+	return checkPermission(ctx, i.permissionChecker, rbac.ResourceProjectDocument, action, proj.Workspace())
 }
 
-func (i *Websocket) GetHistory(ctx context.Context, id string) ([]*ws.History, error) {
-	return i.client.GetHistory(ctx, id)
+func (i *Websocket) GetLatest(ctx context.Context, docID string) (*ws.Document, error) {
+	if err := i.authorize(ctx, docID, rbac.ActionRead); err != nil {
+		return nil, err
+	}
+	return i.client.GetLatest(ctx, docID)
 }
 
-func (i *Websocket) GetHistoryByVersion(ctx context.Context, id string, version int) (*ws.History, error) {
-	return i.client.GetHistoryByVersion(ctx, id, version)
+func (i *Websocket) GetHistory(ctx context.Context, docID string) ([]*ws.History, error) {
+	if err := i.authorize(ctx, docID, rbac.ActionRead); err != nil {
+		return nil, err
+	}
+	return i.client.GetHistory(ctx, docID)
 }
 
-func (i *Websocket) GetHistoryMetadata(ctx context.Context, id string) ([]*ws.HistoryMetadata, error) {
-	return i.client.GetHistoryMetadata(ctx, id)
+func (i *Websocket) GetHistoryByVersion(ctx context.Context, docID string, version int) (*ws.History, error) {
+	if err := i.authorize(ctx, docID, rbac.ActionRead); err != nil {
+		return nil, err
+	}
+	return i.client.GetHistoryByVersion(ctx, docID, version)
 }
 
-func (i *Websocket) Rollback(ctx context.Context, id string, version int) (*ws.Document, error) {
-	return i.client.Rollback(ctx, id, version)
+func (i *Websocket) GetHistoryMetadata(ctx context.Context, docID string) ([]*ws.HistoryMetadata, error) {
+	if err := i.authorize(ctx, docID, rbac.ActionRead); err != nil {
+		return nil, err
+	}
+	return i.client.GetHistoryMetadata(ctx, docID)
 }
 
-func (i *Websocket) FlushToGCS(ctx context.Context, id string) error {
-	return i.client.FlushToGCS(ctx, id)
+func (i *Websocket) GetNamedSnapshots(ctx context.Context, docID string) ([]*ws.SnapshotMetadata, error) {
+	if err := i.authorize(ctx, docID, rbac.ActionRead); err != nil {
+		return nil, err
+	}
+	return i.client.GetNamedSnapshots(ctx, docID)
 }
 
+func (i *Websocket) SaveNamedSnapshot(ctx context.Context, docID, label string) (*ws.SnapshotMetadata, error) {
+	if err := i.authorize(ctx, docID, rbac.ActionEdit); err != nil {
+		return nil, err
+	}
+	return i.client.SaveNamedSnapshot(ctx, docID, label)
+}
+
+// Rollback prunes every update above the target clock.
+func (i *Websocket) Rollback(ctx context.Context, docID string, version int) (*ws.Document, error) {
+	if err := i.authorize(ctx, docID, rbac.ActionEdit); err != nil {
+		return nil, err
+	}
+	return i.client.Rollback(ctx, docID, version)
+}
+
+func (i *Websocket) FlushToGCS(ctx context.Context, docID string) error {
+	if err := i.authorize(ctx, docID, rbac.ActionEdit); err != nil {
+		return err
+	}
+	return i.client.FlushToGCS(ctx, docID)
+}
+
+// CreateSnapshot backs previewSnapshot and does not write, so ActionRead is correct.
 func (i *Websocket) CreateSnapshot(ctx context.Context, docID string, version int, name string) (*ws.Document, error) {
+	if err := i.authorize(ctx, docID, rbac.ActionRead); err != nil {
+		return nil, err
+	}
 	return i.client.CreateSnapshot(ctx, docID, version, name)
 }
 
-func (i *Websocket) CopyProject(ctx context.Context, id string, source string) error {
-	return i.client.CopyDocument(ctx, id, source)
+// CopyDocument needs edit on the destination and read on the source.
+func (i *Websocket) CopyDocument(ctx context.Context, docID string, source string) error {
+	if err := i.authorize(ctx, docID, rbac.ActionEdit); err != nil {
+		return err
+	}
+	if err := i.authorize(ctx, source, rbac.ActionRead); err != nil {
+		return err
+	}
+	return i.client.CopyDocument(ctx, docID, source)
 }
 
-func (i *Websocket) ImportProject(ctx context.Context, id string, data []byte) error {
-	return i.client.ImportDocument(ctx, id, data)
+func (i *Websocket) ImportDocument(ctx context.Context, docID string, data []byte) error {
+	if err := i.authorize(ctx, docID, rbac.ActionEdit); err != nil {
+		return err
+	}
+	return i.client.ImportDocument(ctx, docID, data)
 }
 
-func (i *Websocket) DeleteDocument(ctx context.Context, id string) error {
-	return i.client.DeleteDocument(ctx, id)
+func (i *Websocket) DeleteDocument(ctx context.Context, docID string) error {
+	if err := i.authorize(ctx, docID, rbac.ActionDelete); err != nil {
+		return err
+	}
+	return i.client.DeleteDocument(ctx, docID)
 }
 
 func (i *Websocket) Close() error {

--- a/server/api/internal/usecase/interactor/websocket_permission_test.go
+++ b/server/api/internal/usecase/interactor/websocket_permission_test.go
@@ -54,10 +54,21 @@ func (c *countingWSClient) ImportDocument(context.Context, string, []byte) error
 	c.calls++
 	return nil
 }
+func (c *countingWSClient) GetNamedSnapshots(context.Context, string) ([]*ws.SnapshotMetadata, error) {
+	c.calls++
+	return nil, nil
+}
+func (c *countingWSClient) SaveNamedSnapshot(context.Context, string, string) (*ws.SnapshotMetadata, error) {
+	c.calls++
+	return nil, nil
+}
 func (c *countingWSClient) DeleteDocument(context.Context, string) error { c.calls++; return nil }
 func (c *countingWSClient) Close() error                                 { c.calls++; return nil }
 
-var _ interfaces.WebsocketClient = (*countingWSClient)(nil)
+var (
+	_ interfaces.WebsocketClient = (*countingWSClient)(nil)
+	_ interfaces.WebsocketClient = (*Websocket)(nil)
+)
 
 // wsFixture builds a Websocket interactor over one saved project.
 func wsFixture(t *testing.T, allow bool) (*Websocket, *countingWSClient, *recordingChecker, string, accountsid.WorkspaceID) {
@@ -91,7 +102,7 @@ func assertChecks(t *testing.T, name, action string, call func(context.Context, 
 	t.Helper()
 	i, client, rc, docID, wsID := wsFixture(t, true)
 	require.NoError(t, call(context.Background(), i, docID), name)
-	assert.Equal(t, rbac.ResourceProject, rc.gotResource, name)
+	assert.Equal(t, rbac.ResourceProjectDocument, rc.gotResource, name)
 	assert.Equal(t, action, rc.gotAction, "%s action", name)
 	require.Len(t, rc.gotWorkspace, 1, "%s workspace", name)
 	assert.Equal(t, wsID, rc.gotWorkspace[0], "%s checked the wrong workspace", name)
@@ -126,6 +137,14 @@ func flushToGCS(ctx context.Context, i *Websocket, d string) error { return i.Fl
 func importDocument(ctx context.Context, i *Websocket, d string) error {
 	return i.ImportDocument(ctx, d, []byte("x"))
 }
+func getNamedSnapshots(ctx context.Context, i *Websocket, d string) error {
+	_, err := i.GetNamedSnapshots(ctx, d)
+	return err
+}
+func saveNamedSnapshot(ctx context.Context, i *Websocket, d string) error {
+	_, err := i.SaveNamedSnapshot(ctx, d, "label")
+	return err
+}
 func deleteDocument(ctx context.Context, i *Websocket, d string) error {
 	return i.DeleteDocument(ctx, d)
 }
@@ -142,6 +161,8 @@ func TestWebsocket_DeniedOperationsNeverReachTheClient(t *testing.T) {
 	assertDenied(t, "GetHistoryByVersion", getHistoryByVersion)
 	assertDenied(t, "GetHistoryMetadata", getHistoryMetadata)
 	assertDenied(t, "CreateSnapshot", createSnapshot)
+	assertDenied(t, "GetNamedSnapshots", getNamedSnapshots)
+	assertDenied(t, "SaveNamedSnapshot", saveNamedSnapshot)
 	assertDenied(t, "Rollback", rollback)
 	assertDenied(t, "FlushToGCS", flushToGCS)
 	assertDenied(t, "ImportDocument", importDocument)
@@ -156,6 +177,8 @@ func TestWebsocket_ChecksTargetProjectWorkspace(t *testing.T) {
 	assertChecks(t, "GetHistoryByVersion", rbac.ActionRead, getHistoryByVersion)
 	assertChecks(t, "GetHistoryMetadata", rbac.ActionRead, getHistoryMetadata)
 	assertChecks(t, "CreateSnapshot", rbac.ActionRead, createSnapshot)
+	assertChecks(t, "GetNamedSnapshots", rbac.ActionRead, getNamedSnapshots)
+	assertChecks(t, "SaveNamedSnapshot", rbac.ActionEdit, saveNamedSnapshot)
 	assertChecks(t, "Rollback", rbac.ActionEdit, rollback)
 	assertChecks(t, "FlushToGCS", rbac.ActionEdit, flushToGCS)
 	assertChecks(t, "ImportDocument", rbac.ActionEdit, importDocument)

--- a/server/api/internal/usecase/interactor/websocket_permission_test.go
+++ b/server/api/internal/usecase/interactor/websocket_permission_test.go
@@ -1,0 +1,230 @@
+package interactor
+
+import (
+	"context"
+	"testing"
+
+	accountsid "github.com/reearth/reearth-accounts/server/pkg/id"
+	"github.com/reearth/reearth-flow/api/internal/infrastructure/memory"
+	"github.com/reearth/reearth-flow/api/internal/rbac"
+	"github.com/reearth/reearth-flow/api/internal/usecase/interfaces"
+	"github.com/reearth/reearth-flow/api/pkg/project"
+	ws "github.com/reearth/reearth-flow/api/pkg/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingWSClient records how many times the underlying client was reached.
+// The count is the assertion that matters: a permission check that returns an
+// error but still calls through has denied nothing.
+type countingWSClient struct {
+	calls int
+}
+
+func (c *countingWSClient) GetLatest(context.Context, string) (*ws.Document, error) {
+	c.calls++
+	return nil, nil
+}
+func (c *countingWSClient) GetHistory(context.Context, string) ([]*ws.History, error) {
+	c.calls++
+	return nil, nil
+}
+func (c *countingWSClient) GetHistoryByVersion(context.Context, string, int) (*ws.History, error) {
+	c.calls++
+	return nil, nil
+}
+func (c *countingWSClient) GetHistoryMetadata(context.Context, string) ([]*ws.HistoryMetadata, error) {
+	c.calls++
+	return nil, nil
+}
+func (c *countingWSClient) Rollback(context.Context, string, int) (*ws.Document, error) {
+	c.calls++
+	return nil, nil
+}
+func (c *countingWSClient) FlushToGCS(context.Context, string) error { c.calls++; return nil }
+func (c *countingWSClient) CreateSnapshot(context.Context, string, int, string) (*ws.Document, error) {
+	c.calls++
+	return nil, nil
+}
+func (c *countingWSClient) CopyDocument(context.Context, string, string) error {
+	c.calls++
+	return nil
+}
+func (c *countingWSClient) ImportDocument(context.Context, string, []byte) error {
+	c.calls++
+	return nil
+}
+func (c *countingWSClient) DeleteDocument(context.Context, string) error { c.calls++; return nil }
+func (c *countingWSClient) Close() error                                 { c.calls++; return nil }
+
+var _ interfaces.WebsocketClient = (*countingWSClient)(nil)
+
+// wsFixture builds a Websocket interactor over one saved project.
+func wsFixture(t *testing.T, allow bool) (*Websocket, *countingWSClient, *recordingChecker, string, accountsid.WorkspaceID) {
+	t.Helper()
+	ctx := context.Background()
+	projectRepo := memory.NewProject()
+	wsID := project.NewWorkspaceID()
+	prj := project.New().NewID().Workspace(wsID).MustBuild()
+	require.NoError(t, projectRepo.Save(ctx, prj))
+
+	client := &countingWSClient{}
+	rc := &recordingChecker{allow: allow}
+	return NewWebsocket(client, projectRepo, rc), client, rc, prj.ID().String(), accountsid.WorkspaceID(wsID)
+}
+
+// wsOps is every operation on the surface, with the action each must demand.
+// Table-driven so a newly added method without a permission check shows up as a
+// missing row rather than passing silently.
+var wsOps = []struct {
+	// call first: keeping the pointer-bearing fields adjacent shortens the range
+	// the GC has to scan (govet fieldalignment).
+	call   func(context.Context, *Websocket, string) error
+	name   string
+	action string
+}{
+	{name: "GetLatest", action: rbac.ActionRead, call: func(ctx context.Context, i *Websocket, d string) error {
+		_, err := i.GetLatest(ctx, d)
+		return err
+	}},
+	{name: "GetHistory", action: rbac.ActionRead, call: func(ctx context.Context, i *Websocket, d string) error {
+		_, err := i.GetHistory(ctx, d)
+		return err
+	}},
+	{name: "GetHistoryByVersion", action: rbac.ActionRead, call: func(ctx context.Context, i *Websocket, d string) error {
+		_, err := i.GetHistoryByVersion(ctx, d, 1)
+		return err
+	}},
+	{name: "GetHistoryMetadata", action: rbac.ActionRead, call: func(ctx context.Context, i *Websocket, d string) error {
+		_, err := i.GetHistoryMetadata(ctx, d)
+		return err
+	}},
+	{name: "CreateSnapshot", action: rbac.ActionRead, call: func(ctx context.Context, i *Websocket, d string) error {
+		_, err := i.CreateSnapshot(ctx, d, 1, "n")
+		return err
+	}},
+	{name: "Rollback", action: rbac.ActionEdit, call: func(ctx context.Context, i *Websocket, d string) error {
+		_, err := i.Rollback(ctx, d, 1)
+		return err
+	}},
+	{name: "FlushToGCS", action: rbac.ActionEdit, call: func(ctx context.Context, i *Websocket, d string) error {
+		return i.FlushToGCS(ctx, d)
+	}},
+	{name: "ImportDocument", action: rbac.ActionEdit, call: func(ctx context.Context, i *Websocket, d string) error {
+		return i.ImportDocument(ctx, d, []byte("x"))
+	}},
+	{name: "DeleteDocument", action: rbac.ActionDelete, call: func(ctx context.Context, i *Websocket, d string) error {
+		return i.DeleteDocument(ctx, d)
+	}},
+}
+
+// TestWebsocket_DeniedOperationsNeverReachTheClient is the security assertion.
+// Before this interactor existed, Container.Websocket held the bare HTTP client,
+// so any authenticated user could act on any project in any workspace. The worst
+// of those was Rollback: it prunes every update above the target clock, making it
+// a destructive cross-tenant operation.
+func TestWebsocket_DeniedOperationsNeverReachTheClient(t *testing.T) {
+	for _, op := range wsOps {
+		t.Run(op.name, func(t *testing.T) {
+			i, client, _, docID, _ := wsFixture(t, false) // permission denied
+			err := op.call(context.Background(), i, docID)
+			assert.ErrorIs(t, err, interfaces.ErrOperationDenied)
+			assert.Zero(t, client.calls, "denied %s still called through to the websocket client", op.name)
+		})
+	}
+}
+
+// TestWebsocket_ChecksTargetProjectWorkspace: the check must be evaluated against
+// the workspace that owns the addressed project, not the caller's own. Passing no
+// workspace would let the checker approve based on membership of any workspace,
+// which is the cross-tenant hole this fixes.
+func TestWebsocket_ChecksTargetProjectWorkspace(t *testing.T) {
+	for _, op := range wsOps {
+		t.Run(op.name, func(t *testing.T) {
+			i, client, rc, docID, wsID := wsFixture(t, true)
+			require.NoError(t, op.call(context.Background(), i, docID))
+
+			assert.Equal(t, rbac.ResourceProject, rc.gotResource)
+			assert.Equal(t, op.action, rc.gotAction, "%s must demand %q", op.name, op.action)
+			require.Len(t, rc.gotWorkspace, 1, "%s must scope the check to one workspace", op.name)
+			assert.Equal(t, wsID, rc.gotWorkspace[0], "%s checked the wrong workspace", op.name)
+			assert.Equal(t, 1, client.calls, "%s should reach the client once when allowed", op.name)
+		})
+	}
+}
+
+// TestWebsocket_UnresolvableProjectIsDenied: authorization depends on resolving
+// the project to a workspace, so anything that stops it resolving must deny
+// rather than fall through. Otherwise a malformed or unknown id would be a way to
+// skip the check entirely.
+func TestWebsocket_UnresolvableProjectIsDenied(t *testing.T) {
+	for _, docID := range []string{
+		"",                       // empty
+		"not-a-valid-ulid",       // unparseable
+		project.NewID().String(), // well-formed but no such project
+	} {
+		t.Run(docID, func(t *testing.T) {
+			i, client, _, _, _ := wsFixture(t, true) // checker would ALLOW
+			_, err := i.GetLatest(context.Background(), docID)
+			assert.Error(t, err, "an unresolvable project id must not be allowed through")
+			assert.Zero(t, client.calls)
+		})
+	}
+}
+
+// TestWebsocket_CopyDocumentChecksBothProjects: a copy reads the source and
+// writes the destination, so it needs edit on the destination AND read on the
+// source. Checking only the destination would let a caller pull another
+// workspace's document into a project they legitimately own.
+func TestWebsocket_CopyDocumentChecksBothProjects(t *testing.T) {
+	ctx := context.Background()
+	projectRepo := memory.NewProject()
+
+	dstWS := project.NewWorkspaceID()
+	dst := project.New().NewID().Workspace(dstWS).MustBuild()
+	require.NoError(t, projectRepo.Save(ctx, dst))
+
+	srcWS := project.NewWorkspaceID()
+	src := project.New().NewID().Workspace(srcWS).MustBuild()
+	require.NoError(t, projectRepo.Save(ctx, src))
+
+	// Deny only the SOURCE workspace: the destination is the caller's own project,
+	// so a destination-only check would wrongly permit this.
+	denySource := &perWorkspaceChecker{denied: accountsid.WorkspaceID(srcWS)}
+	client := &countingWSClient{}
+	i := NewWebsocket(client, projectRepo, denySource)
+
+	err := i.CopyDocument(ctx, dst.ID().String(), src.ID().String())
+	assert.ErrorIs(t, err, interfaces.ErrOperationDenied)
+	assert.Zero(t, client.calls, "copy proceeded despite no read permission on the source")
+
+	// With both workspaces permitted it goes through.
+	allowAll := &recordingChecker{allow: true}
+	client2 := &countingWSClient{}
+	i2 := NewWebsocket(client2, projectRepo, allowAll)
+	require.NoError(t, i2.CopyDocument(ctx, dst.ID().String(), src.ID().String()))
+	assert.Equal(t, 1, client2.calls)
+}
+
+// perWorkspaceChecker denies exactly one workspace and allows everything else.
+type perWorkspaceChecker struct {
+	denied accountsid.WorkspaceID
+}
+
+func (p *perWorkspaceChecker) CheckPermission(_ context.Context, _, _ string, workspaceID ...accountsid.WorkspaceID) (bool, error) {
+	for _, w := range workspaceID {
+		if w == p.denied {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// TestWebsocket_CloseNeedsNoPermission: Close is connection lifecycle, not a
+// document operation, and is called on shutdown where there is no user context to
+// authorize against.
+func TestWebsocket_CloseNeedsNoPermission(t *testing.T) {
+	i, client, _, _, _ := wsFixture(t, false) // deny everything
+	require.NoError(t, i.Close())
+	assert.Equal(t, 1, client.calls)
+}

--- a/server/api/internal/usecase/interactor/websocket_permission_test.go
+++ b/server/api/internal/usecase/interactor/websocket_permission_test.go
@@ -73,9 +73,20 @@ func wsFixture(t *testing.T, allow bool) (*Websocket, *countingWSClient, *record
 	return NewWebsocket(client, projectRepo, rc), client, rc, prj.ID().String(), accountsid.WorkspaceID(wsID)
 }
 
-// wsOps is every operation on the surface, with the action each must demand.
+// wsOps covers every SINGLE-PROJECT operation, with the action each must demand.
 // Table-driven so a newly added method without a permission check shows up as a
 // missing row rather than passing silently.
+//
+// Two methods are deliberately outside the table, and both have their own test
+// below — do NOT read this list as the full interface:
+//
+//   - CopyDocument addresses two projects, so it does not fit this signature, and
+//     it authorizes twice (edit on the destination, read on the source). Since
+//     recordingChecker keeps only the last call, a row here would assert
+//     ActionRead and quietly stop checking the destination.
+//     See TestWebsocket_CopyDocumentChecksBothProjects.
+//   - Close is connection lifecycle, not a document operation, and carries no
+//     permission check at all. See TestWebsocket_CloseNeedsNoPermission.
 var wsOps = []struct {
 	// call first: keeping the pointer-bearing fields adjacent shortens the range
 	// the GC has to scan (govet fieldalignment).

--- a/server/api/internal/usecase/interactor/websocket_permission_test.go
+++ b/server/api/internal/usecase/interactor/websocket_permission_test.go
@@ -73,95 +73,93 @@ func wsFixture(t *testing.T, allow bool) (*Websocket, *countingWSClient, *record
 	return NewWebsocket(client, projectRepo, rc), client, rc, prj.ID().String(), accountsid.WorkspaceID(wsID)
 }
 
-// wsOps covers every SINGLE-PROJECT operation, with the action each must demand.
-// Table-driven so a newly added method without a permission check shows up as a
-// missing row rather than passing silently.
-//
-// Two methods are deliberately outside the table, and both have their own test
-// below — do NOT read this list as the full interface:
-//
-//   - CopyDocument addresses two projects, so it does not fit this signature, and
-//     it authorizes twice (edit on the destination, read on the source). Since
-//     recordingChecker keeps only the last call, a row here would assert
-//     ActionRead and quietly stop checking the destination.
-//     See TestWebsocket_CopyDocumentChecksBothProjects.
-//   - Close is connection lifecycle, not a document operation, and carries no
-//     permission check at all. See TestWebsocket_CloseNeedsNoPermission.
-var wsOps = []struct {
-	// call first: keeping the pointer-bearing fields adjacent shortens the range
-	// the GC has to scan (govet fieldalignment).
-	call   func(context.Context, *Websocket, string) error
-	name   string
-	action string
-}{
-	{name: "GetLatest", action: rbac.ActionRead, call: func(ctx context.Context, i *Websocket, d string) error {
-		_, err := i.GetLatest(ctx, d)
-		return err
-	}},
-	{name: "GetHistory", action: rbac.ActionRead, call: func(ctx context.Context, i *Websocket, d string) error {
-		_, err := i.GetHistory(ctx, d)
-		return err
-	}},
-	{name: "GetHistoryByVersion", action: rbac.ActionRead, call: func(ctx context.Context, i *Websocket, d string) error {
-		_, err := i.GetHistoryByVersion(ctx, d, 1)
-		return err
-	}},
-	{name: "GetHistoryMetadata", action: rbac.ActionRead, call: func(ctx context.Context, i *Websocket, d string) error {
-		_, err := i.GetHistoryMetadata(ctx, d)
-		return err
-	}},
-	{name: "CreateSnapshot", action: rbac.ActionRead, call: func(ctx context.Context, i *Websocket, d string) error {
-		_, err := i.CreateSnapshot(ctx, d, 1, "n")
-		return err
-	}},
-	{name: "Rollback", action: rbac.ActionEdit, call: func(ctx context.Context, i *Websocket, d string) error {
-		_, err := i.Rollback(ctx, d, 1)
-		return err
-	}},
-	{name: "FlushToGCS", action: rbac.ActionEdit, call: func(ctx context.Context, i *Websocket, d string) error {
-		return i.FlushToGCS(ctx, d)
-	}},
-	{name: "ImportDocument", action: rbac.ActionEdit, call: func(ctx context.Context, i *Websocket, d string) error {
-		return i.ImportDocument(ctx, d, []byte("x"))
-	}},
-	{name: "DeleteDocument", action: rbac.ActionDelete, call: func(ctx context.Context, i *Websocket, d string) error {
-		return i.DeleteDocument(ctx, d)
-	}},
+// assertDenied: a denied operation must error AND never reach the client. The
+// call count is the assertion that matters, since an error that still calls
+// through has denied nothing.
+func assertDenied(t *testing.T, name string, call func(context.Context, *Websocket, string) error) {
+	t.Helper()
+	i, client, _, docID, _ := wsFixture(t, false)
+	err := call(context.Background(), i, docID)
+	assert.ErrorIs(t, err, interfaces.ErrOperationDenied, name)
+	assert.Zero(t, client.calls, "denied %s still called the client", name)
 }
 
-// TestWebsocket_DeniedOperationsNeverReachTheClient is the security assertion.
-// Before this interactor existed, Container.Websocket held the bare HTTP client,
-// so any authenticated user could act on any project in any workspace. The worst
-// of those was Rollback: it prunes every update above the target clock, making it
-// a destructive cross-tenant operation.
+// assertChecks: the check must be scoped to the workspace owning the addressed
+// project, with the right action. Without the workspace the checker could
+// approve on membership of any workspace, which is the cross-tenant hole.
+func assertChecks(t *testing.T, name, action string, call func(context.Context, *Websocket, string) error) {
+	t.Helper()
+	i, client, rc, docID, wsID := wsFixture(t, true)
+	require.NoError(t, call(context.Background(), i, docID), name)
+	assert.Equal(t, rbac.ResourceProject, rc.gotResource, name)
+	assert.Equal(t, action, rc.gotAction, "%s action", name)
+	require.Len(t, rc.gotWorkspace, 1, "%s workspace", name)
+	assert.Equal(t, wsID, rc.gotWorkspace[0], "%s checked the wrong workspace", name)
+	assert.Equal(t, 1, client.calls, "%s should reach the client once", name)
+}
+
+func getLatest(ctx context.Context, i *Websocket, d string) error {
+	_, err := i.GetLatest(ctx, d)
+	return err
+}
+func getHistory(ctx context.Context, i *Websocket, d string) error {
+	_, err := i.GetHistory(ctx, d)
+	return err
+}
+func getHistoryByVersion(ctx context.Context, i *Websocket, d string) error {
+	_, err := i.GetHistoryByVersion(ctx, d, 1)
+	return err
+}
+func getHistoryMetadata(ctx context.Context, i *Websocket, d string) error {
+	_, err := i.GetHistoryMetadata(ctx, d)
+	return err
+}
+func createSnapshot(ctx context.Context, i *Websocket, d string) error {
+	_, err := i.CreateSnapshot(ctx, d, 1, "n")
+	return err
+}
+func rollback(ctx context.Context, i *Websocket, d string) error {
+	_, err := i.Rollback(ctx, d, 1)
+	return err
+}
+func flushToGCS(ctx context.Context, i *Websocket, d string) error { return i.FlushToGCS(ctx, d) }
+func importDocument(ctx context.Context, i *Websocket, d string) error {
+	return i.ImportDocument(ctx, d, []byte("x"))
+}
+func deleteDocument(ctx context.Context, i *Websocket, d string) error {
+	return i.DeleteDocument(ctx, d)
+}
+
+// TestWebsocket_DeniedOperationsNeverReachTheClient is the security assertion:
+// before this interactor, any authenticated user could act on any project.
+//
+// CopyDocument and Close are covered separately below. CopyDocument authorizes
+// twice and recordingChecker keeps only the last call, so listing it here would
+// assert ActionRead and stop checking the destination.
 func TestWebsocket_DeniedOperationsNeverReachTheClient(t *testing.T) {
-	for _, op := range wsOps {
-		t.Run(op.name, func(t *testing.T) {
-			i, client, _, docID, _ := wsFixture(t, false) // permission denied
-			err := op.call(context.Background(), i, docID)
-			assert.ErrorIs(t, err, interfaces.ErrOperationDenied)
-			assert.Zero(t, client.calls, "denied %s still called through to the websocket client", op.name)
-		})
-	}
+	assertDenied(t, "GetLatest", getLatest)
+	assertDenied(t, "GetHistory", getHistory)
+	assertDenied(t, "GetHistoryByVersion", getHistoryByVersion)
+	assertDenied(t, "GetHistoryMetadata", getHistoryMetadata)
+	assertDenied(t, "CreateSnapshot", createSnapshot)
+	assertDenied(t, "Rollback", rollback)
+	assertDenied(t, "FlushToGCS", flushToGCS)
+	assertDenied(t, "ImportDocument", importDocument)
+	assertDenied(t, "DeleteDocument", deleteDocument)
 }
 
-// TestWebsocket_ChecksTargetProjectWorkspace: the check must be evaluated against
-// the workspace that owns the addressed project, not the caller's own. Passing no
-// workspace would let the checker approve based on membership of any workspace,
-// which is the cross-tenant hole this fixes.
+// TestWebsocket_ChecksTargetProjectWorkspace pins the action each operation
+// demands, and that it is evaluated against the addressed project's workspace.
 func TestWebsocket_ChecksTargetProjectWorkspace(t *testing.T) {
-	for _, op := range wsOps {
-		t.Run(op.name, func(t *testing.T) {
-			i, client, rc, docID, wsID := wsFixture(t, true)
-			require.NoError(t, op.call(context.Background(), i, docID))
-
-			assert.Equal(t, rbac.ResourceProject, rc.gotResource)
-			assert.Equal(t, op.action, rc.gotAction, "%s must demand %q", op.name, op.action)
-			require.Len(t, rc.gotWorkspace, 1, "%s must scope the check to one workspace", op.name)
-			assert.Equal(t, wsID, rc.gotWorkspace[0], "%s checked the wrong workspace", op.name)
-			assert.Equal(t, 1, client.calls, "%s should reach the client once when allowed", op.name)
-		})
-	}
+	assertChecks(t, "GetLatest", rbac.ActionRead, getLatest)
+	assertChecks(t, "GetHistory", rbac.ActionRead, getHistory)
+	assertChecks(t, "GetHistoryByVersion", rbac.ActionRead, getHistoryByVersion)
+	assertChecks(t, "GetHistoryMetadata", rbac.ActionRead, getHistoryMetadata)
+	assertChecks(t, "CreateSnapshot", rbac.ActionRead, createSnapshot)
+	assertChecks(t, "Rollback", rbac.ActionEdit, rollback)
+	assertChecks(t, "FlushToGCS", rbac.ActionEdit, flushToGCS)
+	assertChecks(t, "ImportDocument", rbac.ActionEdit, importDocument)
+	assertChecks(t, "DeleteDocument", rbac.ActionDelete, deleteDocument)
 }
 
 // TestWebsocket_UnresolvableProjectIsDenied: authorization depends on resolving


### PR DESCRIPTION
Closes #2337.

## The problem

Every operation on the document/websocket GraphQL surface takes a `projectId` and passed it straight to the websocket HTTP client. That client knows nothing about projects or workspaces, it just forwards. So a caller only had to be **authenticated**, not authorized, and any signed-in user could act on any project in any workspace:

- read another workspace's document state and version history
- call `rollbackProject`, which reaches `PruneAfter` and deletes every update above the target clock, making it a **destructive cross-tenant operation**
- call `importProject` / `copyProject`, writing into projects they do not own

Snapshot labels are user-authored and often descriptive, so even the read path leaks business information without fetching any state.

The cause was a single line of wiring. `interfaces.Container.Websocket` held the bare infrastructure client, while every other `Container` entry is a permission-checking interactor, so no resolver on this surface had a permission layer to inherit from.

## The fix

`interactor.Websocket` now decorates the client: resolve the project to its owning workspace, check `rbac.ResourceProject`, then delegate.

| Operation | Action |
|---|---|
| `latestProjectSnapshot`, `projectHistory`, `projectSnapshot` | `ActionRead` |
| `previewSnapshot` | `ActionRead` |
| `rollbackProject`, `saveSnapshot`, `importProject` | `ActionEdit` |
| `copyProject` | `ActionEdit` on destination + `ActionRead` on source |
| `DeleteDocument` | `ActionDelete` |

Three decisions worth reviewing:

- **`previewSnapshot` is `ActionRead`, not `ActionEdit`.** Despite the underlying method being named `CreateSnapshot`, the websocket server only materializes state at a version and returns it. Requiring edit would wrongly deny read-only users a preview.
- **`copyProject` checks both ends.** Checking only the destination would let a caller pull another workspace's document into a project they legitimately own.
- **Authorization fails closed at every step.** An unparseable id, a missing project, or a lookup error all deny rather than fall through, so a malformed id cannot be used to skip the check.

**Internal callers stay on the raw client, deliberately.** `ProjectDeleter` already checks `ActionDelete` on the workspace, and it cleans up the document *before* removing the project row. Routing it through here would be redundant, and would break if that ordering ever changed.

This also gives `interactor.Websocket` a purpose. It was dead code slated for deletion in #2334: unreferenced, and carrying method names that did not match the interface it was supposedly for. Rather than delete it and add a new type, it becomes the authorization layer it should always have been. **#2334 can be closed once this merges.**

## Testing

Unit tests cover all nine operations in a table, asserting each demands the right action, scopes the check to the addressed project's workspace, and never reaches the client when denied. Verified against three mutants:

| Mutant | Result |
|---|---|
| Authorization is a no-op (the actual pre-fix state) | 18 subtests fail |
| Check runs but ignores the workspace (the cross-tenant hole) | 9 subtests fail |
| `copyProject` checks only the destination | fails |

The e2e test earns its place by covering what the unit tests cannot: that the container actually points at this interactor. Re-pointing it at the raw client leaves every unit test green. It is memory-backed, so it runs without a database.

Two corrections were needed to give that test teeth, and both are worth knowing about:

1. Asserting only "a GraphQL error occurred" **passes under the very bypass it targets**, because an unreachable websocket server errors too. I confirmed that by mutation. It now asserts the message says `operation denied` and does **not** say `server returned`.
2. That tightening then exposed a second problem: the `importProject` row was failing `Bytes` scalar coercion before reaching the resolver, so it had been asserting nothing at all.

Also worth flagging for a follow-up: the pre-existing `TestDocumentOperations` is not coverage of this surface. Its interceptor answers the GraphQL request itself with canned JSON, so it never reaches the resolvers, the container, or the client.

## Verification

`go build ./...` clean, `golangci-lint` clean on touched packages, unit and new e2e tests pass. The Mongo-backed e2e tests were not run locally (no database available); CI covers them.
