### PR TITLE
chore(engine): new geometry new-geometry for UI migration

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.105"
+version = "0.2.106"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "Inflector",
  "approx",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4959,7 +4959,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5008,7 +5008,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5019,7 +5019,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "bytes",
  "clap",
@@ -5061,7 +5061,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5145,7 +5145,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "approx",
  "bvh",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5243,7 +5243,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5272,7 +5272,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5308,7 +5308,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "bytes",
  "futures",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "bytes",
  "futures",
@@ -5375,7 +5375,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "ahash",
  "bytes",
@@ -5459,7 +5459,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.477"
+version = "0.0.478"
 dependencies = [
  "async-trait",
  "axum",
@@ -8225,7 +8225,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.295"
+version = "0.1.296"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -68,7 +68,8 @@ reearth-flow-state = { path = "runtime/state" }
 reearth-flow-storage = { path = "runtime/storage" }
 reearth-flow-telemetry = { path = "runtime/telemetry" }
 reearth-flow-types = { path = "runtime/types" }
-reearth-flow-worker = { path = "worker" }
+# Keeps `reearth-flow-tests` off the worker's `new-geometry` default.
+reearth-flow-worker = { path = "worker", default-features = false }
 
 nusamai-citygml = { git = "https://github.com/reearth/plateau-gis-converter", features = [
   "serde",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.477"
+version = "0.0.478"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Makefile.toml
+++ b/engine/Makefile.toml
@@ -11,24 +11,16 @@ script = ['''
 cargo fmt --all ${@:-}
 ''']
 
-# NOTE: the `new-geometry` migration flag switches `Feature.geometry` to the new type
-# and is mutually exclusive with the default geometry world, so no single feature set
-# covers both. Each world therefore gets its own full `--workspace --all-targets`
-# invocation, and CI runs both.
 [tasks.check]
 script = ['''
 #!/usr/bin/env bash -eux
 cargo check --workspace --all-targets
-cargo check --workspace --all-targets --features new-geometry \
-  --exclude reearth-flow-tests
 ''']
 
 [tasks.clippy]
 script = ['''
 #!/usr/bin/env bash -eux
 cargo clippy --workspace --all-targets -- -D warnings
-cargo clippy --workspace --all-targets --features new-geometry \
-  --exclude reearth-flow-tests -- -D warnings
 ''']
 
 [tasks.clippy-fix]
@@ -50,9 +42,10 @@ cargo make test-conv-new-geometry ${@:-}
 script = ['''
 #!/usr/bin/env bash -eux
 # Both geometry worlds.
-cargo test --workspace --all-targets --exclude workflow-tests ${@:-}
-cargo test --workspace --all-targets --features new-geometry,schema \
+cargo test --workspace --all-targets --features schema \
   --exclude workflow-tests --exclude reearth-flow-tests ${@:-}
+cargo test --workspace --all-targets --no-default-features \
+  --exclude workflow-tests ${@:-}
 ''']
 
 # Runs in the new-geometry world. Every test case whose `workflow_test.json`
@@ -96,8 +89,7 @@ export PLATEAU_TILES_TEST_CONCURRENCY="${PLATEAU_TILES_TEST_CONCURRENCY:-4}" # d
 cargo run -p plateau-tiles-test --bin plateau-tiles-test ${@:-}
 ''']
 
-# Separate task since it builds a distinct binary (new-geometry feature); folds
-# into test-conv once new-geometry becomes the default and this one is removed.
+# Separate task since it builds a distinct binary (new-geometry feature).
 [tasks.test-conv-new-geometry]
 script = ['''
 #!/usr/bin/env bash -eux
@@ -116,7 +108,7 @@ cargo run -p plateau-tiles-test --bin plateau-tiles-test --features new-geometry
 script = ['''
 #!/usr/bin/env bash -eux
 cargo clean --doc
-cargo doc --no-deps --features new-geometry,schema
+cargo doc --no-deps --features schema
 ''']
 
 [tasks.coverage]

--- a/engine/cli/Cargo.toml
+++ b/engine/cli/Cargo.toml
@@ -20,8 +20,7 @@ memory-stats = [
   "reearth-flow-action-plateau-processor/memory-stats",
   "reearth-flow-action-processor/memory-stats",
 ]
-# Temporary migration flag for the new-geometry migration.
-# TODO: Remove after migration.
+# Temporary migration flag, on by default. TODO: Remove after migration.
 new-geometry = [
   "reearth-flow-action-plateau-processor/new-geometry",
   "reearth-flow-action-processor/new-geometry",

--- a/engine/cli/Cargo.toml
+++ b/engine/cli/Cargo.toml
@@ -15,7 +15,7 @@ name = "reearth-flow"
 path = "src/main.rs"
 
 [features]
-default = []
+default = ["new-geometry"]
 memory-stats = [
   "reearth-flow-action-plateau-processor/memory-stats",
   "reearth-flow-action-processor/memory-stats",

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -2139,8 +2139,6 @@ Writes features to Cesium 3D Tiles format for 3D web visualization.
   "description": "Configuration for writing features to Cesium 3D Tiles.",
   "type": "object",
   "required": [
-    "maxZoom",
-    "minZoom",
     "output"
   ],
   "properties": {
@@ -2166,27 +2164,16 @@ Writes features to Cesium 3D Tiles format for 3D web visualization.
         }
       }
     },
-    "minZoom": {
-      "title": "Minimum Zoom Level",
-      "description": "Lowest zoom level to generate tiles for, from 0 to 24.",
-      "type": "integer",
-      "format": "uint8",
-      "minimum": 0.0
-    },
-    "maxZoom": {
-      "title": "Maximum Zoom Level",
-      "description": "Highest zoom level to generate tiles for, from 0 to 24.",
-      "type": "integer",
-      "format": "uint8",
-      "minimum": 0.0
-    },
-    "attachTexture": {
-      "title": "Attach Textures",
-      "description": "Whether to include texture information in the generated tiles.",
+    "maxDepth": {
+      "title": "Max Depth",
+      "description": "Hard cap on the quadtree subdivision depth; tile granularity otherwise follows feature size. Defaults to 24, from 0 to 24.",
       "type": [
-        "boolean",
+        "integer",
         "null"
-      ]
+      ],
+      "format": "uint32",
+      "maximum": 24.0,
+      "minimum": 0.0
     },
     "dracoCompression": {
       "title": "Draco Compression",
@@ -2264,31 +2251,6 @@ Writes features to Cesium 3D Tiles format for 3D web visualization.
         "string",
         "null"
       ]
-    },
-    "compressOutput": {
-      "title": "Compressed Output Path",
-      "description": "Optional path where a compressed archive of the tiles is also written.",
-      "type": [
-        "object",
-        "null"
-      ],
-      "format": "code",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "flowExpr",
-            "string"
-          ]
-        },
-        "value": {
-          "type": "string"
-        }
-      }
     }
   },
   "definitions": {
@@ -2701,6 +2663,186 @@ Extracts coordinates from geometry vertices into feature attributes
 ```
 ### Input Ports
 * features
+### Output Ports
+* features
+* rejected
+### Category
+* Geometry
+
+## Coordinate Frame Reprojector
+### Type
+* processor
+### Description
+Reprojects geometry between coordinate reference systems and converts between a CRS and a Euclidean frame.
+### Parameters
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Coordinate Frame Reprojector Parameters",
+  "description": "Reproject geometry across coordinate reference systems and convert between a CRS and a Euclidean frame. Converting across the Euclidean/CRS boundary reinterprets coordinates as-is: values and ring winding are left unchanged, so orientation follows the destination frame's axis order.\n\nReprojecting across coordinate reference systems takes 2D geometry lying at a single elevation into 3D.",
+  "type": "object",
+  "required": [
+    "destinationFrame"
+  ],
+  "properties": {
+    "destinationFrame": {
+      "title": "Destination Frame",
+      "description": "Coordinate frame to convert geometry into.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/DestinationFrame"
+        }
+      ]
+    },
+    "epsgCode": {
+      "title": "EPSG Code",
+      "description": "EPSG code of the destination CRS. Required when the destination frame is a CRS.",
+      "default": null,
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint16",
+      "minimum": 0.0
+    },
+    "basePointSource": {
+      "title": "Base Point",
+      "description": "How coordinates bridge the Euclidean/CRS boundary.",
+      "default": {
+        "type": "asIs"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/BasePoint"
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "DestinationFrame": {
+      "description": "The destination coordinate frame kind.",
+      "oneOf": [
+        {
+          "title": "CRS",
+          "description": "Reproject to a coordinate reference system identified by an EPSG code.",
+          "type": "string",
+          "enum": [
+            "crs"
+          ]
+        },
+        {
+          "title": "Euclidean",
+          "description": "Convert to a non-georeferenced Euclidean frame.",
+          "type": "string",
+          "enum": [
+            "euclidean"
+          ]
+        }
+      ]
+    },
+    "BasePoint": {
+      "description": "How coordinates bridge the Euclidean/CRS boundary, carrying the input each mode needs. Ignored for a pure CRS-to-CRS reprojection.",
+      "oneOf": [
+        {
+          "title": "As Is",
+          "description": "Reinterpret coordinate values unchanged across the boundary.",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "asIs"
+              ]
+            }
+          }
+        },
+        {
+          "title": "Value",
+          "description": "Offset by a base point given as an expression evaluating to `[x, y, z]`.",
+          "type": "object",
+          "required": [
+            "basePoint",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "value"
+              ]
+            },
+            "basePoint": {
+              "title": "Base Point",
+              "description": "Expression evaluating to an `[x, y, z]` origin in CRS space, in the CRS's declared axis order.",
+              "type": "object",
+              "format": "code",
+              "required": [
+                "type",
+                "value"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "flowExpr"
+                  ]
+                },
+                "value": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "From Port",
+          "description": "Offset by a base point taken from the base-point input port, matched to each feature by a key.",
+          "type": "object",
+          "required": [
+            "matchKey",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "fromPort"
+              ]
+            },
+            "matchKey": {
+              "title": "Match Key",
+              "description": "Expression identifying which base-point feature applies to a given feature. Evaluated against both streams.",
+              "type": "object",
+              "format": "code",
+              "required": [
+                "type",
+                "value"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "flowExpr"
+                  ]
+                },
+                "value": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+### Input Ports
+* features
+* base-point
 ### Output Ports
 * features
 * rejected
@@ -5337,22 +5479,6 @@ Filter Features by Geometry Type
       }
     },
     {
-      "title": "Multiple Geometries",
-      "description": "Separates the features whose geometry is a container that can hold more than one part.",
-      "type": "object",
-      "required": [
-        "filterType"
-      ],
-      "properties": {
-        "filterType": {
-          "type": "string",
-          "enum": [
-            "multiple"
-          ]
-        }
-      }
-    },
-    {
       "title": "Geometry Type",
       "description": "Routes by the geometry family a feature belongs to: point, curve, surface, triangle or solid.",
       "type": "object",
@@ -5367,6 +5493,22 @@ Filter Features by Geometry Type
           ]
         }
       }
+    },
+    {
+      "title": "Detailed Geometry Type",
+      "description": "Routes by the exact geometry type rather than the family, so a face, a surface mesh and a multi-surface each leave by their own port.",
+      "type": "object",
+      "required": [
+        "filterType"
+      ],
+      "properties": {
+        "filterType": {
+          "type": "string",
+          "enum": [
+            "detailedGeometryType"
+          ]
+        }
+      }
     }
   ]
 }
@@ -5376,17 +5518,24 @@ Filter Features by Geometry Type
 ### Output Ports
 * unfiltered
 * none
-* contains
-* solid
-* multiSurface
-* compositeSurface
+* point
+* curve
 * surface
 * triangle
-* multiCurve
-* curve
-* multiPoint
-* point
-* tin
+* solid
+* multi-point
+* point-cloud
+* line-string
+* multi-curve
+* polygon
+* multi-area
+* face
+* polygon-mesh
+* triangular-mesh
+* multi-surface
+* csg
+* multi-solid
+* aggregate
 ### Category
 * Geometry
 
@@ -5499,46 +5648,7 @@ Replace Feature Geometry from Attribute
 ### Description
 Split Multi-Geometries into Individual Features
 ### Parameters
-```json
-{
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "GeometrySplitterParam",
-  "description": "Parameters for GeometrySplitter",
-  "type": "object",
-  "properties": {
-    "splitLevel": {
-      "description": "Split level for CityGML geometry. - \"element\": Split by surface elements (RoofSurface, WallSurface, etc.) - default - \"polygon\": Split down to individual polygons within each element",
-      "default": "element",
-      "allOf": [
-        {
-          "$ref": "#/definitions/SplitLevel"
-        }
-      ]
-    }
-  },
-  "definitions": {
-    "SplitLevel": {
-      "description": "Split level for CityGML geometry",
-      "oneOf": [
-        {
-          "description": "Split by GmlGeometry elements (e.g., RoofSurface, WallSurface)",
-          "type": "string",
-          "enum": [
-            "element"
-          ]
-        },
-        {
-          "description": "Split down to individual polygons within each element",
-          "type": "string",
-          "enum": [
-            "polygon"
-          ]
-        }
-      ]
-    }
-  }
-}
-```
+* No parameters
 ### Input Ports
 * features
 ### Output Ports
@@ -5559,14 +5669,6 @@ Validate Feature Geometry Quality
   "description": "Configure which validation checks to perform on feature geometries",
   "type": "object",
   "properties": {
-    "validationTypes": {
-      "title": "Validation Types",
-      "default": [],
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/ValidationType"
-      }
-    },
     "disabledOptionalChecks": {
       "title": "Disabled Optional Checks",
       "description": "Advisory checks to disable. Disabled checks do not run and are treated as passing; core validity checks always run. Empty by default, so every optional check runs.",
@@ -5615,63 +5717,6 @@ Validate Feature Geometry Quality
     }
   },
   "definitions": {
-    "ValidationType": {
-      "oneOf": [
-        {
-          "type": "string",
-          "enum": [
-            "duplicatePoints"
-          ]
-        },
-        {
-          "type": "object",
-          "required": [
-            "duplicateConsecutivePoints"
-          ],
-          "properties": {
-            "duplicateConsecutivePoints": {
-              "type": "number",
-              "format": "double"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "Corrupt geometry check with optional tolerance for interior/exterior ring intersection.",
-          "type": "object",
-          "required": [
-            "corruptGeometry"
-          ],
-          "properties": {
-            "corruptGeometry": {
-              "type": [
-                "number",
-                "null"
-              ],
-              "format": "double"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "Self-intersection check with optional tolerance. If tolerance is None or 0.0, exact intersection check is performed. If tolerance > 0.0, intersections within tolerance distance are ignored.",
-          "type": "object",
-          "required": [
-            "selfIntersection"
-          ],
-          "properties": {
-            "selfIntersection": {
-              "type": [
-                "number",
-                "null"
-              ],
-              "format": "double"
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
     "OptionalCheck": {
       "description": "An advisory (optional) validation check that can be individually disabled. A disabled check does not run and is treated as passing. Only checks that the geometry crate classifies as optional are listed here; core validity checks always run and cannot be disabled.",
       "type": "string",
@@ -12447,6 +12492,7 @@ Force 3D Geometry to 2D by Removing Z-Coordinates
 * features
 ### Output Ports
 * features
+* rejected
 ### Category
 * Geometry
 

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -2172,8 +2172,6 @@
         "description": "Configuration for writing features to Cesium 3D Tiles.",
         "type": "object",
         "required": [
-          "maxZoom",
-          "minZoom",
           "output"
         ],
         "properties": {
@@ -2199,27 +2197,16 @@
               }
             }
           },
-          "minZoom": {
-            "title": "Minimum Zoom Level",
-            "description": "Lowest zoom level to generate tiles for, from 0 to 24.",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "maxZoom": {
-            "title": "Maximum Zoom Level",
-            "description": "Highest zoom level to generate tiles for, from 0 to 24.",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "attachTexture": {
-            "title": "Attach Textures",
-            "description": "Whether to include texture information in the generated tiles.",
+          "maxDepth": {
+            "title": "Max Depth",
+            "description": "Hard cap on the quadtree subdivision depth; tile granularity otherwise follows feature size. Defaults to 24, from 0 to 24.",
             "type": [
-              "boolean",
+              "integer",
               "null"
-            ]
+            ],
+            "format": "uint32",
+            "maximum": 24.0,
+            "minimum": 0.0
           },
           "dracoCompression": {
             "title": "Draco Compression",
@@ -2297,31 +2284,6 @@
               "string",
               "null"
             ]
-          },
-          "compressOutput": {
-            "title": "Compressed Output Path",
-            "description": "Optional path where a compressed archive of the tiles is also written.",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
           }
         },
         "definitions": {
@@ -2761,6 +2723,190 @@
         "Geometry"
       ],
       "tags": []
+    },
+    {
+      "name": "Coordinate Frame Reprojector",
+      "type": "processor",
+      "description": "Reprojects geometry between coordinate reference systems and converts between a CRS and a Euclidean frame.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Coordinate Frame Reprojector Parameters",
+        "description": "Reproject geometry across coordinate reference systems and convert between a CRS and a Euclidean frame. Converting across the Euclidean/CRS boundary reinterprets coordinates as-is: values and ring winding are left unchanged, so orientation follows the destination frame's axis order.\n\nReprojecting across coordinate reference systems takes 2D geometry lying at a single elevation into 3D.",
+        "type": "object",
+        "required": [
+          "destinationFrame"
+        ],
+        "properties": {
+          "destinationFrame": {
+            "title": "Destination Frame",
+            "description": "Coordinate frame to convert geometry into.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/DestinationFrame"
+              }
+            ]
+          },
+          "epsgCode": {
+            "title": "EPSG Code",
+            "description": "EPSG code of the destination CRS. Required when the destination frame is a CRS.",
+            "default": null,
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint16",
+            "minimum": 0.0
+          },
+          "basePointSource": {
+            "title": "Base Point",
+            "description": "How coordinates bridge the Euclidean/CRS boundary.",
+            "default": {
+              "type": "asIs"
+            },
+            "allOf": [
+              {
+                "$ref": "#/definitions/BasePoint"
+              }
+            ]
+          }
+        },
+        "definitions": {
+          "DestinationFrame": {
+            "description": "The destination coordinate frame kind.",
+            "oneOf": [
+              {
+                "title": "CRS",
+                "description": "Reproject to a coordinate reference system identified by an EPSG code.",
+                "type": "string",
+                "enum": [
+                  "crs"
+                ]
+              },
+              {
+                "title": "Euclidean",
+                "description": "Convert to a non-georeferenced Euclidean frame.",
+                "type": "string",
+                "enum": [
+                  "euclidean"
+                ]
+              }
+            ]
+          },
+          "BasePoint": {
+            "description": "How coordinates bridge the Euclidean/CRS boundary, carrying the input each mode needs. Ignored for a pure CRS-to-CRS reprojection.",
+            "oneOf": [
+              {
+                "title": "As Is",
+                "description": "Reinterpret coordinate values unchanged across the boundary.",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "asIs"
+                    ]
+                  }
+                }
+              },
+              {
+                "title": "Value",
+                "description": "Offset by a base point given as an expression evaluating to `[x, y, z]`.",
+                "type": "object",
+                "required": [
+                  "basePoint",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "value"
+                    ]
+                  },
+                  "basePoint": {
+                    "title": "Base Point",
+                    "description": "Expression evaluating to an `[x, y, z]` origin in CRS space, in the CRS's declared axis order.",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "From Port",
+                "description": "Offset by a base point taken from the base-point input port, matched to each feature by a key.",
+                "type": "object",
+                "required": [
+                  "matchKey",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "fromPort"
+                    ]
+                  },
+                  "matchKey": {
+                    "title": "Match Key",
+                    "description": "Expression identifying which base-point feature applies to a given feature. Evaluated against both streams.",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "features",
+        "base-point"
+      ],
+      "outputPorts": [
+        "features",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ],
+      "tags": [
+        "coordinate-system",
+        "3d"
+      ]
     },
     {
       "name": "Date Time Converter",
@@ -5480,22 +5626,6 @@
             }
           },
           {
-            "title": "Multiple Geometries",
-            "description": "Separates the features whose geometry is a container that can hold more than one part.",
-            "type": "object",
-            "required": [
-              "filterType"
-            ],
-            "properties": {
-              "filterType": {
-                "type": "string",
-                "enum": [
-                  "multiple"
-                ]
-              }
-            }
-          },
-          {
             "title": "Geometry Type",
             "description": "Routes by the geometry family a feature belongs to: point, curve, surface, triangle or solid.",
             "type": "object",
@@ -5510,6 +5640,22 @@
                 ]
               }
             }
+          },
+          {
+            "title": "Detailed Geometry Type",
+            "description": "Routes by the exact geometry type rather than the family, so a face, a surface mesh and a multi-surface each leave by their own port.",
+            "type": "object",
+            "required": [
+              "filterType"
+            ],
+            "properties": {
+              "filterType": {
+                "type": "string",
+                "enum": [
+                  "detailedGeometryType"
+                ]
+              }
+            }
           }
         ]
       },
@@ -5520,17 +5666,24 @@
       "outputPorts": [
         "unfiltered",
         "none",
-        "contains",
-        "solid",
-        "multiSurface",
-        "compositeSurface",
+        "point",
+        "curve",
         "surface",
         "triangle",
-        "multiCurve",
-        "curve",
-        "multiPoint",
-        "point",
-        "tin"
+        "solid",
+        "multi-point",
+        "point-cloud",
+        "line-string",
+        "multi-curve",
+        "polygon",
+        "multi-area",
+        "face",
+        "polygon-mesh",
+        "triangular-mesh",
+        "multi-surface",
+        "csg",
+        "multi-solid",
+        "aggregate"
       ],
       "categories": [
         "Geometry"
@@ -5651,44 +5804,7 @@
       "name": "Geometry Splitter",
       "type": "processor",
       "description": "Split Multi-Geometries into Individual Features",
-      "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "GeometrySplitterParam",
-        "description": "Parameters for GeometrySplitter",
-        "type": "object",
-        "properties": {
-          "splitLevel": {
-            "description": "Split level for CityGML geometry. - \"element\": Split by surface elements (RoofSurface, WallSurface, etc.) - default - \"polygon\": Split down to individual polygons within each element",
-            "default": "element",
-            "allOf": [
-              {
-                "$ref": "#/definitions/SplitLevel"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "SplitLevel": {
-            "description": "Split level for CityGML geometry",
-            "oneOf": [
-              {
-                "description": "Split by GmlGeometry elements (e.g., RoofSurface, WallSurface)",
-                "type": "string",
-                "enum": [
-                  "element"
-                ]
-              },
-              {
-                "description": "Split down to individual polygons within each element",
-                "type": "string",
-                "enum": [
-                  "polygon"
-                ]
-              }
-            ]
-          }
-        }
-      },
+      "parameter": null,
       "builtin": true,
       "inputPorts": [
         "features"
@@ -5714,14 +5830,6 @@
         "description": "Configure which validation checks to perform on feature geometries",
         "type": "object",
         "properties": {
-          "validationTypes": {
-            "title": "Validation Types",
-            "default": [],
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/ValidationType"
-            }
-          },
           "disabledOptionalChecks": {
             "title": "Disabled Optional Checks",
             "description": "Advisory checks to disable. Disabled checks do not run and are treated as passing; core validity checks always run. Empty by default, so every optional check runs.",
@@ -5770,63 +5878,6 @@
           }
         },
         "definitions": {
-          "ValidationType": {
-            "oneOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "duplicatePoints"
-                ]
-              },
-              {
-                "type": "object",
-                "required": [
-                  "duplicateConsecutivePoints"
-                ],
-                "properties": {
-                  "duplicateConsecutivePoints": {
-                    "type": "number",
-                    "format": "double"
-                  }
-                },
-                "additionalProperties": false
-              },
-              {
-                "description": "Corrupt geometry check with optional tolerance for interior/exterior ring intersection.",
-                "type": "object",
-                "required": [
-                  "corruptGeometry"
-                ],
-                "properties": {
-                  "corruptGeometry": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "format": "double"
-                  }
-                },
-                "additionalProperties": false
-              },
-              {
-                "description": "Self-intersection check with optional tolerance. If tolerance is None or 0.0, exact intersection check is performed. If tolerance > 0.0, intersections within tolerance distance are ignored.",
-                "type": "object",
-                "required": [
-                  "selfIntersection"
-                ],
-                "properties": {
-                  "selfIntersection": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "format": "double"
-                  }
-                },
-                "additionalProperties": false
-              }
-            ]
-          },
           "OptionalCheck": {
             "description": "An advisory (optional) validation check that can be individually disabled. A disabled check does not run and is treated as passing. Only checks that the geometry crate classifies as optional are listed here; core validity checks always run and cannot be disabled.",
             "type": "string",
@@ -12768,7 +12819,8 @@
         "features"
       ],
       "outputPorts": [
-        "features"
+        "features",
+        "rejected"
       ],
       "categories": [
         "Geometry"

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -2172,8 +2172,6 @@
         "description": "Configuration for writing features to Cesium 3D Tiles.",
         "type": "object",
         "required": [
-          "maxZoom",
-          "minZoom",
           "output"
         ],
         "properties": {
@@ -2199,27 +2197,16 @@
               }
             }
           },
-          "minZoom": {
-            "title": "Nivel de Zoom Mínimo",
-            "description": "Nivel de zoom mínimo para la generación de mosaicos (0-24)",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "maxZoom": {
-            "title": "Nivel de Zoom Máximo",
-            "description": "Nivel de zoom máximo para la generación de mosaicos (0-24)",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "attachTexture": {
-            "title": "Adjuntar Texturas",
-            "description": "Si se debe incluir información de textura en los mosaicos generados",
+          "maxDepth": {
+            "title": "Profundidad Máxima",
+            "description": "Límite máximo de la profundidad de subdivisión del quadtree; por lo demás, la granularidad de los mosaicos sigue el tamaño de las entidades. Por defecto 24, de 0 a 24.",
             "type": [
-              "boolean",
+              "integer",
               "null"
-            ]
+            ],
+            "format": "uint32",
+            "maximum": 24.0,
+            "minimum": 0.0
           },
           "dracoCompression": {
             "title": "Compresión Draco",
@@ -2297,31 +2284,6 @@
               "string",
               "null"
             ]
-          },
-          "compressOutput": {
-            "title": "Ruta de Salida Comprimida",
-            "description": "Ruta opcional para la salida del archivo comprimido",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
           }
         },
         "definitions": {
@@ -2761,6 +2723,190 @@
         "Geometry"
       ],
       "tags": []
+    },
+    {
+      "name": "Coordinate Frame Reprojector",
+      "type": "processor",
+      "description": "Reproyecta la geometría entre sistemas de referencia de coordenadas y convierte entre un SRC y un marco euclídeo",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Coordinate Frame Reprojector Parameters",
+        "description": "Reproject geometry across coordinate reference systems and convert between a CRS and a Euclidean frame. Converting across the Euclidean/CRS boundary reinterprets coordinates as-is: values and ring winding are left unchanged, so orientation follows the destination frame's axis order.\n\nReprojecting across coordinate reference systems takes 2D geometry lying at a single elevation into 3D.",
+        "type": "object",
+        "required": [
+          "destinationFrame"
+        ],
+        "properties": {
+          "destinationFrame": {
+            "title": "Destination Frame",
+            "description": "Coordinate frame to convert geometry into.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/DestinationFrame"
+              }
+            ]
+          },
+          "epsgCode": {
+            "title": "EPSG Code",
+            "description": "EPSG code of the destination CRS. Required when the destination frame is a CRS.",
+            "default": null,
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint16",
+            "minimum": 0.0
+          },
+          "basePointSource": {
+            "title": "Base Point",
+            "description": "How coordinates bridge the Euclidean/CRS boundary.",
+            "default": {
+              "type": "asIs"
+            },
+            "allOf": [
+              {
+                "$ref": "#/definitions/BasePoint"
+              }
+            ]
+          }
+        },
+        "definitions": {
+          "DestinationFrame": {
+            "description": "The destination coordinate frame kind.",
+            "oneOf": [
+              {
+                "title": "CRS",
+                "description": "Reproject to a coordinate reference system identified by an EPSG code.",
+                "type": "string",
+                "enum": [
+                  "crs"
+                ]
+              },
+              {
+                "title": "Euclidean",
+                "description": "Convert to a non-georeferenced Euclidean frame.",
+                "type": "string",
+                "enum": [
+                  "euclidean"
+                ]
+              }
+            ]
+          },
+          "BasePoint": {
+            "description": "How coordinates bridge the Euclidean/CRS boundary, carrying the input each mode needs. Ignored for a pure CRS-to-CRS reprojection.",
+            "oneOf": [
+              {
+                "title": "As Is",
+                "description": "Reinterpret coordinate values unchanged across the boundary.",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "asIs"
+                    ]
+                  }
+                }
+              },
+              {
+                "title": "Value",
+                "description": "Offset by a base point given as an expression evaluating to `[x, y, z]`.",
+                "type": "object",
+                "required": [
+                  "basePoint",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "value"
+                    ]
+                  },
+                  "basePoint": {
+                    "title": "Base Point",
+                    "description": "Expression evaluating to an `[x, y, z]` origin in CRS space, in the CRS's declared axis order.",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "From Port",
+                "description": "Offset by a base point taken from the base-point input port, matched to each feature by a key.",
+                "type": "object",
+                "required": [
+                  "matchKey",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "fromPort"
+                    ]
+                  },
+                  "matchKey": {
+                    "title": "Match Key",
+                    "description": "Expression identifying which base-point feature applies to a given feature. Evaluated against both streams.",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "features",
+        "base-point"
+      ],
+      "outputPorts": [
+        "features",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ],
+      "tags": [
+        "coordinate-system",
+        "3d"
+      ]
     },
     {
       "name": "Date Time Converter",
@@ -5480,22 +5626,6 @@
             }
           },
           {
-            "title": "Multiple Geometries",
-            "description": "Separates the features whose geometry is a container that can hold more than one part.",
-            "type": "object",
-            "required": [
-              "filterType"
-            ],
-            "properties": {
-              "filterType": {
-                "type": "string",
-                "enum": [
-                  "multiple"
-                ]
-              }
-            }
-          },
-          {
             "title": "Geometry Type",
             "description": "Routes by the geometry family a feature belongs to: point, curve, surface, triangle or solid.",
             "type": "object",
@@ -5510,6 +5640,22 @@
                 ]
               }
             }
+          },
+          {
+            "title": "Detailed Geometry Type",
+            "description": "Routes by the exact geometry type rather than the family, so a face, a surface mesh and a multi-surface each leave by their own port.",
+            "type": "object",
+            "required": [
+              "filterType"
+            ],
+            "properties": {
+              "filterType": {
+                "type": "string",
+                "enum": [
+                  "detailedGeometryType"
+                ]
+              }
+            }
           }
         ]
       },
@@ -5520,17 +5666,24 @@
       "outputPorts": [
         "unfiltered",
         "none",
-        "contains",
-        "solid",
-        "multiSurface",
-        "compositeSurface",
+        "point",
+        "curve",
         "surface",
         "triangle",
-        "multiCurve",
-        "curve",
-        "multiPoint",
-        "point",
-        "tin"
+        "solid",
+        "multi-point",
+        "point-cloud",
+        "line-string",
+        "multi-curve",
+        "polygon",
+        "multi-area",
+        "face",
+        "polygon-mesh",
+        "triangular-mesh",
+        "multi-surface",
+        "csg",
+        "multi-solid",
+        "aggregate"
       ],
       "categories": [
         "Geometry"
@@ -5651,44 +5804,7 @@
       "name": "Geometry Splitter",
       "type": "processor",
       "description": "Divide la geometría por tipo",
-      "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "GeometrySplitterParam",
-        "description": "Parameters for GeometrySplitter",
-        "type": "object",
-        "properties": {
-          "splitLevel": {
-            "description": "Split level for CityGML geometry. - \"element\": Split by surface elements (RoofSurface, WallSurface, etc.) - default - \"polygon\": Split down to individual polygons within each element",
-            "default": "element",
-            "allOf": [
-              {
-                "$ref": "#/definitions/SplitLevel"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "SplitLevel": {
-            "description": "Split level for CityGML geometry",
-            "oneOf": [
-              {
-                "description": "Split by GmlGeometry elements (e.g., RoofSurface, WallSurface)",
-                "type": "string",
-                "enum": [
-                  "element"
-                ]
-              },
-              {
-                "description": "Split down to individual polygons within each element",
-                "type": "string",
-                "enum": [
-                  "polygon"
-                ]
-              }
-            ]
-          }
-        }
-      },
+      "parameter": null,
       "builtin": true,
       "inputPorts": [
         "features"
@@ -5714,15 +5830,6 @@
         "description": "Configure which validation checks to perform on feature geometries",
         "type": "object",
         "properties": {
-          "validationTypes": {
-            "title": "Validation Types",
-            "default": [],
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/ValidationType"
-            },
-            "description": "List of validation checks to perform on the geometry (duplicate points, corrupt geometry, self-intersection)"
-          },
           "disabledOptionalChecks": {
             "title": "Disabled Optional Checks",
             "description": "Advisory checks to disable. Disabled checks do not run and are treated as passing; core validity checks always run. Empty by default, so every optional check runs. Applies only under the new geometry backend.",
@@ -5771,63 +5878,6 @@
           }
         },
         "definitions": {
-          "ValidationType": {
-            "oneOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "duplicatePoints"
-                ]
-              },
-              {
-                "type": "object",
-                "required": [
-                  "duplicateConsecutivePoints"
-                ],
-                "properties": {
-                  "duplicateConsecutivePoints": {
-                    "type": "number",
-                    "format": "double"
-                  }
-                },
-                "additionalProperties": false
-              },
-              {
-                "description": "Corrupt geometry check with optional tolerance for interior/exterior ring intersection.",
-                "type": "object",
-                "required": [
-                  "corruptGeometry"
-                ],
-                "properties": {
-                  "corruptGeometry": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "format": "double"
-                  }
-                },
-                "additionalProperties": false
-              },
-              {
-                "description": "Self-intersection check with optional tolerance. If tolerance is None or 0.0, exact intersection check is performed. If tolerance > 0.0, intersections within tolerance distance are ignored.",
-                "type": "object",
-                "required": [
-                  "selfIntersection"
-                ],
-                "properties": {
-                  "selfIntersection": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "format": "double"
-                  }
-                },
-                "additionalProperties": false
-              }
-            ]
-          },
           "OptionalCheck": {
             "description": "An advisory (optional) validation check that can be individually disabled. A disabled check does not run and is treated as passing. Only checks that the geometry crate classifies as optional are listed here; core validity checks always run and cannot be disabled.",
             "type": "string",
@@ -12769,7 +12819,8 @@
         "features"
       ],
       "outputPorts": [
-        "features"
+        "features",
+        "rejected"
       ],
       "categories": [
         "Geometry"

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -2198,8 +2198,8 @@
             }
           },
           "maxDepth": {
-            "title": "Profundidad Máxima",
-            "description": "Límite máximo de la profundidad de subdivisión del quadtree; por lo demás, la granularidad de los mosaicos sigue el tamaño de las entidades. Por defecto 24, de 0 a 24.",
+            "title": "Max Depth",
+            "description": "Hard cap on the quadtree subdivision depth; tile granularity otherwise follows feature size. Defaults to 24, from 0 to 24.",
             "type": [
               "integer",
               "null"
@@ -2727,7 +2727,7 @@
     {
       "name": "Coordinate Frame Reprojector",
       "type": "processor",
-      "description": "Reproyecta la geometría entre sistemas de referencia de coordenadas y convierte entre un SRC y un marco euclídeo",
+      "description": "Reprojects geometry between coordinate reference systems and converts between a CRS and a Euclidean frame.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Coordinate Frame Reprojector Parameters",

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -2198,8 +2198,8 @@
             }
           },
           "maxDepth": {
-            "title": "Profondeur Maximale",
-            "description": "Limite stricte de la profondeur de subdivision du quadtree ; sinon, la granularité des tuiles suit la taille des entités. Par défaut 24, de 0 à 24.",
+            "title": "Max Depth",
+            "description": "Hard cap on the quadtree subdivision depth; tile granularity otherwise follows feature size. Defaults to 24, from 0 to 24.",
             "type": [
               "integer",
               "null"
@@ -2727,7 +2727,7 @@
     {
       "name": "Coordinate Frame Reprojector",
       "type": "processor",
-      "description": "Reprojette la géométrie entre systèmes de coordonnées de référence et convertit entre un SCR et un repère euclidien",
+      "description": "Reprojects geometry between coordinate reference systems and converts between a CRS and a Euclidean frame.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Coordinate Frame Reprojector Parameters",

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -2172,8 +2172,6 @@
         "description": "Configuration for writing features to Cesium 3D Tiles.",
         "type": "object",
         "required": [
-          "maxZoom",
-          "minZoom",
           "output"
         ],
         "properties": {
@@ -2199,27 +2197,16 @@
               }
             }
           },
-          "minZoom": {
-            "title": "Niveau de Zoom Minimum",
-            "description": "Niveau de zoom minimum pour la génération de tuiles (0-24)",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "maxZoom": {
-            "title": "Niveau de Zoom Maximum",
-            "description": "Niveau de zoom maximum pour la génération de tuiles (0-24)",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "attachTexture": {
-            "title": "Joindre les Textures",
-            "description": "Indique s'il faut inclure les informations de texture dans les tuiles générées",
+          "maxDepth": {
+            "title": "Profondeur Maximale",
+            "description": "Limite stricte de la profondeur de subdivision du quadtree ; sinon, la granularité des tuiles suit la taille des entités. Par défaut 24, de 0 à 24.",
             "type": [
-              "boolean",
+              "integer",
               "null"
-            ]
+            ],
+            "format": "uint32",
+            "maximum": 24.0,
+            "minimum": 0.0
           },
           "dracoCompression": {
             "title": "Compression Draco",
@@ -2297,31 +2284,6 @@
               "string",
               "null"
             ]
-          },
-          "compressOutput": {
-            "title": "Chemin de Sortie Compressé",
-            "description": "Chemin optionnel pour la sortie de l'archive compressée",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
           }
         },
         "definitions": {
@@ -2761,6 +2723,190 @@
         "Geometry"
       ],
       "tags": []
+    },
+    {
+      "name": "Coordinate Frame Reprojector",
+      "type": "processor",
+      "description": "Reprojette la géométrie entre systèmes de coordonnées de référence et convertit entre un SCR et un repère euclidien",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Coordinate Frame Reprojector Parameters",
+        "description": "Reproject geometry across coordinate reference systems and convert between a CRS and a Euclidean frame. Converting across the Euclidean/CRS boundary reinterprets coordinates as-is: values and ring winding are left unchanged, so orientation follows the destination frame's axis order.\n\nReprojecting across coordinate reference systems takes 2D geometry lying at a single elevation into 3D.",
+        "type": "object",
+        "required": [
+          "destinationFrame"
+        ],
+        "properties": {
+          "destinationFrame": {
+            "title": "Destination Frame",
+            "description": "Coordinate frame to convert geometry into.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/DestinationFrame"
+              }
+            ]
+          },
+          "epsgCode": {
+            "title": "EPSG Code",
+            "description": "EPSG code of the destination CRS. Required when the destination frame is a CRS.",
+            "default": null,
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint16",
+            "minimum": 0.0
+          },
+          "basePointSource": {
+            "title": "Base Point",
+            "description": "How coordinates bridge the Euclidean/CRS boundary.",
+            "default": {
+              "type": "asIs"
+            },
+            "allOf": [
+              {
+                "$ref": "#/definitions/BasePoint"
+              }
+            ]
+          }
+        },
+        "definitions": {
+          "DestinationFrame": {
+            "description": "The destination coordinate frame kind.",
+            "oneOf": [
+              {
+                "title": "CRS",
+                "description": "Reproject to a coordinate reference system identified by an EPSG code.",
+                "type": "string",
+                "enum": [
+                  "crs"
+                ]
+              },
+              {
+                "title": "Euclidean",
+                "description": "Convert to a non-georeferenced Euclidean frame.",
+                "type": "string",
+                "enum": [
+                  "euclidean"
+                ]
+              }
+            ]
+          },
+          "BasePoint": {
+            "description": "How coordinates bridge the Euclidean/CRS boundary, carrying the input each mode needs. Ignored for a pure CRS-to-CRS reprojection.",
+            "oneOf": [
+              {
+                "title": "As Is",
+                "description": "Reinterpret coordinate values unchanged across the boundary.",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "asIs"
+                    ]
+                  }
+                }
+              },
+              {
+                "title": "Value",
+                "description": "Offset by a base point given as an expression evaluating to `[x, y, z]`.",
+                "type": "object",
+                "required": [
+                  "basePoint",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "value"
+                    ]
+                  },
+                  "basePoint": {
+                    "title": "Base Point",
+                    "description": "Expression evaluating to an `[x, y, z]` origin in CRS space, in the CRS's declared axis order.",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "From Port",
+                "description": "Offset by a base point taken from the base-point input port, matched to each feature by a key.",
+                "type": "object",
+                "required": [
+                  "matchKey",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "fromPort"
+                    ]
+                  },
+                  "matchKey": {
+                    "title": "Match Key",
+                    "description": "Expression identifying which base-point feature applies to a given feature. Evaluated against both streams.",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "features",
+        "base-point"
+      ],
+      "outputPorts": [
+        "features",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ],
+      "tags": [
+        "coordinate-system",
+        "3d"
+      ]
     },
     {
       "name": "Date Time Converter",
@@ -5480,22 +5626,6 @@
             }
           },
           {
-            "title": "Multiple Geometries",
-            "description": "Separates the features whose geometry is a container that can hold more than one part.",
-            "type": "object",
-            "required": [
-              "filterType"
-            ],
-            "properties": {
-              "filterType": {
-                "type": "string",
-                "enum": [
-                  "multiple"
-                ]
-              }
-            }
-          },
-          {
             "title": "Geometry Type",
             "description": "Routes by the geometry family a feature belongs to: point, curve, surface, triangle or solid.",
             "type": "object",
@@ -5510,6 +5640,22 @@
                 ]
               }
             }
+          },
+          {
+            "title": "Detailed Geometry Type",
+            "description": "Routes by the exact geometry type rather than the family, so a face, a surface mesh and a multi-surface each leave by their own port.",
+            "type": "object",
+            "required": [
+              "filterType"
+            ],
+            "properties": {
+              "filterType": {
+                "type": "string",
+                "enum": [
+                  "detailedGeometryType"
+                ]
+              }
+            }
           }
         ]
       },
@@ -5520,17 +5666,24 @@
       "outputPorts": [
         "unfiltered",
         "none",
-        "contains",
-        "solid",
-        "multiSurface",
-        "compositeSurface",
+        "point",
+        "curve",
         "surface",
         "triangle",
-        "multiCurve",
-        "curve",
-        "multiPoint",
-        "point",
-        "tin"
+        "solid",
+        "multi-point",
+        "point-cloud",
+        "line-string",
+        "multi-curve",
+        "polygon",
+        "multi-area",
+        "face",
+        "polygon-mesh",
+        "triangular-mesh",
+        "multi-surface",
+        "csg",
+        "multi-solid",
+        "aggregate"
       ],
       "categories": [
         "Geometry"
@@ -5651,44 +5804,7 @@
       "name": "Geometry Splitter",
       "type": "processor",
       "description": "Split Multi-Geometries into Individual Features",
-      "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "GeometrySplitterParam",
-        "description": "Parameters for GeometrySplitter",
-        "type": "object",
-        "properties": {
-          "splitLevel": {
-            "description": "Split level for CityGML geometry. - \"element\": Split by surface elements (RoofSurface, WallSurface, etc.) - default - \"polygon\": Split down to individual polygons within each element",
-            "default": "element",
-            "allOf": [
-              {
-                "$ref": "#/definitions/SplitLevel"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "SplitLevel": {
-            "description": "Split level for CityGML geometry",
-            "oneOf": [
-              {
-                "description": "Split by GmlGeometry elements (e.g., RoofSurface, WallSurface)",
-                "type": "string",
-                "enum": [
-                  "element"
-                ]
-              },
-              {
-                "description": "Split down to individual polygons within each element",
-                "type": "string",
-                "enum": [
-                  "polygon"
-                ]
-              }
-            ]
-          }
-        }
-      },
+      "parameter": null,
       "builtin": true,
       "inputPorts": [
         "features"
@@ -5714,15 +5830,6 @@
         "description": "Configure which validation checks to perform on feature geometries",
         "type": "object",
         "properties": {
-          "validationTypes": {
-            "title": "Validation Types",
-            "default": [],
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/ValidationType"
-            },
-            "description": "List of validation checks to perform on the geometry (duplicate points, corrupt geometry, self-intersection)"
-          },
           "disabledOptionalChecks": {
             "title": "Disabled Optional Checks",
             "description": "Advisory checks to disable. Disabled checks do not run and are treated as passing; core validity checks always run. Empty by default, so every optional check runs. Applies only under the new geometry backend.",
@@ -5771,63 +5878,6 @@
           }
         },
         "definitions": {
-          "ValidationType": {
-            "oneOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "duplicatePoints"
-                ]
-              },
-              {
-                "type": "object",
-                "required": [
-                  "duplicateConsecutivePoints"
-                ],
-                "properties": {
-                  "duplicateConsecutivePoints": {
-                    "type": "number",
-                    "format": "double"
-                  }
-                },
-                "additionalProperties": false
-              },
-              {
-                "description": "Corrupt geometry check with optional tolerance for interior/exterior ring intersection.",
-                "type": "object",
-                "required": [
-                  "corruptGeometry"
-                ],
-                "properties": {
-                  "corruptGeometry": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "format": "double"
-                  }
-                },
-                "additionalProperties": false
-              },
-              {
-                "description": "Self-intersection check with optional tolerance. If tolerance is None or 0.0, exact intersection check is performed. If tolerance > 0.0, intersections within tolerance distance are ignored.",
-                "type": "object",
-                "required": [
-                  "selfIntersection"
-                ],
-                "properties": {
-                  "selfIntersection": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "format": "double"
-                  }
-                },
-                "additionalProperties": false
-              }
-            ]
-          },
           "OptionalCheck": {
             "description": "An advisory (optional) validation check that can be individually disabled. A disabled check does not run and is treated as passing. Only checks that the geometry crate classifies as optional are listed here; core validity checks always run and cannot be disabled.",
             "type": "string",
@@ -12769,7 +12819,8 @@
         "features"
       ],
       "outputPorts": [
-        "features"
+        "features",
+        "rejected"
       ],
       "categories": [
         "Geometry"

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -2198,8 +2198,8 @@
             }
           },
           "maxDepth": {
-            "title": "最大深度",
-            "description": "四分木の分割深度の上限。これを超えない範囲でタイルの粒度は地物のサイズに従う。デフォルトは 24、範囲は 0〜24。",
+            "title": "Max Depth",
+            "description": "Hard cap on the quadtree subdivision depth; tile granularity otherwise follows feature size. Defaults to 24, from 0 to 24.",
             "type": [
               "integer",
               "null"
@@ -2727,19 +2727,19 @@
     {
       "name": "Coordinate Frame Reprojector",
       "type": "processor",
-      "description": "ジオメトリを座標参照系間で再投影し、座標参照系とユークリッド座標系の間で変換する",
+      "description": "Reprojects geometry between coordinate reference systems and converts between a CRS and a Euclidean frame.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "CoordinateFrameReprojector パラメータ",
-        "description": "ジオメトリを座標参照系間で再投影し、座標参照系とユークリッド座標系の間で変換する。ユークリッド座標系と座標参照系の境界をまたぐ変換では座標値をそのまま解釈するため、値とリングの回転方向は変更されず、向きは変換先の座標系の軸順序に従う。\n\n座標参照系間の再投影では、単一の標高上にある 2D ジオメトリは 3D になる。",
+        "title": "Coordinate Frame Reprojector Parameters",
+        "description": "Reproject geometry across coordinate reference systems and convert between a CRS and a Euclidean frame. Converting across the Euclidean/CRS boundary reinterprets coordinates as-is: values and ring winding are left unchanged, so orientation follows the destination frame's axis order.\n\nReprojecting across coordinate reference systems takes 2D geometry lying at a single elevation into 3D.",
         "type": "object",
         "required": [
           "destinationFrame"
         ],
         "properties": {
           "destinationFrame": {
-            "title": "変換先の座標系",
-            "description": "ジオメトリの変換先となる座標系。",
+            "title": "Destination Frame",
+            "description": "Coordinate frame to convert geometry into.",
             "allOf": [
               {
                 "$ref": "#/definitions/DestinationFrame"
@@ -2747,8 +2747,8 @@
             ]
           },
           "epsgCode": {
-            "title": "EPSG コード",
-            "description": "変換先の座標参照系の EPSG コード。変換先が座標参照系の場合は必須。",
+            "title": "EPSG Code",
+            "description": "EPSG code of the destination CRS. Required when the destination frame is a CRS.",
             "default": null,
             "type": [
               "integer",
@@ -2758,8 +2758,8 @@
             "minimum": 0.0
           },
           "basePointSource": {
-            "title": "基準点",
-            "description": "ユークリッド座標系と座標参照系の境界をまたぐ際に座標を対応付ける方法。",
+            "title": "Base Point",
+            "description": "How coordinates bridge the Euclidean/CRS boundary.",
             "default": {
               "type": "asIs"
             },
@@ -2775,16 +2775,16 @@
             "description": "The destination coordinate frame kind.",
             "oneOf": [
               {
-                "title": "座標参照系",
-                "description": "EPSG コードで指定した座標参照系に再投影する。",
+                "title": "CRS",
+                "description": "Reproject to a coordinate reference system identified by an EPSG code.",
                 "type": "string",
                 "enum": [
                   "crs"
                 ]
               },
               {
-                "title": "ユークリッド座標系",
-                "description": "地理参照を持たないユークリッド座標系に変換する。",
+                "title": "Euclidean",
+                "description": "Convert to a non-georeferenced Euclidean frame.",
                 "type": "string",
                 "enum": [
                   "euclidean"

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -2172,8 +2172,6 @@
         "description": "地物をCesium 3D Tilesに書き出す設定",
         "type": "object",
         "required": [
-          "maxZoom",
-          "minZoom",
           "output"
         ],
         "properties": {
@@ -2199,27 +2197,16 @@
               }
             }
           },
-          "minZoom": {
-            "title": "最小ズームレベル",
-            "description": "タイルを生成する最小ズームレベル（0〜24）",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "maxZoom": {
-            "title": "最大ズームレベル",
-            "description": "タイルを生成する最大ズームレベル（0〜24）",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "attachTexture": {
-            "title": "テクスチャを添付",
-            "description": "生成するタイルにテクスチャ情報を含めるか",
+          "maxDepth": {
+            "title": "最大深度",
+            "description": "四分木の分割深度の上限。これを超えない範囲でタイルの粒度は地物のサイズに従う。デフォルトは 24、範囲は 0〜24。",
             "type": [
-              "boolean",
+              "integer",
               "null"
-            ]
+            ],
+            "format": "uint32",
+            "maximum": 24.0,
+            "minimum": 0.0
           },
           "dracoCompression": {
             "title": "Draco 圧縮",
@@ -2297,31 +2284,6 @@
               "string",
               "null"
             ]
-          },
-          "compressOutput": {
-            "title": "圧縮出力パス",
-            "description": "タイルの圧縮アーカイブを書き出す出力先パス（任意）",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
           }
         },
         "definitions": {
@@ -2761,6 +2723,190 @@
         "Geometry"
       ],
       "tags": []
+    },
+    {
+      "name": "Coordinate Frame Reprojector",
+      "type": "processor",
+      "description": "ジオメトリを座標参照系間で再投影し、座標参照系とユークリッド座標系の間で変換する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "CoordinateFrameReprojector パラメータ",
+        "description": "ジオメトリを座標参照系間で再投影し、座標参照系とユークリッド座標系の間で変換する。ユークリッド座標系と座標参照系の境界をまたぐ変換では座標値をそのまま解釈するため、値とリングの回転方向は変更されず、向きは変換先の座標系の軸順序に従う。\n\n座標参照系間の再投影では、単一の標高上にある 2D ジオメトリは 3D になる。",
+        "type": "object",
+        "required": [
+          "destinationFrame"
+        ],
+        "properties": {
+          "destinationFrame": {
+            "title": "変換先の座標系",
+            "description": "ジオメトリの変換先となる座標系。",
+            "allOf": [
+              {
+                "$ref": "#/definitions/DestinationFrame"
+              }
+            ]
+          },
+          "epsgCode": {
+            "title": "EPSG コード",
+            "description": "変換先の座標参照系の EPSG コード。変換先が座標参照系の場合は必須。",
+            "default": null,
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint16",
+            "minimum": 0.0
+          },
+          "basePointSource": {
+            "title": "基準点",
+            "description": "ユークリッド座標系と座標参照系の境界をまたぐ際に座標を対応付ける方法。",
+            "default": {
+              "type": "asIs"
+            },
+            "allOf": [
+              {
+                "$ref": "#/definitions/BasePoint"
+              }
+            ]
+          }
+        },
+        "definitions": {
+          "DestinationFrame": {
+            "description": "The destination coordinate frame kind.",
+            "oneOf": [
+              {
+                "title": "座標参照系",
+                "description": "EPSG コードで指定した座標参照系に再投影する。",
+                "type": "string",
+                "enum": [
+                  "crs"
+                ]
+              },
+              {
+                "title": "ユークリッド座標系",
+                "description": "地理参照を持たないユークリッド座標系に変換する。",
+                "type": "string",
+                "enum": [
+                  "euclidean"
+                ]
+              }
+            ]
+          },
+          "BasePoint": {
+            "description": "How coordinates bridge the Euclidean/CRS boundary, carrying the input each mode needs. Ignored for a pure CRS-to-CRS reprojection.",
+            "oneOf": [
+              {
+                "title": "As Is",
+                "description": "Reinterpret coordinate values unchanged across the boundary.",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "asIs"
+                    ]
+                  }
+                }
+              },
+              {
+                "title": "Value",
+                "description": "Offset by a base point given as an expression evaluating to `[x, y, z]`.",
+                "type": "object",
+                "required": [
+                  "basePoint",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "value"
+                    ]
+                  },
+                  "basePoint": {
+                    "title": "Base Point",
+                    "description": "Expression evaluating to an `[x, y, z]` origin in CRS space, in the CRS's declared axis order.",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "From Port",
+                "description": "Offset by a base point taken from the base-point input port, matched to each feature by a key.",
+                "type": "object",
+                "required": [
+                  "matchKey",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "fromPort"
+                    ]
+                  },
+                  "matchKey": {
+                    "title": "Match Key",
+                    "description": "Expression identifying which base-point feature applies to a given feature. Evaluated against both streams.",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "features",
+        "base-point"
+      ],
+      "outputPorts": [
+        "features",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ],
+      "tags": [
+        "coordinate-system",
+        "3d"
+      ]
     },
     {
       "name": "Date Time Converter",
@@ -5480,22 +5626,6 @@
             }
           },
           {
-            "title": "Multiple Geometries",
-            "description": "Separates the features whose geometry is a container that can hold more than one part.",
-            "type": "object",
-            "required": [
-              "filterType"
-            ],
-            "properties": {
-              "filterType": {
-                "type": "string",
-                "enum": [
-                  "multiple"
-                ]
-              }
-            }
-          },
-          {
             "title": "Geometry Type",
             "description": "Routes by the geometry family a feature belongs to: point, curve, surface, triangle or solid.",
             "type": "object",
@@ -5510,6 +5640,22 @@
                 ]
               }
             }
+          },
+          {
+            "title": "Detailed Geometry Type",
+            "description": "Routes by the exact geometry type rather than the family, so a face, a surface mesh and a multi-surface each leave by their own port.",
+            "type": "object",
+            "required": [
+              "filterType"
+            ],
+            "properties": {
+              "filterType": {
+                "type": "string",
+                "enum": [
+                  "detailedGeometryType"
+                ]
+              }
+            }
           }
         ]
       },
@@ -5520,17 +5666,24 @@
       "outputPorts": [
         "unfiltered",
         "none",
-        "contains",
-        "solid",
-        "multiSurface",
-        "compositeSurface",
+        "point",
+        "curve",
         "surface",
         "triangle",
-        "multiCurve",
-        "curve",
-        "multiPoint",
-        "point",
-        "tin"
+        "solid",
+        "multi-point",
+        "point-cloud",
+        "line-string",
+        "multi-curve",
+        "polygon",
+        "multi-area",
+        "face",
+        "polygon-mesh",
+        "triangular-mesh",
+        "multi-surface",
+        "csg",
+        "multi-solid",
+        "aggregate"
       ],
       "categories": [
         "Geometry"
@@ -5651,44 +5804,7 @@
       "name": "Geometry Splitter",
       "type": "processor",
       "description": "ジオメトリをタイプ別に分割する",
-      "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "GeometrySplitter パラメータ",
-        "description": "GeometrySplitter のパラメータ",
-        "type": "object",
-        "properties": {
-          "splitLevel": {
-            "description": "CityGML ジオメトリの分割レベル。 - \"element\": サーフェス要素（RoofSurface、WallSurface など）で分割（デフォルト） - \"polygon\": 各要素内の個々のポリゴンまで分割",
-            "default": "element",
-            "allOf": [
-              {
-                "$ref": "#/definitions/SplitLevel"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "SplitLevel": {
-            "description": "Split level for CityGML geometry",
-            "oneOf": [
-              {
-                "description": "GmlGeometry 要素（例: RoofSurface、WallSurface）で分割する",
-                "type": "string",
-                "enum": [
-                  "element"
-                ]
-              },
-              {
-                "description": "各要素内の個々のポリゴンまで分割する",
-                "type": "string",
-                "enum": [
-                  "polygon"
-                ]
-              }
-            ]
-          }
-        }
-      },
+      "parameter": null,
       "builtin": true,
       "inputPorts": [
         "features"
@@ -5714,15 +5830,6 @@
         "description": "フィーチャージオメトリに対して実行する検証チェックを設定する",
         "type": "object",
         "properties": {
-          "validationTypes": {
-            "title": "検証タイプ",
-            "default": [],
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/ValidationType"
-            },
-            "description": "ジオメトリに対して実行する検証チェックのリスト（重複点、破損ジオメトリ、自己交差）"
-          },
           "disabledOptionalChecks": {
             "title": "Disabled Optional Checks",
             "description": "Advisory checks to disable. Disabled checks do not run and are treated as passing; core validity checks always run. Empty by default, so every optional check runs. Applies only under the new geometry backend.",
@@ -5771,63 +5878,6 @@
           }
         },
         "definitions": {
-          "ValidationType": {
-            "oneOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "duplicatePoints"
-                ]
-              },
-              {
-                "type": "object",
-                "required": [
-                  "duplicateConsecutivePoints"
-                ],
-                "properties": {
-                  "duplicateConsecutivePoints": {
-                    "type": "number",
-                    "format": "double"
-                  }
-                },
-                "additionalProperties": false
-              },
-              {
-                "description": "Corrupt geometry check with optional tolerance for interior/exterior ring intersection.",
-                "type": "object",
-                "required": [
-                  "corruptGeometry"
-                ],
-                "properties": {
-                  "corruptGeometry": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "format": "double"
-                  }
-                },
-                "additionalProperties": false
-              },
-              {
-                "description": "Self-intersection check with optional tolerance. If tolerance is None or 0.0, exact intersection check is performed. If tolerance > 0.0, intersections within tolerance distance are ignored.",
-                "type": "object",
-                "required": [
-                  "selfIntersection"
-                ],
-                "properties": {
-                  "selfIntersection": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "format": "double"
-                  }
-                },
-                "additionalProperties": false
-              }
-            ]
-          },
           "OptionalCheck": {
             "description": "An advisory (optional) validation check that can be individually disabled. A disabled check does not run and is treated as passing. Only checks that the geometry crate classifies as optional are listed here; core validity checks always run and cannot be disabled.",
             "type": "string",
@@ -12769,7 +12819,8 @@
         "features"
       ],
       "outputPorts": [
-        "features"
+        "features",
+        "rejected"
       ],
       "categories": [
         "Geometry"

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -2172,8 +2172,6 @@
         "description": "Configuration for writing features to Cesium 3D Tiles.",
         "type": "object",
         "required": [
-          "maxZoom",
-          "minZoom",
           "output"
         ],
         "properties": {
@@ -2199,27 +2197,16 @@
               }
             }
           },
-          "minZoom": {
-            "title": "最小缩放级别",
-            "description": "瓦片生成的最小缩放级别（0-24）",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "maxZoom": {
-            "title": "最大缩放级别",
-            "description": "瓦片生成的最大缩放级别（0-24）",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "attachTexture": {
-            "title": "附加纹理",
-            "description": "是否在生成的瓦片中包含纹理信息",
+          "maxDepth": {
+            "title": "最大深度",
+            "description": "四叉树细分深度的硬性上限；其余情况下瓦片粒度取决于要素大小。默认为 24，取值范围 0 到 24。",
             "type": [
-              "boolean",
+              "integer",
               "null"
-            ]
+            ],
+            "format": "uint32",
+            "maximum": 24.0,
+            "minimum": 0.0
           },
           "dracoCompression": {
             "title": "Draco 压缩",
@@ -2297,31 +2284,6 @@
               "string",
               "null"
             ]
-          },
-          "compressOutput": {
-            "title": "压缩输出路径",
-            "description": "压缩归档输出的可选路径",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
           }
         },
         "definitions": {
@@ -2761,6 +2723,190 @@
         "Geometry"
       ],
       "tags": []
+    },
+    {
+      "name": "Coordinate Frame Reprojector",
+      "type": "processor",
+      "description": "在坐标参照系之间重投影几何，并在坐标参照系与欧几里得坐标系之间转换",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Coordinate Frame Reprojector Parameters",
+        "description": "Reproject geometry across coordinate reference systems and convert between a CRS and a Euclidean frame. Converting across the Euclidean/CRS boundary reinterprets coordinates as-is: values and ring winding are left unchanged, so orientation follows the destination frame's axis order.\n\nReprojecting across coordinate reference systems takes 2D geometry lying at a single elevation into 3D.",
+        "type": "object",
+        "required": [
+          "destinationFrame"
+        ],
+        "properties": {
+          "destinationFrame": {
+            "title": "Destination Frame",
+            "description": "Coordinate frame to convert geometry into.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/DestinationFrame"
+              }
+            ]
+          },
+          "epsgCode": {
+            "title": "EPSG Code",
+            "description": "EPSG code of the destination CRS. Required when the destination frame is a CRS.",
+            "default": null,
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint16",
+            "minimum": 0.0
+          },
+          "basePointSource": {
+            "title": "Base Point",
+            "description": "How coordinates bridge the Euclidean/CRS boundary.",
+            "default": {
+              "type": "asIs"
+            },
+            "allOf": [
+              {
+                "$ref": "#/definitions/BasePoint"
+              }
+            ]
+          }
+        },
+        "definitions": {
+          "DestinationFrame": {
+            "description": "The destination coordinate frame kind.",
+            "oneOf": [
+              {
+                "title": "CRS",
+                "description": "Reproject to a coordinate reference system identified by an EPSG code.",
+                "type": "string",
+                "enum": [
+                  "crs"
+                ]
+              },
+              {
+                "title": "Euclidean",
+                "description": "Convert to a non-georeferenced Euclidean frame.",
+                "type": "string",
+                "enum": [
+                  "euclidean"
+                ]
+              }
+            ]
+          },
+          "BasePoint": {
+            "description": "How coordinates bridge the Euclidean/CRS boundary, carrying the input each mode needs. Ignored for a pure CRS-to-CRS reprojection.",
+            "oneOf": [
+              {
+                "title": "As Is",
+                "description": "Reinterpret coordinate values unchanged across the boundary.",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "asIs"
+                    ]
+                  }
+                }
+              },
+              {
+                "title": "Value",
+                "description": "Offset by a base point given as an expression evaluating to `[x, y, z]`.",
+                "type": "object",
+                "required": [
+                  "basePoint",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "value"
+                    ]
+                  },
+                  "basePoint": {
+                    "title": "Base Point",
+                    "description": "Expression evaluating to an `[x, y, z]` origin in CRS space, in the CRS's declared axis order.",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "From Port",
+                "description": "Offset by a base point taken from the base-point input port, matched to each feature by a key.",
+                "type": "object",
+                "required": [
+                  "matchKey",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "fromPort"
+                    ]
+                  },
+                  "matchKey": {
+                    "title": "Match Key",
+                    "description": "Expression identifying which base-point feature applies to a given feature. Evaluated against both streams.",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "features",
+        "base-point"
+      ],
+      "outputPorts": [
+        "features",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ],
+      "tags": [
+        "coordinate-system",
+        "3d"
+      ]
     },
     {
       "name": "Date Time Converter",
@@ -5480,22 +5626,6 @@
             }
           },
           {
-            "title": "Multiple Geometries",
-            "description": "Separates the features whose geometry is a container that can hold more than one part.",
-            "type": "object",
-            "required": [
-              "filterType"
-            ],
-            "properties": {
-              "filterType": {
-                "type": "string",
-                "enum": [
-                  "multiple"
-                ]
-              }
-            }
-          },
-          {
             "title": "Geometry Type",
             "description": "Routes by the geometry family a feature belongs to: point, curve, surface, triangle or solid.",
             "type": "object",
@@ -5510,6 +5640,22 @@
                 ]
               }
             }
+          },
+          {
+            "title": "Detailed Geometry Type",
+            "description": "Routes by the exact geometry type rather than the family, so a face, a surface mesh and a multi-surface each leave by their own port.",
+            "type": "object",
+            "required": [
+              "filterType"
+            ],
+            "properties": {
+              "filterType": {
+                "type": "string",
+                "enum": [
+                  "detailedGeometryType"
+                ]
+              }
+            }
           }
         ]
       },
@@ -5520,17 +5666,24 @@
       "outputPorts": [
         "unfiltered",
         "none",
-        "contains",
-        "solid",
-        "multiSurface",
-        "compositeSurface",
+        "point",
+        "curve",
         "surface",
         "triangle",
-        "multiCurve",
-        "curve",
-        "multiPoint",
-        "point",
-        "tin"
+        "solid",
+        "multi-point",
+        "point-cloud",
+        "line-string",
+        "multi-curve",
+        "polygon",
+        "multi-area",
+        "face",
+        "polygon-mesh",
+        "triangular-mesh",
+        "multi-surface",
+        "csg",
+        "multi-solid",
+        "aggregate"
       ],
       "categories": [
         "Geometry"
@@ -5651,44 +5804,7 @@
       "name": "Geometry Splitter",
       "type": "processor",
       "description": "根据类型分割几何",
-      "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "GeometrySplitterParam",
-        "description": "Parameters for GeometrySplitter",
-        "type": "object",
-        "properties": {
-          "splitLevel": {
-            "description": "Split level for CityGML geometry. - \"element\": Split by surface elements (RoofSurface, WallSurface, etc.) - default - \"polygon\": Split down to individual polygons within each element",
-            "default": "element",
-            "allOf": [
-              {
-                "$ref": "#/definitions/SplitLevel"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "SplitLevel": {
-            "description": "Split level for CityGML geometry",
-            "oneOf": [
-              {
-                "description": "Split by GmlGeometry elements (e.g., RoofSurface, WallSurface)",
-                "type": "string",
-                "enum": [
-                  "element"
-                ]
-              },
-              {
-                "description": "Split down to individual polygons within each element",
-                "type": "string",
-                "enum": [
-                  "polygon"
-                ]
-              }
-            ]
-          }
-        }
-      },
+      "parameter": null,
       "builtin": true,
       "inputPorts": [
         "features"
@@ -5714,15 +5830,6 @@
         "description": "Configure which validation checks to perform on feature geometries",
         "type": "object",
         "properties": {
-          "validationTypes": {
-            "title": "Validation Types",
-            "default": [],
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/ValidationType"
-            },
-            "description": "List of validation checks to perform on the geometry (duplicate points, corrupt geometry, self-intersection)"
-          },
           "disabledOptionalChecks": {
             "title": "Disabled Optional Checks",
             "description": "Advisory checks to disable. Disabled checks do not run and are treated as passing; core validity checks always run. Empty by default, so every optional check runs. Applies only under the new geometry backend.",
@@ -5771,63 +5878,6 @@
           }
         },
         "definitions": {
-          "ValidationType": {
-            "oneOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "duplicatePoints"
-                ]
-              },
-              {
-                "type": "object",
-                "required": [
-                  "duplicateConsecutivePoints"
-                ],
-                "properties": {
-                  "duplicateConsecutivePoints": {
-                    "type": "number",
-                    "format": "double"
-                  }
-                },
-                "additionalProperties": false
-              },
-              {
-                "description": "Corrupt geometry check with optional tolerance for interior/exterior ring intersection.",
-                "type": "object",
-                "required": [
-                  "corruptGeometry"
-                ],
-                "properties": {
-                  "corruptGeometry": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "format": "double"
-                  }
-                },
-                "additionalProperties": false
-              },
-              {
-                "description": "Self-intersection check with optional tolerance. If tolerance is None or 0.0, exact intersection check is performed. If tolerance > 0.0, intersections within tolerance distance are ignored.",
-                "type": "object",
-                "required": [
-                  "selfIntersection"
-                ],
-                "properties": {
-                  "selfIntersection": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "format": "double"
-                  }
-                },
-                "additionalProperties": false
-              }
-            ]
-          },
           "OptionalCheck": {
             "description": "An advisory (optional) validation check that can be individually disabled. A disabled check does not run and is treated as passing. Only checks that the geometry crate classifies as optional are listed here; core validity checks always run and cannot be disabled.",
             "type": "string",
@@ -12769,7 +12819,8 @@
         "features"
       ],
       "outputPorts": [
-        "features"
+        "features",
+        "rejected"
       ],
       "categories": [
         "Geometry"

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -2198,8 +2198,8 @@
             }
           },
           "maxDepth": {
-            "title": "最大深度",
-            "description": "四叉树细分深度的硬性上限；其余情况下瓦片粒度取决于要素大小。默认为 24，取值范围 0 到 24。",
+            "title": "Max Depth",
+            "description": "Hard cap on the quadtree subdivision depth; tile granularity otherwise follows feature size. Defaults to 24, from 0 to 24.",
             "type": [
               "integer",
               "null"
@@ -2727,7 +2727,7 @@
     {
       "name": "Coordinate Frame Reprojector",
       "type": "processor",
-      "description": "在坐标参照系之间重投影几何，并在坐标参照系与欧几里得坐标系之间转换",
+      "description": "Reprojects geometry between coordinate reference systems and converts between a CRS and a Euclidean frame.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Coordinate Frame Reprojector Parameters",

--- a/engine/schema/i18n/actions/es.json
+++ b/engine/schema/i18n/actions/es.json
@@ -811,8 +811,8 @@
           "description": "Usar compresión Draco. Verdadero por defecto."
         },
         "maxDepth": {
-          "title": "Profundidad Máxima",
-          "description": "Límite máximo de la profundidad de subdivisión del quadtree; por lo demás, la granularidad de los mosaicos sigue el tamaño de las entidades. Por defecto 24, de 0 a 24."
+          "title": "Max Depth",
+          "description": "Hard cap on the quadtree subdivision depth; tile granularity otherwise follows feature size. Defaults to 24, from 0 to 24."
         },
         "output": {
           "title": "Ruta de Salida",
@@ -943,7 +943,6 @@
     },
     {
       "name": "Coordinate Frame Reprojector",
-      "description": "Reproyecta la geometría entre sistemas de referencia de coordenadas y convierte entre un SRC y un marco euclídeo",
       "parameterI18n": {
         "": {
           "title": "Coordinate Frame Reprojector Parameters",

--- a/engine/schema/i18n/actions/es.json
+++ b/engine/schema/i18n/actions/es.json
@@ -802,14 +802,6 @@
           "title": "Tamaño del Atlas",
           "description": "Dimensión máxima del atlas de texturas en píxeles. Las texturas que la superan se distribuyen en páginas de atlas adicionales; una sola textura mayor que este valor se reduce para que quepa. El valor predeterminado es 2048."
         },
-        "attachTexture": {
-          "title": "Adjuntar Texturas",
-          "description": "Si se debe incluir información de textura en los mosaicos generados"
-        },
-        "compressOutput": {
-          "title": "Ruta de Salida Comprimida",
-          "description": "Ruta opcional para la salida del archivo comprimido"
-        },
         "computeFlatNormal": {
           "title": "Calcular Normales Planas",
           "description": "Calcula normales planas por polígono para la iluminación. Verdadero por defecto. Cuando se desactiva, no se escriben normales y la malla es más pequeña, pero el mosaico no incluye datos de iluminación (el visor debe derivar las normales planas por sí mismo)."
@@ -818,13 +810,9 @@
           "title": "Compresión Draco",
           "description": "Usar compresión Draco. Verdadero por defecto."
         },
-        "maxZoom": {
-          "title": "Nivel de Zoom Máximo",
-          "description": "Nivel de zoom máximo para la generación de mosaicos (0-24)"
-        },
-        "minZoom": {
-          "title": "Nivel de Zoom Mínimo",
-          "description": "Nivel de zoom mínimo para la generación de mosaicos (0-24)"
+        "maxDepth": {
+          "title": "Profundidad Máxima",
+          "description": "Límite máximo de la profundidad de subdivisión del quadtree; por lo demás, la granularidad de los mosaicos sigue el tamaño de las entidades. Por defecto 24, de 0 a 24."
         },
         "output": {
           "title": "Ruta de Salida",
@@ -950,6 +938,40 @@
         "mode": {
           "title": "Extraction Mode",
           "description": "How to extract coordinates from geometry vertices."
+        }
+      }
+    },
+    {
+      "name": "Coordinate Frame Reprojector",
+      "description": "Reproyecta la geometría entre sistemas de referencia de coordenadas y convierte entre un SRC y un marco euclídeo",
+      "parameterI18n": {
+        "": {
+          "title": "Coordinate Frame Reprojector Parameters",
+          "description": "Reproject geometry across coordinate reference systems and convert between a CRS and a Euclidean frame. Converting across the Euclidean/CRS boundary reinterprets coordinates as-is: values and ring winding are left unchanged, so orientation follows the destination frame's axis order.\n\nReprojecting across coordinate reference systems takes 2D geometry lying at a single elevation into 3D."
+        },
+        "basePointSource": {
+          "title": "Base Point",
+          "description": "How coordinates bridge the Euclidean/CRS boundary."
+        },
+        "destinationFrame": {
+          "title": "Destination Frame",
+          "description": "Coordinate frame to convert geometry into."
+        },
+        "epsgCode": {
+          "title": "EPSG Code",
+          "description": "EPSG code of the destination CRS. Required when the destination frame is a CRS."
+        }
+      },
+      "enumI18n": {
+        "DestinationFrame": {
+          "crs": {
+            "title": "CRS",
+            "description": "Reproject to a coordinate reference system identified by an EPSG code."
+          },
+          "euclidean": {
+            "title": "Euclidean",
+            "description": "Convert to a non-georeferenced Euclidean frame."
+          }
         }
       }
     },
@@ -1781,26 +1803,7 @@
     },
     {
       "name": "Geometry Splitter",
-      "description": "Divide la geometría por tipo",
-      "parameterI18n": {
-        "": {
-          "title": "GeometrySplitterParam",
-          "description": "Parameters for GeometrySplitter"
-        },
-        "splitLevel": {
-          "description": "Split level for CityGML geometry. - \"element\": Split by surface elements (RoofSurface, WallSurface, etc.) - default - \"polygon\": Split down to individual polygons within each element"
-        }
-      },
-      "enumI18n": {
-        "SplitLevel": {
-          "element": {
-            "description": "Split by GmlGeometry elements (e.g., RoofSurface, WallSurface)"
-          },
-          "polygon": {
-            "description": "Split down to individual polygons within each element"
-          }
-        }
-      }
+      "description": "Divide la geometría por tipo"
     },
     {
       "name": "Geometry Validator",
@@ -1825,10 +1828,6 @@
         "planarityThreshold": {
           "title": "Planarity Threshold",
           "description": "Optional override for how the planarity check bounds a face's out-of-plane deviation: a scale-invariant `ratio` (the default), or an absolute `maxHeight` in the frame's linear unit (linear-unit frames only). Applies only under the new geometry backend."
-        },
-        "validationTypes": {
-          "title": "Validation Types",
-          "description": "List of validation checks to perform on the geometry (duplicate points, corrupt geometry, self-intersection)"
         }
       },
       "definitionI18n": {
@@ -1842,11 +1841,6 @@
           "minVolume": {
             "description": "Minimum volume of a 3D geometry (solid)."
           }
-        }
-      },
-      "enumI18n": {
-        "ValidationType": {
-          "duplicatePoints": {}
         }
       }
     },

--- a/engine/schema/i18n/actions/fr.json
+++ b/engine/schema/i18n/actions/fr.json
@@ -811,8 +811,8 @@
           "description": "Utiliser la compression Draco. Vrai par défaut."
         },
         "maxDepth": {
-          "title": "Profondeur Maximale",
-          "description": "Limite stricte de la profondeur de subdivision du quadtree ; sinon, la granularité des tuiles suit la taille des entités. Par défaut 24, de 0 à 24."
+          "title": "Max Depth",
+          "description": "Hard cap on the quadtree subdivision depth; tile granularity otherwise follows feature size. Defaults to 24, from 0 to 24."
         },
         "output": {
           "title": "Chemin de Sortie",
@@ -943,7 +943,6 @@
     },
     {
       "name": "Coordinate Frame Reprojector",
-      "description": "Reprojette la géométrie entre systèmes de coordonnées de référence et convertit entre un SCR et un repère euclidien",
       "parameterI18n": {
         "": {
           "title": "Coordinate Frame Reprojector Parameters",

--- a/engine/schema/i18n/actions/fr.json
+++ b/engine/schema/i18n/actions/fr.json
@@ -802,14 +802,6 @@
           "title": "Taille de l'Atlas",
           "description": "Dimension maximale de l'atlas de textures en pixels. Les textures qui la dépassent débordent sur des pages d'atlas supplémentaires ; une seule texture plus grande que cette valeur est sous-échantillonnée pour s'y adapter. La valeur par défaut est 2048."
         },
-        "attachTexture": {
-          "title": "Joindre les Textures",
-          "description": "Indique s'il faut inclure les informations de texture dans les tuiles générées"
-        },
-        "compressOutput": {
-          "title": "Chemin de Sortie Compressé",
-          "description": "Chemin optionnel pour la sortie de l'archive compressée"
-        },
         "computeFlatNormal": {
           "title": "Calculer les Normales Plates",
           "description": "Calcule des normales plates par polygone pour l'éclairage. Vrai par défaut. Lorsqu'elle est désactivée, aucune normale n'est écrite et le maillage est plus petit, mais la tuile ne contient aucune donnée d'éclairage (le visualiseur doit dériver lui-même les normales plates)."
@@ -818,13 +810,9 @@
           "title": "Compression Draco",
           "description": "Utiliser la compression Draco. Vrai par défaut."
         },
-        "maxZoom": {
-          "title": "Niveau de Zoom Maximum",
-          "description": "Niveau de zoom maximum pour la génération de tuiles (0-24)"
-        },
-        "minZoom": {
-          "title": "Niveau de Zoom Minimum",
-          "description": "Niveau de zoom minimum pour la génération de tuiles (0-24)"
+        "maxDepth": {
+          "title": "Profondeur Maximale",
+          "description": "Limite stricte de la profondeur de subdivision du quadtree ; sinon, la granularité des tuiles suit la taille des entités. Par défaut 24, de 0 à 24."
         },
         "output": {
           "title": "Chemin de Sortie",
@@ -950,6 +938,40 @@
         "mode": {
           "title": "Extraction Mode",
           "description": "How to extract coordinates from geometry vertices."
+        }
+      }
+    },
+    {
+      "name": "Coordinate Frame Reprojector",
+      "description": "Reprojette la géométrie entre systèmes de coordonnées de référence et convertit entre un SCR et un repère euclidien",
+      "parameterI18n": {
+        "": {
+          "title": "Coordinate Frame Reprojector Parameters",
+          "description": "Reproject geometry across coordinate reference systems and convert between a CRS and a Euclidean frame. Converting across the Euclidean/CRS boundary reinterprets coordinates as-is: values and ring winding are left unchanged, so orientation follows the destination frame's axis order.\n\nReprojecting across coordinate reference systems takes 2D geometry lying at a single elevation into 3D."
+        },
+        "basePointSource": {
+          "title": "Base Point",
+          "description": "How coordinates bridge the Euclidean/CRS boundary."
+        },
+        "destinationFrame": {
+          "title": "Destination Frame",
+          "description": "Coordinate frame to convert geometry into."
+        },
+        "epsgCode": {
+          "title": "EPSG Code",
+          "description": "EPSG code of the destination CRS. Required when the destination frame is a CRS."
+        }
+      },
+      "enumI18n": {
+        "DestinationFrame": {
+          "crs": {
+            "title": "CRS",
+            "description": "Reproject to a coordinate reference system identified by an EPSG code."
+          },
+          "euclidean": {
+            "title": "Euclidean",
+            "description": "Convert to a non-georeferenced Euclidean frame."
+          }
         }
       }
     },
@@ -1781,26 +1803,7 @@
     },
     {
       "name": "Geometry Splitter",
-      "description": "Split Multi-Geometries into Individual Features",
-      "parameterI18n": {
-        "": {
-          "title": "GeometrySplitterParam",
-          "description": "Parameters for GeometrySplitter"
-        },
-        "splitLevel": {
-          "description": "Split level for CityGML geometry. - \"element\": Split by surface elements (RoofSurface, WallSurface, etc.) - default - \"polygon\": Split down to individual polygons within each element"
-        }
-      },
-      "enumI18n": {
-        "SplitLevel": {
-          "element": {
-            "description": "Split by GmlGeometry elements (e.g., RoofSurface, WallSurface)"
-          },
-          "polygon": {
-            "description": "Split down to individual polygons within each element"
-          }
-        }
-      }
+      "description": "Split Multi-Geometries into Individual Features"
     },
     {
       "name": "Geometry Validator",
@@ -1825,10 +1828,6 @@
         "planarityThreshold": {
           "title": "Planarity Threshold",
           "description": "Optional override for how the planarity check bounds a face's out-of-plane deviation: a scale-invariant `ratio` (the default), or an absolute `maxHeight` in the frame's linear unit (linear-unit frames only). Applies only under the new geometry backend."
-        },
-        "validationTypes": {
-          "title": "Validation Types",
-          "description": "List of validation checks to perform on the geometry (duplicate points, corrupt geometry, self-intersection)"
         }
       },
       "definitionI18n": {
@@ -1842,11 +1841,6 @@
           "minVolume": {
             "description": "Minimum volume of a 3D geometry (solid)."
           }
-        }
-      },
-      "enumI18n": {
-        "ValidationType": {
-          "duplicatePoints": {}
         }
       }
     },

--- a/engine/schema/i18n/actions/ja.json
+++ b/engine/schema/i18n/actions/ja.json
@@ -802,14 +802,6 @@
           "title": "アトラスサイズ",
           "description": "テクスチャアトラスの最大寸法（ピクセル）。これを超えるテクスチャは追加のアトラスページに分割され、単一のテクスチャがこれより大きい場合は収まるようにダウンサンプリングされる。デフォルトは 2048。"
         },
-        "attachTexture": {
-          "title": "テクスチャを添付",
-          "description": "生成するタイルにテクスチャ情報を含めるか"
-        },
-        "compressOutput": {
-          "title": "圧縮出力パス",
-          "description": "タイルの圧縮アーカイブを書き出す出力先パス（任意）"
-        },
         "computeFlatNormal": {
           "title": "フラット法線を計算",
           "description": "ライティング用にポリゴンごとのフラット法線を計算するか。デフォルトは true。無効にすると法線は出力されずメッシュは小さくなるが、タイルにライティング情報が含まれないためビューアー側でフラット法線を導出する必要がある"
@@ -818,13 +810,9 @@
           "title": "Draco 圧縮",
           "description": "メッシュジオメトリをDracoで圧縮するか（デフォルト: true）"
         },
-        "maxZoom": {
-          "title": "最大ズームレベル",
-          "description": "タイルを生成する最大ズームレベル（0〜24）"
-        },
-        "minZoom": {
-          "title": "最小ズームレベル",
-          "description": "タイルを生成する最小ズームレベル（0〜24）"
+        "maxDepth": {
+          "title": "最大深度",
+          "description": "四分木の分割深度の上限。これを超えない範囲でタイルの粒度は地物のサイズに従う。デフォルトは 24、範囲は 0〜24。"
         },
         "output": {
           "title": "出力パス",
@@ -950,6 +938,40 @@
         "mode": {
           "title": "抽出モード",
           "description": "ジオメトリの頂点から座標を抽出する方法"
+        }
+      }
+    },
+    {
+      "name": "Coordinate Frame Reprojector",
+      "description": "ジオメトリを座標参照系間で再投影し、座標参照系とユークリッド座標系の間で変換する",
+      "parameterI18n": {
+        "": {
+          "title": "CoordinateFrameReprojector パラメータ",
+          "description": "ジオメトリを座標参照系間で再投影し、座標参照系とユークリッド座標系の間で変換する。ユークリッド座標系と座標参照系の境界をまたぐ変換では座標値をそのまま解釈するため、値とリングの回転方向は変更されず、向きは変換先の座標系の軸順序に従う。\n\n座標参照系間の再投影では、単一の標高上にある 2D ジオメトリは 3D になる。"
+        },
+        "basePointSource": {
+          "title": "基準点",
+          "description": "ユークリッド座標系と座標参照系の境界をまたぐ際に座標を対応付ける方法。"
+        },
+        "destinationFrame": {
+          "title": "変換先の座標系",
+          "description": "ジオメトリの変換先となる座標系。"
+        },
+        "epsgCode": {
+          "title": "EPSG コード",
+          "description": "変換先の座標参照系の EPSG コード。変換先が座標参照系の場合は必須。"
+        }
+      },
+      "enumI18n": {
+        "DestinationFrame": {
+          "crs": {
+            "title": "座標参照系",
+            "description": "EPSG コードで指定した座標参照系に再投影する。"
+          },
+          "euclidean": {
+            "title": "ユークリッド座標系",
+            "description": "地理参照を持たないユークリッド座標系に変換する。"
+          }
         }
       }
     },
@@ -1781,26 +1803,7 @@
     },
     {
       "name": "Geometry Splitter",
-      "description": "ジオメトリをタイプ別に分割する",
-      "parameterI18n": {
-        "": {
-          "title": "GeometrySplitter パラメータ",
-          "description": "GeometrySplitter のパラメータ"
-        },
-        "splitLevel": {
-          "description": "CityGML ジオメトリの分割レベル。 - \"element\": サーフェス要素（RoofSurface、WallSurface など）で分割（デフォルト） - \"polygon\": 各要素内の個々のポリゴンまで分割"
-        }
-      },
-      "enumI18n": {
-        "SplitLevel": {
-          "element": {
-            "description": "GmlGeometry 要素（例: RoofSurface、WallSurface）で分割する"
-          },
-          "polygon": {
-            "description": "各要素内の個々のポリゴンまで分割する"
-          }
-        }
-      }
+      "description": "ジオメトリをタイプ別に分割する"
     },
     {
       "name": "Geometry Validator",
@@ -1825,10 +1828,6 @@
         "planarityThreshold": {
           "title": "Planarity Threshold",
           "description": "Optional override for how the planarity check bounds a face's out-of-plane deviation: a scale-invariant `ratio` (the default), or an absolute `maxHeight` in the frame's linear unit (linear-unit frames only). Applies only under the new geometry backend."
-        },
-        "validationTypes": {
-          "title": "検証タイプ",
-          "description": "ジオメトリに対して実行する検証チェックのリスト（重複点、破損ジオメトリ、自己交差）"
         }
       },
       "definitionI18n": {
@@ -1842,11 +1841,6 @@
           "minVolume": {
             "description": "Minimum volume of a 3D geometry (solid)."
           }
-        }
-      },
-      "enumI18n": {
-        "ValidationType": {
-          "duplicatePoints": {}
         }
       }
     },

--- a/engine/schema/i18n/actions/ja.json
+++ b/engine/schema/i18n/actions/ja.json
@@ -811,8 +811,8 @@
           "description": "メッシュジオメトリをDracoで圧縮するか（デフォルト: true）"
         },
         "maxDepth": {
-          "title": "最大深度",
-          "description": "四分木の分割深度の上限。これを超えない範囲でタイルの粒度は地物のサイズに従う。デフォルトは 24、範囲は 0〜24。"
+          "title": "Max Depth",
+          "description": "Hard cap on the quadtree subdivision depth; tile granularity otherwise follows feature size. Defaults to 24, from 0 to 24."
         },
         "output": {
           "title": "出力パス",
@@ -943,34 +943,33 @@
     },
     {
       "name": "Coordinate Frame Reprojector",
-      "description": "ジオメトリを座標参照系間で再投影し、座標参照系とユークリッド座標系の間で変換する",
       "parameterI18n": {
         "": {
-          "title": "CoordinateFrameReprojector パラメータ",
-          "description": "ジオメトリを座標参照系間で再投影し、座標参照系とユークリッド座標系の間で変換する。ユークリッド座標系と座標参照系の境界をまたぐ変換では座標値をそのまま解釈するため、値とリングの回転方向は変更されず、向きは変換先の座標系の軸順序に従う。\n\n座標参照系間の再投影では、単一の標高上にある 2D ジオメトリは 3D になる。"
+          "title": "Coordinate Frame Reprojector Parameters",
+          "description": "Reproject geometry across coordinate reference systems and convert between a CRS and a Euclidean frame. Converting across the Euclidean/CRS boundary reinterprets coordinates as-is: values and ring winding are left unchanged, so orientation follows the destination frame's axis order.\n\nReprojecting across coordinate reference systems takes 2D geometry lying at a single elevation into 3D."
         },
         "basePointSource": {
-          "title": "基準点",
-          "description": "ユークリッド座標系と座標参照系の境界をまたぐ際に座標を対応付ける方法。"
+          "title": "Base Point",
+          "description": "How coordinates bridge the Euclidean/CRS boundary."
         },
         "destinationFrame": {
-          "title": "変換先の座標系",
-          "description": "ジオメトリの変換先となる座標系。"
+          "title": "Destination Frame",
+          "description": "Coordinate frame to convert geometry into."
         },
         "epsgCode": {
-          "title": "EPSG コード",
-          "description": "変換先の座標参照系の EPSG コード。変換先が座標参照系の場合は必須。"
+          "title": "EPSG Code",
+          "description": "EPSG code of the destination CRS. Required when the destination frame is a CRS."
         }
       },
       "enumI18n": {
         "DestinationFrame": {
           "crs": {
-            "title": "座標参照系",
-            "description": "EPSG コードで指定した座標参照系に再投影する。"
+            "title": "CRS",
+            "description": "Reproject to a coordinate reference system identified by an EPSG code."
           },
           "euclidean": {
-            "title": "ユークリッド座標系",
-            "description": "地理参照を持たないユークリッド座標系に変換する。"
+            "title": "Euclidean",
+            "description": "Convert to a non-georeferenced Euclidean frame."
           }
         }
       }

--- a/engine/schema/i18n/actions/zh.json
+++ b/engine/schema/i18n/actions/zh.json
@@ -802,14 +802,6 @@
           "title": "图集大小",
           "description": "纹理图集的最大尺寸（像素）。超过此值的纹理会分布到额外的图集页；单个大于此值的纹理会被降采样以适配。默认值为 2048。"
         },
-        "attachTexture": {
-          "title": "附加纹理",
-          "description": "是否在生成的瓦片中包含纹理信息"
-        },
-        "compressOutput": {
-          "title": "压缩输出路径",
-          "description": "压缩归档输出的可选路径"
-        },
         "computeFlatNormal": {
           "title": "计算平面法线",
           "description": "为光照计算逐多边形的平面法线。默认为 true。禁用时不写入法线，网格更小，但瓦片不包含光照数据（查看器需自行推导平面法线）。"
@@ -818,13 +810,9 @@
           "title": "Draco 压缩",
           "description": "使用 Draco 压缩。默认为 true。"
         },
-        "maxZoom": {
-          "title": "最大缩放级别",
-          "description": "瓦片生成的最大缩放级别（0-24）"
-        },
-        "minZoom": {
-          "title": "最小缩放级别",
-          "description": "瓦片生成的最小缩放级别（0-24）"
+        "maxDepth": {
+          "title": "最大深度",
+          "description": "四叉树细分深度的硬性上限；其余情况下瓦片粒度取决于要素大小。默认为 24，取值范围 0 到 24。"
         },
         "output": {
           "title": "输出路径",
@@ -950,6 +938,40 @@
         "mode": {
           "title": "Extraction Mode",
           "description": "How to extract coordinates from geometry vertices."
+        }
+      }
+    },
+    {
+      "name": "Coordinate Frame Reprojector",
+      "description": "在坐标参照系之间重投影几何，并在坐标参照系与欧几里得坐标系之间转换",
+      "parameterI18n": {
+        "": {
+          "title": "Coordinate Frame Reprojector Parameters",
+          "description": "Reproject geometry across coordinate reference systems and convert between a CRS and a Euclidean frame. Converting across the Euclidean/CRS boundary reinterprets coordinates as-is: values and ring winding are left unchanged, so orientation follows the destination frame's axis order.\n\nReprojecting across coordinate reference systems takes 2D geometry lying at a single elevation into 3D."
+        },
+        "basePointSource": {
+          "title": "Base Point",
+          "description": "How coordinates bridge the Euclidean/CRS boundary."
+        },
+        "destinationFrame": {
+          "title": "Destination Frame",
+          "description": "Coordinate frame to convert geometry into."
+        },
+        "epsgCode": {
+          "title": "EPSG Code",
+          "description": "EPSG code of the destination CRS. Required when the destination frame is a CRS."
+        }
+      },
+      "enumI18n": {
+        "DestinationFrame": {
+          "crs": {
+            "title": "CRS",
+            "description": "Reproject to a coordinate reference system identified by an EPSG code."
+          },
+          "euclidean": {
+            "title": "Euclidean",
+            "description": "Convert to a non-georeferenced Euclidean frame."
+          }
         }
       }
     },
@@ -1781,26 +1803,7 @@
     },
     {
       "name": "Geometry Splitter",
-      "description": "根据类型分割几何",
-      "parameterI18n": {
-        "": {
-          "title": "GeometrySplitterParam",
-          "description": "Parameters for GeometrySplitter"
-        },
-        "splitLevel": {
-          "description": "Split level for CityGML geometry. - \"element\": Split by surface elements (RoofSurface, WallSurface, etc.) - default - \"polygon\": Split down to individual polygons within each element"
-        }
-      },
-      "enumI18n": {
-        "SplitLevel": {
-          "element": {
-            "description": "Split by GmlGeometry elements (e.g., RoofSurface, WallSurface)"
-          },
-          "polygon": {
-            "description": "Split down to individual polygons within each element"
-          }
-        }
-      }
+      "description": "根据类型分割几何"
     },
     {
       "name": "Geometry Validator",
@@ -1825,10 +1828,6 @@
         "planarityThreshold": {
           "title": "Planarity Threshold",
           "description": "Optional override for how the planarity check bounds a face's out-of-plane deviation: a scale-invariant `ratio` (the default), or an absolute `maxHeight` in the frame's linear unit (linear-unit frames only). Applies only under the new geometry backend."
-        },
-        "validationTypes": {
-          "title": "Validation Types",
-          "description": "List of validation checks to perform on the geometry (duplicate points, corrupt geometry, self-intersection)"
         }
       },
       "definitionI18n": {
@@ -1842,11 +1841,6 @@
           "minVolume": {
             "description": "Minimum volume of a 3D geometry (solid)."
           }
-        }
-      },
-      "enumI18n": {
-        "ValidationType": {
-          "duplicatePoints": {}
         }
       }
     },

--- a/engine/schema/i18n/actions/zh.json
+++ b/engine/schema/i18n/actions/zh.json
@@ -811,8 +811,8 @@
           "description": "使用 Draco 压缩。默认为 true。"
         },
         "maxDepth": {
-          "title": "最大深度",
-          "description": "四叉树细分深度的硬性上限；其余情况下瓦片粒度取决于要素大小。默认为 24，取值范围 0 到 24。"
+          "title": "Max Depth",
+          "description": "Hard cap on the quadtree subdivision depth; tile granularity otherwise follows feature size. Defaults to 24, from 0 to 24."
         },
         "output": {
           "title": "输出路径",
@@ -943,7 +943,6 @@
     },
     {
       "name": "Coordinate Frame Reprojector",
-      "description": "在坐标参照系之间重投影几何，并在坐标参照系与欧几里得坐标系之间转换",
       "parameterI18n": {
         "": {
           "title": "Coordinate Frame Reprojector Parameters",

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.105"
+version = "0.2.106"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.295"
+version = "0.1.296"
 edition = "2021"
 
 [features]

--- a/engine/worker/Cargo.toml
+++ b/engine/worker/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [features]
+default = ["new-geometry"]
 # Temporary migration flag for the new-geometry migration.
 # TODO: Remove after migration.
 new-geometry = [

--- a/engine/worker/Cargo.toml
+++ b/engine/worker/Cargo.toml
@@ -12,8 +12,7 @@ version.workspace = true
 
 [features]
 default = ["new-geometry"]
-# Temporary migration flag for the new-geometry migration.
-# TODO: Remove after migration.
+# Temporary migration flag, on by default. TODO: Remove after migration.
 new-geometry = [
   "reearth-flow-action-plateau-processor/new-geometry",
   "reearth-flow-action-processor/new-geometry",


### PR DESCRIPTION
# What I have done
This PR makes `new-geometry` the default for the UI. Everything that reaches the UI is now build with `new-geometry`, with no feature flag passed anywhere: The `worker` and `cli` container images, the release `worker` binary, and the action schema the server serves are all built with `new-geometry`.

Also, the action docs and schemas are now regenerated with `new-geometry`.