### PR TITLE
fix(engine): keep proj.db reachable when grid search paths are set

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.113"
+version = "0.2.114"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "Inflector",
  "approx",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4960,7 +4960,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "bytes",
  "clap",
@@ -5063,7 +5063,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5106,7 +5106,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5147,7 +5147,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "approx",
  "bvh",
@@ -5205,7 +5205,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5278,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5314,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5345,7 +5345,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "bytes",
  "futures",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "bytes",
  "futures",
@@ -5381,7 +5381,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5431,7 +5431,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "ahash",
  "bytes",
@@ -5467,7 +5467,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.489"
+version = "0.0.490"
 dependencies = [
  "async-trait",
  "axum",
@@ -8233,7 +8233,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.303"
+version = "0.1.304"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.489"
+version = "0.0.490"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/geometry/src/ops/reproject/grids.rs
+++ b/engine/runtime/geometry/src/ops/reproject/grids.rs
@@ -12,8 +12,8 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use proj_sys::{
-    proj_context_create, proj_context_destroy, proj_context_get_user_writable_directory,
-    proj_context_set_search_paths, PJ_CONTEXT,
+    proj_context_create, proj_context_destroy, proj_context_get_database_path,
+    proj_context_get_user_writable_directory, proj_context_set_search_paths, PJ_CONTEXT,
 };
 
 use crate::error::{Error, Result};
@@ -130,7 +130,8 @@ fn ordered_dirs(
 }
 
 /// The directories PROJ would look in for a grid on its own, in its own order:
-/// its user-writable directory, then those named by `PROJ_DATA`.
+/// its user-writable directory, those named by `PROJ_DATA`, then the directory
+/// holding `proj.db`, where an installation keeps the grids it ships with.
 fn proj_default_grid_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
     if let Some(dir) = user_writable_dir() {
@@ -139,7 +140,30 @@ fn proj_default_grid_dirs() -> Vec<PathBuf> {
     if let Some(list) = std::env::var_os("PROJ_DATA").or_else(|| std::env::var_os("PROJ_LIB")) {
         dirs.extend(std::env::split_paths(&list).filter(|p| !p.as_os_str().is_empty()));
     }
+    if let Some(dir) = database_dir().filter(|dir| !dirs.contains(dir)) {
+        dirs.push(dir);
+    }
     dirs
+}
+
+/// The directory holding the `proj.db` PROJ resolves on its own.
+fn database_dir() -> Option<PathBuf> {
+    // SAFETY: the returned string belongs to the context, so it is copied before
+    // the context is destroyed; a null context is never passed on.
+    let path = unsafe {
+        let ctx = proj_context_create();
+        if ctx.is_null() {
+            return None;
+        }
+        let path = proj_context_get_database_path(ctx);
+        let path = (!path.is_null()).then(|| CStr::from_ptr(path).to_string_lossy().into_owned());
+        proj_context_destroy(ctx);
+        path.filter(|p| !p.is_empty())?
+    };
+    PathBuf::from(path)
+        .parent()
+        .filter(|dir| !dir.as_os_str().is_empty())
+        .map(PathBuf::from)
 }
 
 /// The directory PROJ treats as its own writable store. Does not create it.
@@ -283,6 +307,22 @@ mod tests {
         );
     }
 
+    /// The grids an installation ships with sit beside its `proj.db`.
+    #[test]
+    fn the_directory_holding_proj_db_is_on_the_search_path() {
+        // Nothing to keep where PROJ resolves no `proj.db`.
+        let Some(dir) = database_dir() else {
+            return;
+        };
+        assert!(
+            resolved()
+                .search
+                .iter()
+                .any(|path| path.as_bytes() == dir.as_os_str().as_encoded_bytes()),
+            "the resolved search path drops {dir:?}"
+        );
+    }
+
     fn all_grids() -> Vec<&'static EmbeddedGrid> {
         EMBEDDED_GRIDS.iter().collect()
     }
@@ -342,7 +382,8 @@ mod tests {
                 [204000.0, 325300.0, 95.0],
                 140.73,
             ),
-            // RGF93 / Lambert-93 + NGF-IGN69 -> WGS84 3D: RAF20.
+            // RGF93 / Lambert-93 + NGF-IGN69 -> WGS84 3D: RAF20, or RAF18 where the
+            // installation supplies it, which puts the point 0.01 higher.
             ("france", 5698, 4979, [650000.0, 6860000.0, 100.0], 143.81),
             // WGS84 3D -> EGM96 height, the global fallback.
             ("egm96", 4979, 5773, [35.6586, 139.7454, 10.0], -26.41),
@@ -353,7 +394,7 @@ mod tests {
                 .transform(EpsgCode::new(from), EpsgCode::new(to), point)
                 .unwrap_or_else(|e| panic!("{label} EPSG:{from}->EPSG:{to}: {e}"));
             assert!(
-                (got[2] - expected).abs() < 0.01,
+                (got[2] - expected).abs() < 0.05,
                 "{label}: expected a height near {expected}, got {}",
                 got[2]
             );

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.113"
+version = "0.2.114"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.303"
+version = "0.1.304"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
# Overview

Coordinate transformation fails on installations where `proj.db` lives under PROJ's own default search path, because the grid search paths introduced in #2346 replace that path instead of adding to it. This restores the database lookup so reprojection works again on such installations.

## What I've done

- Ask a context with PROJ's untouched defaults where it resolved `proj.db`, and append that directory to the grid search paths we hand to every context, so the database — and the grids an installation ships beside it — stay reachable.
- Add a regression test asserting the resolved search path still holds the directory of the `proj.db` PROJ found on its own.
- Loosen the vertical-datum height tolerance from 0.01 m to 0.05 m: with the installation's own grid directory now searched, the France case may pick RAF18 instead of the embedded RAF20, which puts the point 0.01 m higher.

## What I haven't done

- No fallback when PROJ itself finds no database; that case behaves as it did before.

## How I tested

`cargo make test` on macOS with Homebrew PROJ, which fails without this change at every PROJ call and passes with it.

## Screenshot

## Which point I want you to review particularly

## Memo

`proj_context_set_search_paths` replaces PROJ's search paths rather than prepending to them, so a Homebrew install whose `proj.db` sits in `share/proj` loses it the moment we point the context at the embedded grid directory. CI did not catch this — worth knowing that this code path is only exercised on layouts where the database is not alongside the grids.
