### PR TITLE
feat(engine): port Dissolver to new geometry

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.114"
+version = "0.2.115"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "Inflector",
  "approx",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4960,7 +4960,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "bytes",
  "clap",
@@ -5063,7 +5063,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5106,7 +5106,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5147,7 +5147,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "approx",
  "bvh",
@@ -5205,7 +5205,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5278,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5314,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5345,7 +5345,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "bytes",
  "futures",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "bytes",
  "futures",
@@ -5381,7 +5381,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5431,7 +5431,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "ahash",
  "bytes",
@@ -5467,7 +5467,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.490"
+version = "0.0.491"
 dependencies = [
  "async-trait",
  "axum",
@@ -8233,7 +8233,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.304"
+version = "0.1.305"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.490"
+version = "0.0.491"
 
 [profile.dev]
 opt-level = 0

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -3215,7 +3215,7 @@ Dissolve Features by Grouping Attributes
         },
         {
           "title": "Use Attributes From One Feature",
-          "description": "The output inherits the attributes of one representative feature (the last feature in the group)",
+          "description": "The output inherits the attributes of one representative feature of the group",
           "type": "string",
           "enum": [
             "useOneFeature"

--- a/engine/runtime/action-processor/src/geometry/dissolver.rs
+++ b/engine/runtime/action-processor/src/geometry/dissolver.rs
@@ -32,7 +32,7 @@ use reearth_flow_types::{Geometry, GeometryValue};
 use reearth_flow_geometry::{
     collection::Collection2D,
     coordinate::CoordinateFrame,
-    overlay::dissolve_2d,
+    overlay::dissolve_leaves,
     polygon::Polygon2D,
     predicates::view::{flatten_2d, Leaf2D},
     Euclidean2DGeometry, Geometry,
@@ -353,6 +353,8 @@ impl Dissolver {
         self.group_map.clear();
         #[cfg(feature = "new-geometry")]
         self.group_frame.clear();
+        #[cfg(feature = "new-geometry")]
+        self.reported_groups.clear();
         self.group_count = 0;
 
         Ok(dissolved)
@@ -630,14 +632,15 @@ impl Dissolver {
 
         // The whole group goes in as one operand and dissolves in a single call:
         // the backend snaps coordinates to an adaptive grid, so folding the
-        // members in pairwise would let the result drift member by member.
-        let group = Euclidean2DGeometry::Collection(Collection2D::new(features.iter().filter_map(
-            |feature| match feature.geometry.as_ref() {
-                Geometry::Euclidean2D(geom_2d) => Some(geom_2d.clone()),
-                _ => None,
-            },
-        )));
-        let polygons = dissolve_2d(&group, self.tolerance).map_err(|e| {
+        // members in pairwise would let the result drift member by member. The
+        // leaves borrow the members, so the group's coordinates are not copied.
+        let mut leaves = Vec::new();
+        for feature in &features {
+            if let Geometry::Euclidean2D(geom_2d) = feature.geometry.as_ref() {
+                flatten_2d(geom_2d, &mut leaves);
+            }
+        }
+        let polygons = dissolve_leaves(&leaves, self.tolerance).map_err(|e| {
             GeometryProcessorError::Dissolver(format!("Failed to dissolve group: {e}"))
         })?;
 

--- a/engine/runtime/action-processor/src/geometry/dissolver.rs
+++ b/engine/runtime/action-processor/src/geometry/dissolver.rs
@@ -1,14 +1,12 @@
 use std::collections::HashMap;
+#[cfg(feature = "new-geometry")]
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 
 use indexmap::IndexMap;
 use once_cell::sync::Lazy;
-use reearth_flow_geometry::{
-    algorithm::{bool_ops::BooleanOps, tolerance::glue_vertices_closer_than},
-    types::multi_polygon::MultiPolygon2D,
-};
 use reearth_flow_runtime::{
     cache::executor_cache_subdir,
     errors::BoxedError,
@@ -17,10 +15,28 @@ use reearth_flow_runtime::{
     forwarder::ProcessorChannelForwarder,
     node::{Port, Processor, ProcessorFactory, FEATURES_PORT, REJECTED_PORT},
 };
-use reearth_flow_types::{Attribute, AttributeValue, Feature, Geometry, GeometryValue};
+use reearth_flow_types::{Attribute, AttributeValue, Feature};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+
+#[cfg(not(feature = "new-geometry"))]
+use reearth_flow_geometry::{
+    algorithm::{bool_ops::BooleanOps, tolerance::glue_vertices_closer_than},
+    types::multi_polygon::MultiPolygon2D,
+};
+#[cfg(not(feature = "new-geometry"))]
+use reearth_flow_types::{Geometry, GeometryValue};
+
+#[cfg(feature = "new-geometry")]
+use reearth_flow_geometry::{
+    collection::Collection2D,
+    coordinate::CoordinateFrame,
+    overlay::dissolve_2d,
+    polygon::Polygon2D,
+    predicates::view::{flatten_2d, Leaf2D},
+    Euclidean2DGeometry, Geometry,
+};
 
 use super::errors::GeometryProcessorError;
 use crate::ACCUMULATOR_BUFFER_BYTE_THRESHOLD;
@@ -44,7 +60,7 @@ pub enum AttributeAccumulationStrategy {
     /// The output feature will merge all input attributes. When multiple features have the same attribute with different values, all values are collected into an array
     MergeAttributes,
     /// # Use Attributes From One Feature
-    /// The output inherits the attributes of one representative feature (the last feature in the group)
+    /// The output inherits the attributes of one representative feature of the group
     #[default]
     UseOneFeature,
 }
@@ -108,6 +124,10 @@ impl ProcessorFactory for DissolverFactory {
             tolerance: param.tolerance.unwrap_or(0.0),
             attribute_accumulation: param.attribute_accumulation,
             group_map: HashMap::new(),
+            #[cfg(feature = "new-geometry")]
+            group_frame: HashMap::new(),
+            #[cfg(feature = "new-geometry")]
+            reported_groups: HashSet::new(),
             group_count: 0,
             temp_dir: None,
             buffer: HashMap::new(),
@@ -142,6 +162,15 @@ pub struct Dissolver {
     attribute_accumulation: AttributeAccumulationStrategy,
     // Disk-backed state
     group_map: HashMap<AttributeValue, usize>,
+    /// The coordinate frame each group's members must share, fixed by the
+    /// group's first feature. The dissolve merges point sets, which is only
+    /// meaningful within one frame.
+    #[cfg(feature = "new-geometry")]
+    group_frame: HashMap<usize, CoordinateFrame>,
+    /// Groups whose frame mismatch has already been reported, so the same
+    /// upstream problem is logged once rather than once per feature.
+    #[cfg(feature = "new-geometry")]
+    reported_groups: HashSet<usize>,
     group_count: usize,
     temp_dir: Option<PathBuf>,
     // In-memory buffer: group_idx -> compressed zstd bytes (concatenated frames)
@@ -166,6 +195,10 @@ impl Clone for Dissolver {
             tolerance: self.tolerance,
             attribute_accumulation: self.attribute_accumulation.clone(),
             group_map: HashMap::new(),
+            #[cfg(feature = "new-geometry")]
+            group_frame: HashMap::new(),
+            #[cfg(feature = "new-geometry")]
+            reported_groups: HashSet::new(),
             group_count: 0,
             temp_dir: None,
             buffer: HashMap::new(),
@@ -249,7 +282,50 @@ impl Dissolver {
         Ok(features)
     }
 
+    /// Whether the incoming feature's geometry may join `group_idx`. The legacy
+    /// geometry world reads no CRS off the geometry, so every group takes it.
     #[cfg(not(feature = "new-geometry"))]
+    fn admit_frame(&mut self, _group_idx: usize, _ctx: &ExecutorContext) -> bool {
+        true
+    }
+
+    /// Whether the incoming feature's geometry may join `group_idx`: a group's
+    /// members must all be in the coordinate frame its first feature fixed,
+    /// since the dissolve merges their point sets.
+    ///
+    /// A frame mismatch is a property of the upstream pipeline rather than of
+    /// one feature, and so would repeat for every remaining member: it is
+    /// reported once per group.
+    #[cfg(feature = "new-geometry")]
+    fn admit_frame(&mut self, group_idx: usize, ctx: &ExecutorContext) -> bool {
+        let Geometry::Euclidean2D(geom_2d) = ctx.feature.geometry.as_ref() else {
+            return false;
+        };
+        let mut leaves = Vec::new();
+        flatten_2d(geom_2d, &mut leaves);
+        let Some(frame) = leaves.first().map(Leaf2D::frame) else {
+            return false;
+        };
+        let Some(group_frame) = self.group_frame.get(&group_idx) else {
+            self.group_frame.insert(group_idx, frame.clone());
+            return true;
+        };
+        if group_frame == frame {
+            return true;
+        }
+
+        let message = format!(
+            "Dissolver rejected a feature in {frame:?}: its group is in {group_frame:?}. \
+             Reproject the input to one coordinate frame upstream."
+        );
+        if self.reported_groups.insert(group_idx) {
+            ctx.event_hub.warn_log(Some(ctx.error_span()), message);
+        } else {
+            ctx.event_hub.debug_log(Some(ctx.error_span()), message);
+        }
+        false
+    }
+
     fn dissolve_all_groups(&mut self) -> Result<Vec<Feature>, BoxedError> {
         // Flush buffer before reading files
         self.flush_buffer()?;
@@ -262,13 +338,8 @@ impl Dissolver {
                 Err(_) => continue,
             };
 
-            let buffered_features_2d: Vec<Feature> = features
-                .into_iter()
-                .filter(|f| matches!(&f.geometry.value, GeometryValue::FlowGeometry2D(_)))
-                .collect();
-
-            if let Some(dissolved_2d) = self.dissolve_2d(buffered_features_2d) {
-                dissolved.push(dissolved_2d);
+            if let Some(feature) = self.dissolve_group(features)? {
+                dissolved.push(feature);
             }
         }
 
@@ -280,123 +351,46 @@ impl Dissolver {
 
         // Reset state
         self.group_map.clear();
+        #[cfg(feature = "new-geometry")]
+        self.group_frame.clear();
         self.group_count = 0;
 
         Ok(dissolved)
     }
-}
 
-impl Processor for Dissolver {
-    fn is_accumulating(&self) -> bool {
-        true
-    }
-
-    #[cfg(not(feature = "new-geometry"))]
-    fn process(
-        &mut self,
-        ctx: ExecutorContext,
-        fw: &ProcessorChannelForwarder,
-    ) -> Result<(), BoxedError> {
-        // Capture executor_id on first process call for cache isolation
-        if self.executor_id.is_none() {
-            self.executor_id = Some(fw.executor_id());
-        }
-
-        let feature = &ctx.feature;
-        let geometry = &feature.geometry;
-        if geometry.is_empty() {
-            fw.send(ctx.new_with_feature_and_port(ctx.feature.clone(), REJECTED_PORT.clone()));
-            return Ok(());
-        };
-        match &geometry.value {
-            GeometryValue::None => {
-                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
-            }
-            GeometryValue::FlowGeometry2D(_) => {
-                let key = if let Some(group_by) = &self.group_by {
-                    AttributeValue::Array(
-                        group_by
-                            .iter()
-                            .filter_map(|attr| feature.attributes.get(attr).cloned())
-                            .collect(),
-                    )
-                } else {
-                    AttributeValue::Null
-                };
-
-                // Get or create group index for this key
-                let group_idx = if let Some(&idx) = self.group_map.get(&key) {
-                    idx
-                } else {
-                    let idx = self.group_count;
-                    self.group_map.insert(key, idx);
-                    self.group_count += 1;
-                    idx
-                };
-
-                self.write_feature(group_idx, feature)?;
-            }
-            _ => {
-                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
-            }
-        }
-        Ok(())
-    }
-
-    #[cfg(not(feature = "new-geometry"))]
-    fn finish(
-        &mut self,
-        ctx: NodeContext,
-        fw: &ProcessorChannelForwarder,
-    ) -> Result<(), BoxedError> {
-        for dissolved in self.dissolve_all_groups()? {
-            fw.send(ExecutorContext::new_with_node_context_feature_and_port(
-                &ctx,
-                dissolved,
-                AREA_PORT.clone(),
-            ));
-        }
-        Ok(())
-    }
-
-    fn name(&self) -> &str {
-        "Dissolver"
-    }
-}
-
-impl Dissolver {
-    #[cfg(not(feature = "new-geometry"))]
-    fn dissolve_2d(&self, buffered_features_2d: Vec<Feature>) -> Option<Feature> {
-        // Start with an empty multi-polygon
-        let mut multi_polygon_2d = MultiPolygon2D::new(vec![]);
-
-        // Apply attribute accumulation strategy
-        let attrs: IndexMap<_, _> = match self.attribute_accumulation {
+    /// The attributes carried onto a group's dissolved output, under the
+    /// configured strategy. `representative` is the group's stand-in feature for
+    /// the strategies that take attributes from a single member.
+    fn accumulate_attributes(
+        &self,
+        features: &[Feature],
+        representative: Option<&Feature>,
+    ) -> IndexMap<Attribute, AttributeValue> {
+        match self.attribute_accumulation {
             AttributeAccumulationStrategy::DropAttributes => {
                 // Only keep group_by attributes if specified
-                if let (Some(group_by), Some(last_feature)) =
-                    (&self.group_by, buffered_features_2d.last())
-                {
+                if let (Some(group_by), Some(representative)) = (&self.group_by, representative) {
                     group_by
                         .iter()
                         .filter_map(|attr| {
-                            let value = last_feature.attributes.get(attr).cloned()?;
+                            let value = representative.attributes.get(attr).cloned()?;
                             Some((attr.clone(), value))
                         })
-                        .collect::<IndexMap<_, _>>()
+                        .collect()
                 } else {
                     IndexMap::new()
                 }
             }
             AttributeAccumulationStrategy::MergeAttributes => {
                 // Merge all attributes from all features
-                let mut merged_attributes = IndexMap::new();
+                let mut merged_attributes: IndexMap<Attribute, Vec<AttributeValue>> =
+                    IndexMap::new();
 
-                for feature in &buffered_features_2d {
+                for feature in features {
                     for (key, value) in feature.attributes.iter() {
                         merged_attributes
                             .entry(key.clone())
-                            .and_modify(|existing: &mut Vec<AttributeValue>| {
+                            .and_modify(|existing| {
                                 // Add value if it's not already in the list
                                 if !existing.contains(value) {
                                     existing.push(value.clone());
@@ -417,21 +411,111 @@ impl Dissolver {
                         };
                         (key, final_value)
                     })
-                    .collect::<IndexMap<_, _>>()
+                    .collect()
             }
-            AttributeAccumulationStrategy::UseOneFeature => {
-                // Use attributes from the last feature
-                if let Some(last_feature) = buffered_features_2d.last() {
-                    (*last_feature.attributes).clone()
-                } else {
-                    IndexMap::new()
-                }
-            }
+            AttributeAccumulationStrategy::UseOneFeature => representative
+                .map(|feature| (*feature.attributes).clone())
+                .unwrap_or_default(),
+        }
+    }
+}
+
+impl Processor for Dissolver {
+    fn is_accumulating(&self) -> bool {
+        true
+    }
+
+    fn process(
+        &mut self,
+        ctx: ExecutorContext,
+        fw: &ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        // Capture executor_id on first process call for cache isolation
+        if self.executor_id.is_none() {
+            self.executor_id = Some(fw.executor_id());
+        }
+
+        let feature = &ctx.feature;
+        if !accepts(feature.geometry.as_ref()) {
+            fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+            return Ok(());
+        }
+
+        let key = if let Some(group_by) = &self.group_by {
+            AttributeValue::Array(
+                group_by
+                    .iter()
+                    .filter_map(|attr| feature.attributes.get(attr).cloned())
+                    .collect(),
+            )
+        } else {
+            AttributeValue::Null
         };
 
-        // Process all features uniformly
-        for feature in buffered_features_2d {
-            let geometry = feature.geometry.value.as_flow_geometry_2d()?;
+        // Get or create group index for this key
+        let group_idx = if let Some(&idx) = self.group_map.get(&key) {
+            idx
+        } else {
+            let idx = self.group_count;
+            self.group_map.insert(key, idx);
+            self.group_count += 1;
+            idx
+        };
+
+        if !self.admit_frame(group_idx, &ctx) {
+            fw.send(ctx.new_with_feature_and_port(ctx.feature.clone(), REJECTED_PORT.clone()));
+            return Ok(());
+        }
+
+        self.write_feature(group_idx, &ctx.feature)?;
+        Ok(())
+    }
+
+    fn finish(
+        &mut self,
+        ctx: NodeContext,
+        fw: &ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        for dissolved in self.dissolve_all_groups()? {
+            fw.send(ExecutorContext::new_with_node_context_feature_and_port(
+                &ctx,
+                dissolved,
+                AREA_PORT.clone(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        "Dissolver"
+    }
+}
+
+// --- legacy geometry ---------------------------------------------------------
+
+/// Whether the geometry can take part in a dissolve: any non-empty 2D geometry.
+#[cfg(not(feature = "new-geometry"))]
+fn accepts(geometry: &Geometry) -> bool {
+    !geometry.is_empty() && matches!(geometry.value, GeometryValue::FlowGeometry2D(_))
+}
+
+/// The group's representative feature: its last one.
+#[cfg(not(feature = "new-geometry"))]
+fn representative(features: &[Feature]) -> Option<&Feature> {
+    features.last()
+}
+
+#[cfg(not(feature = "new-geometry"))]
+impl Dissolver {
+    fn dissolve_group(&self, features: Vec<Feature>) -> Result<Option<Feature>, BoxedError> {
+        let attrs = self.accumulate_attributes(&features, representative(&features));
+
+        // Start with an empty multi-polygon
+        let mut multi_polygon_2d = MultiPolygon2D::new(vec![]);
+        for feature in features {
+            let Some(geometry) = feature.geometry.value.as_flow_geometry_2d() else {
+                continue;
+            };
             let mut multi_polygon = if let Some(mp) = geometry.as_multi_polygon() {
                 mp.clone()
             } else if let Some(polygon) = geometry.as_polygon() {
@@ -447,13 +531,601 @@ impl Dissolver {
 
         // Only create feature if we accumulated some geometry
         if multi_polygon_2d.is_empty() {
-            return None;
+            return Ok(None);
         }
 
         let geometry = Geometry {
             value: GeometryValue::FlowGeometry2D(multi_polygon_2d.into()),
             ..Default::default()
         };
-        Some(Feature::new_with_attributes_and_geometry(attrs, geometry))
+        Ok(Some(Feature::new_with_attributes_and_geometry(
+            attrs, geometry,
+        )))
+    }
+}
+
+// --- new geometry ------------------------------------------------------------
+
+/// Whether the geometry can take part in a dissolve: a planar areal geometry
+/// (polygons or meshes) whose leaves share one coordinate frame.
+///
+/// The dissolve reasons about the plane alone, so a leaf placed at an elevation
+/// is refused rather than silently merged with one at a different height. Areas
+/// are what dissolve, so a line string is refused.
+#[cfg(feature = "new-geometry")]
+fn accepts(geometry: &Geometry) -> bool {
+    let Geometry::Euclidean2D(geom_2d) = geometry else {
+        return false;
+    };
+    let mut leaves = Vec::new();
+    flatten_2d(geom_2d, &mut leaves);
+    let Some(frame) = leaves.first().map(Leaf2D::frame) else {
+        return false;
+    };
+    leaves.iter().all(|leaf| {
+        leaf.frame() == frame
+            && leaf_elevation(leaf).is_none()
+            && matches!(
+                leaf,
+                Leaf2D::Polygon(_) | Leaf2D::PolygonMesh(_) | Leaf2D::TriangularMesh(_)
+            )
+    })
+}
+
+/// The elevation a 2D leaf lies at, or `None` when it is planar.
+#[cfg(feature = "new-geometry")]
+fn leaf_elevation(leaf: &Leaf2D<'_>) -> Option<f64> {
+    match leaf {
+        Leaf2D::Polygon(p) => p.elevation(),
+        Leaf2D::PolygonMesh(m) => m.elevation(),
+        Leaf2D::TriangularMesh(m) => m.elevation(),
+        Leaf2D::Line(l) => l.elevation(),
+        Leaf2D::Point(_) => None,
+    }
+}
+
+/// The group's representative feature: the one covering the most area. Ties go
+/// to the earliest feature of the group.
+#[cfg(feature = "new-geometry")]
+fn representative(features: &[Feature]) -> Option<&Feature> {
+    let mut largest: Option<(&Feature, f64)> = None;
+    for feature in features {
+        let area = covered_area(feature);
+        if largest.is_none_or(|(_, most)| area > most) {
+            largest = Some((feature, area));
+        }
+    }
+    largest.map(|(feature, _)| feature)
+}
+
+/// The total planar area the feature's geometry covers.
+#[cfg(feature = "new-geometry")]
+fn covered_area(feature: &Feature) -> f64 {
+    let Geometry::Euclidean2D(geom_2d) = feature.geometry.as_ref() else {
+        return 0.0;
+    };
+    let mut leaves = Vec::new();
+    flatten_2d(geom_2d, &mut leaves);
+    leaves.iter().map(Leaf2D::area).sum()
+}
+
+/// Dissolved polygons as one geometry.
+#[cfg(feature = "new-geometry")]
+fn wrap_polygons(mut polygons: Vec<Polygon2D>) -> Euclidean2DGeometry {
+    if polygons.len() == 1 {
+        Euclidean2DGeometry::Polygon(Box::new(polygons.remove(0)))
+    } else {
+        Euclidean2DGeometry::Collection(Collection2D::new(
+            polygons
+                .into_iter()
+                .map(|p| Euclidean2DGeometry::Polygon(Box::new(p))),
+        ))
+    }
+}
+
+#[cfg(feature = "new-geometry")]
+impl Dissolver {
+    fn dissolve_group(&self, features: Vec<Feature>) -> Result<Option<Feature>, BoxedError> {
+        let attrs = self.accumulate_attributes(&features, representative(&features));
+
+        // The whole group goes in as one operand and dissolves in a single call:
+        // the backend snaps coordinates to an adaptive grid, so folding the
+        // members in pairwise would let the result drift member by member.
+        let group = Euclidean2DGeometry::Collection(Collection2D::new(features.iter().filter_map(
+            |feature| match feature.geometry.as_ref() {
+                Geometry::Euclidean2D(geom_2d) => Some(geom_2d.clone()),
+                _ => None,
+            },
+        )));
+        let polygons = dissolve_2d(&group, self.tolerance).map_err(|e| {
+            GeometryProcessorError::Dissolver(format!("Failed to dissolve group: {e}"))
+        })?;
+
+        // Only create feature if the group enclosed some area
+        if polygons.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(Feature::new_with_attributes_and_geometry(
+            attrs,
+            Geometry::Euclidean2D(wrap_polygons(polygons)),
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use pretty_assertions::assert_eq;
+    use reearth_flow_runtime::forwarder::NoopChannelForwarder;
+
+    use super::*;
+    use crate::tests::utils::create_default_execute_context;
+
+    // --- shared fixtures -----------------------------------------------------
+
+    /// A closed CCW square ring with the corner at `min` and the given side.
+    fn square_ring(min: [f64; 2], side: f64) -> Vec<[f64; 2]> {
+        vec![
+            [min[0], min[1]],
+            [min[0] + side, min[1]],
+            [min[0] + side, min[1] + side],
+            [min[0], min[1] + side],
+            [min[0], min[1]],
+        ]
+    }
+
+    fn attributes(pairs: &[(&str, &str)]) -> IndexMap<Attribute, AttributeValue> {
+        pairs
+            .iter()
+            .map(|(k, v)| {
+                (
+                    Attribute::new(k.to_string()),
+                    AttributeValue::String(v.to_string()),
+                )
+            })
+            .collect()
+    }
+
+    fn with_attributes(mut feature: Feature, pairs: &[(&str, &str)]) -> Feature {
+        feature.attributes = Arc::new(attributes(pairs));
+        feature
+    }
+
+    fn attribute(feature: &Feature, key: &str) -> Option<AttributeValue> {
+        feature
+            .attributes
+            .get(&Attribute::new(key.to_string()))
+            .cloned()
+    }
+
+    fn dissolver(
+        group_by: Option<Vec<Attribute>>,
+        tolerance: f64,
+        attribute_accumulation: AttributeAccumulationStrategy,
+    ) -> Dissolver {
+        Dissolver {
+            group_by,
+            tolerance,
+            attribute_accumulation,
+            group_map: HashMap::new(),
+            #[cfg(feature = "new-geometry")]
+            group_frame: HashMap::new(),
+            #[cfg(feature = "new-geometry")]
+            reported_groups: HashSet::new(),
+            group_count: 0,
+            temp_dir: None,
+            buffer: HashMap::new(),
+            buffer_bytes: 0,
+            executor_id: None,
+        }
+    }
+
+    /// Feed `features` through the processor and collect what the `area` and
+    /// `rejected` ports received.
+    fn run(mut processor: Dissolver, features: Vec<Feature>) -> (Vec<Feature>, Vec<Feature>) {
+        let fw = ProcessorChannelForwarder::Noop(NoopChannelForwarder::default());
+        for feature in &features {
+            processor
+                .process(create_default_execute_context(feature), &fw)
+                .unwrap();
+        }
+        processor.finish(NodeContext::default(), &fw).unwrap();
+
+        let ProcessorChannelForwarder::Noop(noop) = fw else {
+            unreachable!("the forwarder is the one built above");
+        };
+        let ports = noop.send_ports.lock().unwrap().clone();
+        let sent = noop.send_features.lock().unwrap().clone();
+        let mut area = Vec::new();
+        let mut rejected = Vec::new();
+        for (port, feature) in ports.iter().zip(sent) {
+            if *port == *AREA_PORT {
+                area.push(feature);
+            } else if *port == *REJECTED_PORT {
+                rejected.push(feature);
+            } else {
+                panic!("unexpected port {port:?}");
+            }
+        }
+        (area, rejected)
+    }
+
+    // --- per-world fixtures --------------------------------------------------
+
+    /// A feature carrying a square face with the corner at `min`.
+    #[cfg(not(feature = "new-geometry"))]
+    fn square(min: [f64; 2], side: f64) -> Feature {
+        use reearth_flow_geometry::types::{
+            coordinate::Coordinate2D, geometry::Geometry2D, line_string::LineString2D,
+            polygon::Polygon2D,
+        };
+
+        let ring: Vec<Coordinate2D<f64>> = square_ring(min, side)
+            .into_iter()
+            .map(|[x, y]| Coordinate2D::new_(x, y))
+            .collect();
+        let polygon = Polygon2D::new(LineString2D::from(ring), vec![]);
+        Feature::from(Geometry::with_value(GeometryValue::FlowGeometry2D(
+            Geometry2D::Polygon(polygon),
+        )))
+    }
+
+    #[cfg(feature = "new-geometry")]
+    fn square(min: [f64; 2], side: f64) -> Feature {
+        Feature::from(Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(
+            Box::new(Polygon2D::from_rings(
+                CoordinateFrame::Euclidean,
+                square_ring(min, side),
+                Vec::<Vec<[f64; 2]>>::new(),
+            )),
+        )))
+    }
+
+    /// The total area the output feature's geometry covers.
+    #[cfg(not(feature = "new-geometry"))]
+    fn output_area(feature: &Feature) -> f64 {
+        use reearth_flow_geometry::algorithm::area2d::Area2D;
+
+        feature
+            .geometry
+            .value
+            .as_flow_geometry_2d()
+            .and_then(|g| g.as_multi_polygon().map(|mp| mp.unsigned_area2d()))
+            .unwrap_or(0.0)
+    }
+
+    #[cfg(feature = "new-geometry")]
+    fn output_area(feature: &Feature) -> f64 {
+        covered_area(feature)
+    }
+
+    /// The number of separate faces the output feature's geometry holds.
+    #[cfg(not(feature = "new-geometry"))]
+    fn output_faces(feature: &Feature) -> usize {
+        feature
+            .geometry
+            .value
+            .as_flow_geometry_2d()
+            .and_then(|g| g.as_multi_polygon().map(|mp| mp.0.len()))
+            .unwrap_or(0)
+    }
+
+    #[cfg(feature = "new-geometry")]
+    fn output_faces(feature: &Feature) -> usize {
+        let Geometry::Euclidean2D(geom_2d) = feature.geometry.as_ref() else {
+            return 0;
+        };
+        let mut leaves = Vec::new();
+        flatten_2d(geom_2d, &mut leaves);
+        leaves.len()
+    }
+
+    // --- behaviour shared by both geometry worlds ----------------------------
+
+    #[test]
+    fn adjacent_squares_in_one_group_dissolve_into_one_feature() {
+        let (area, rejected) = run(
+            dissolver(None, 0.0, AttributeAccumulationStrategy::UseOneFeature),
+            vec![square([0.0, 0.0], 2.0), square([2.0, 0.0], 2.0)],
+        );
+        assert_eq!(rejected.len(), 0);
+        assert_eq!(area.len(), 1);
+        assert_eq!(output_faces(&area[0]), 1);
+        assert_eq!(output_area(&area[0]), 8.0);
+    }
+
+    #[test]
+    fn group_by_dissolves_each_group_separately() {
+        let features = vec![
+            with_attributes(square([0.0, 0.0], 2.0), &[("side", "west")]),
+            with_attributes(square([2.0, 0.0], 2.0), &[("side", "west")]),
+            with_attributes(square([10.0, 0.0], 2.0), &[("side", "east")]),
+        ];
+        let (area, rejected) = run(
+            dissolver(
+                Some(vec![Attribute::new("side".to_string())]),
+                0.0,
+                AttributeAccumulationStrategy::UseOneFeature,
+            ),
+            features,
+        );
+        assert_eq!(rejected.len(), 0);
+        assert_eq!(area.len(), 2);
+        let mut areas: Vec<f64> = area.iter().map(output_area).collect();
+        areas.sort_by(f64::total_cmp);
+        assert_eq!(areas, vec![4.0, 8.0]);
+    }
+
+    #[test]
+    fn separate_squares_in_one_group_stay_separate_faces() {
+        let (area, _) = run(
+            dissolver(None, 0.0, AttributeAccumulationStrategy::UseOneFeature),
+            vec![square([0.0, 0.0], 2.0), square([10.0, 0.0], 2.0)],
+        );
+        assert_eq!(area.len(), 1);
+        assert_eq!(output_faces(&area[0]), 2);
+        assert_eq!(output_area(&area[0]), 8.0);
+    }
+
+    #[test]
+    fn merge_attributes_collects_differing_values_into_an_array() {
+        let features = vec![
+            with_attributes(square([0.0, 0.0], 2.0), &[("name", "a"), ("kind", "road")]),
+            with_attributes(square([2.0, 0.0], 2.0), &[("name", "b"), ("kind", "road")]),
+        ];
+        let (area, _) = run(
+            dissolver(None, 0.0, AttributeAccumulationStrategy::MergeAttributes),
+            features,
+        );
+        assert_eq!(area.len(), 1);
+        assert_eq!(
+            attribute(&area[0], "name"),
+            Some(AttributeValue::Array(vec![
+                AttributeValue::String("a".to_string()),
+                AttributeValue::String("b".to_string()),
+            ]))
+        );
+        // A value the whole group agrees on stays a single value.
+        assert_eq!(
+            attribute(&area[0], "kind"),
+            Some(AttributeValue::String("road".to_string()))
+        );
+    }
+
+    #[test]
+    fn drop_attributes_keeps_only_the_group_by_attributes() {
+        let feature = with_attributes(
+            square([0.0, 0.0], 2.0),
+            &[("side", "west"), ("name", "dropped")],
+        );
+        let (area, _) = run(
+            dissolver(
+                Some(vec![Attribute::new("side".to_string())]),
+                0.0,
+                AttributeAccumulationStrategy::DropAttributes,
+            ),
+            vec![feature],
+        );
+        assert_eq!(area.len(), 1);
+        assert_eq!(
+            attribute(&area[0], "side"),
+            Some(AttributeValue::String("west".to_string()))
+        );
+        assert_eq!(attribute(&area[0], "name"), None);
+    }
+
+    #[test]
+    fn an_empty_input_produces_no_output() {
+        let (area, rejected) = run(
+            dissolver(None, 0.0, AttributeAccumulationStrategy::UseOneFeature),
+            vec![],
+        );
+        assert_eq!((area.len(), rejected.len()), (0, 0));
+    }
+
+    #[test]
+    fn the_tolerance_merges_squares_whose_shared_edge_nearly_coincides() {
+        // The right neighbour's left edge sits 0.001 away from the left one's.
+        let nearly_adjacent = || vec![square([0.0, 0.0], 2.0), square([2.001, 0.0], 2.0)];
+
+        let (untouched, _) = run(
+            dissolver(None, 0.0, AttributeAccumulationStrategy::UseOneFeature),
+            nearly_adjacent(),
+        );
+        assert_eq!(untouched.len(), 1);
+        assert_eq!(output_faces(&untouched[0]), 2);
+
+        let (snapped, _) = run(
+            dissolver(None, 0.01, AttributeAccumulationStrategy::UseOneFeature),
+            nearly_adjacent(),
+        );
+        assert_eq!(snapped.len(), 1);
+        assert_eq!(output_faces(&snapped[0]), 1);
+    }
+
+    // --- legacy geometry -----------------------------------------------------
+
+    /// The legacy world keeps taking single-feature attributes from the group's
+    /// last member, where the new world takes them from its largest.
+    #[test]
+    #[cfg(not(feature = "new-geometry"))]
+    fn use_one_feature_takes_the_last_features_attributes() {
+        let features = vec![
+            with_attributes(square([1.0, 0.0], 4.0), &[("name", "large")]),
+            with_attributes(square([0.0, 0.0], 1.0), &[("name", "small")]),
+        ];
+        let (area, _) = run(
+            dissolver(None, 0.0, AttributeAccumulationStrategy::UseOneFeature),
+            features,
+        );
+        assert_eq!(area.len(), 1);
+        assert_eq!(
+            attribute(&area[0], "name"),
+            Some(AttributeValue::String("small".to_string()))
+        );
+    }
+
+    // --- new geometry --------------------------------------------------------
+
+    #[test]
+    #[cfg(feature = "new-geometry")]
+    fn use_one_feature_takes_the_largest_features_attributes() {
+        // The large face comes first, so "the group's last feature" would pick
+        // the small one: the choice really is by area.
+        let features = vec![
+            with_attributes(square([1.0, 0.0], 4.0), &[("name", "large")]),
+            with_attributes(square([0.0, 0.0], 1.0), &[("name", "small")]),
+        ];
+        let (area, _) = run(
+            dissolver(None, 0.0, AttributeAccumulationStrategy::UseOneFeature),
+            features,
+        );
+        assert_eq!(area.len(), 1);
+        assert_eq!(
+            attribute(&area[0], "name"),
+            Some(AttributeValue::String("large".to_string()))
+        );
+    }
+
+    #[cfg(feature = "new-geometry")]
+    fn rejects(feature: Feature) -> bool {
+        let (area, rejected) = run(
+            dissolver(None, 0.0, AttributeAccumulationStrategy::UseOneFeature),
+            vec![feature],
+        );
+        area.is_empty() && rejected.len() == 1
+    }
+
+    #[test]
+    #[cfg(feature = "new-geometry")]
+    fn geometries_that_enclose_no_area_are_rejected_rather_than_dropped() {
+        use reearth_flow_geometry::line_string::LineString2D;
+        use reearth_flow_geometry::point::Point2D;
+        use reearth_flow_geometry::polygon::Polygon3D;
+        use reearth_flow_geometry::Euclidean3DGeometry;
+
+        assert!(rejects(Feature::from(Geometry::None)));
+
+        assert!(rejects(Feature::from(Geometry::Euclidean2D(
+            Euclidean2DGeometry::Point(Point2D::new(CoordinateFrame::Euclidean, [1.0, 1.0]))
+        ))));
+
+        // A closed line is still a line, not an area.
+        assert!(rejects(Feature::from(Geometry::Euclidean2D(
+            Euclidean2DGeometry::LineString(LineString2D::from_coords(
+                CoordinateFrame::Euclidean,
+                square_ring([0.0, 0.0], 2.0),
+            ))
+        ))));
+
+        // 3D has no boolean overlay to dissolve with.
+        assert!(rejects(Feature::from(Geometry::Euclidean3D(
+            Euclidean3DGeometry::Polygon(Box::new(Polygon3D::from_rings(
+                CoordinateFrame::Euclidean,
+                [
+                    [0.0, 0.0, 0.0],
+                    [2.0, 0.0, 0.0],
+                    [2.0, 2.0, 0.0],
+                    [0.0, 0.0, 0.0],
+                ],
+                Vec::<Vec<[f64; 3]>>::new(),
+            )))
+        ))));
+    }
+
+    #[test]
+    #[cfg(feature = "new-geometry")]
+    fn an_elevated_face_is_rejected() {
+        // The dissolve reasons about the plane alone, so a face lifted off it is
+        // refused rather than silently flattened onto its neighbours.
+        assert!(rejects(Feature::from(Geometry::Euclidean2D(
+            Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings_at_elevation(
+                CoordinateFrame::Euclidean,
+                square_ring([0.0, 0.0], 2.0),
+                Vec::<Vec<[f64; 2]>>::new(),
+                5.0,
+            )))
+        ))));
+    }
+
+    /// A square face with the corner at `min`, in `frame`.
+    #[cfg(feature = "new-geometry")]
+    fn square_in(frame: CoordinateFrame, min: [f64; 2], side: f64) -> Feature {
+        Feature::from(Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(
+            Box::new(Polygon2D::from_rings(
+                frame,
+                square_ring(min, side),
+                Vec::<Vec<[f64; 2]>>::new(),
+            )),
+        )))
+    }
+
+    #[test]
+    #[cfg(feature = "new-geometry")]
+    fn a_group_rejects_members_outside_the_frame_its_first_feature_fixed() {
+        use reearth_flow_geometry::coordinate::EpsgCode;
+
+        let (area, rejected) = run(
+            dissolver(None, 0.0, AttributeAccumulationStrategy::UseOneFeature),
+            vec![
+                square([0.0, 0.0], 2.0),
+                square_in(CoordinateFrame::Crs(EpsgCode::new(6677)), [2.0, 0.0], 3.0),
+            ],
+        );
+        assert_eq!(area.len(), 1);
+        assert_eq!(output_area(&area[0]), 4.0);
+        assert_eq!(rejected.len(), 1);
+        assert_eq!(output_area(&rejected[0]), 9.0);
+    }
+
+    #[test]
+    #[cfg(feature = "new-geometry")]
+    fn the_output_keeps_the_groups_coordinate_frame() {
+        use reearth_flow_geometry::coordinate::EpsgCode;
+
+        let frame = CoordinateFrame::Crs(EpsgCode::new(6677));
+        let (area, _) = run(
+            dissolver(None, 0.0, AttributeAccumulationStrategy::UseOneFeature),
+            vec![
+                square_in(frame.clone(), [0.0, 0.0], 2.0),
+                square_in(frame.clone(), [2.0, 0.0], 2.0),
+            ],
+        );
+        assert_eq!(area.len(), 1);
+        let Geometry::Euclidean2D(geom_2d) = area[0].geometry.as_ref() else {
+            panic!("expected a 2D geometry");
+        };
+        let mut leaves = Vec::new();
+        flatten_2d(geom_2d, &mut leaves);
+        assert!(!leaves.is_empty());
+        assert!(leaves.iter().all(|leaf| leaf.frame() == &frame));
+    }
+
+    #[test]
+    #[cfg(feature = "new-geometry")]
+    fn a_mesh_dissolves_with_the_polygon_it_adjoins() {
+        use reearth_flow_geometry::triangular_mesh::TriangularMesh2D;
+
+        // Two triangles covering [0,2] x [0,2], adjoining the square at x = 2.
+        let mesh = TriangularMesh2D::from_parts(
+            CoordinateFrame::Euclidean,
+            vec![[0.0, 0.0], [2.0, 0.0], [2.0, 2.0], [0.0, 2.0]],
+            [0u32, 1, 2, 0, 2, 3],
+        )
+        .unwrap();
+        let mesh = Feature::from(Geometry::Euclidean2D(Euclidean2DGeometry::TriangularMesh(
+            Box::new(mesh),
+        )));
+
+        let (area, rejected) = run(
+            dissolver(None, 0.0, AttributeAccumulationStrategy::UseOneFeature),
+            vec![mesh, square([2.0, 0.0], 2.0)],
+        );
+        assert_eq!(rejected.len(), 0);
+        assert_eq!(area.len(), 1);
+        assert_eq!(output_faces(&area[0]), 1);
+        assert_eq!(output_area(&area[0]), 8.0);
     }
 }

--- a/engine/runtime/action-processor/src/geometry/dissolver.rs
+++ b/engine/runtime/action-processor/src/geometry/dissolver.rs
@@ -630,10 +630,9 @@ impl Dissolver {
     fn dissolve_group(&self, features: Vec<Feature>) -> Result<Option<Feature>, BoxedError> {
         let attrs = self.accumulate_attributes(&features, representative(&features));
 
-        // The whole group goes in as one operand and dissolves in a single call:
-        // the backend snaps coordinates to an adaptive grid, so folding the
-        // members in pairwise would let the result drift member by member. The
-        // leaves borrow the members, so the group's coordinates are not copied.
+        // The whole group dissolves in one call rather than one union per member:
+        // the backend rounds its input to a grid, so unioning one member at a
+        // time would round the same coordinates again on every pass.
         let mut leaves = Vec::new();
         for feature in &features {
             if let Geometry::Euclidean2D(geom_2d) = feature.geometry.as_ref() {

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/02-tran-rwy-trk-squr-wwy.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/02-tran-rwy-trk-squr-wwy.yml
@@ -518,7 +518,7 @@ graphs:
       - gml_id
       - __package
       - __lod
-      attributeAccumulationMode: useOne
+      attributeAccumulation: useOneFeature
   - id: b4c8d9e0-f1a2-3b4c-5d6e-7f8a9b0c1d2e
     name: FeatureSorterPreMVT
     type: action

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/02-tran-rwy-trk-squr-wwy/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/02-tran-rwy-trk-squr-wwy/workflow.yml
@@ -274,7 +274,7 @@ graphs:
             - gml_id
             - __package
             - __lod
-          attributeAccumulationMode: useOne
+          attributeAccumulation: useOneFeature
 
       - id: b4c8d9e0-f1a2-3b4c-5d6e-7f8a9b0c1d2e
         name: FeatureSorterPreMVT

--- a/engine/runtime/geometry/src/overlay/mod.rs
+++ b/engine/runtime/geometry/src/overlay/mod.rs
@@ -153,11 +153,19 @@ pub fn dissolve(g: &Geometry, tolerance: f64) -> Result<Vec<Polygon2D>> {
     dissolve_leaves(&leaves, tolerance)
 }
 
-/// [`dissolve`] over a 2D geometry.
-pub fn dissolve_2d(g: &Euclidean2DGeometry, tolerance: f64) -> Result<Vec<Polygon2D>> {
-    let mut leaves = Vec::new();
-    flatten_2d(g, &mut leaves);
-    dissolve_leaves(&leaves, tolerance)
+/// [`dissolve`] over leaves already flattened by the caller, letting several
+/// geometries dissolve as one operand without being copied into a collection
+/// first.
+pub fn dissolve_leaves(leaves: &[Leaf2D<'_>], tolerance: f64) -> Result<Vec<Polygon2D>> {
+    require_common_frame_leaves(leaves, &[])?;
+    let mut shapes = shapes::areal_shapes(leaves).map_err(|_| PredicateError::Unsupported {
+        geometry: operand_name(leaves, is_areal),
+    })?;
+    let Some(frame) = leaves.first().map(Leaf2D::frame) else {
+        return Ok(Vec::new());
+    };
+    snap::snap_shapes(&mut shapes, tolerance);
+    Ok(dissolve_shapes(shapes, frame))
 }
 
 /// The portion of the polylines of `lines` inside the areal geometry `area`,
@@ -241,18 +249,6 @@ fn overlay_leaves(a: &[Leaf2D<'_>], b: &[Leaf2D<'_>], op: OverlayOp) -> Result<V
             Ok(shapes::shapes_to_polygons(result, frame))
         }
     }
-}
-
-fn dissolve_leaves(leaves: &[Leaf2D<'_>], tolerance: f64) -> Result<Vec<Polygon2D>> {
-    require_common_frame_leaves(leaves, &[])?;
-    let mut shapes = shapes::areal_shapes(leaves).map_err(|_| PredicateError::Unsupported {
-        geometry: operand_name(leaves, is_areal),
-    })?;
-    let Some(frame) = leaves.first().map(Leaf2D::frame) else {
-        return Ok(Vec::new());
-    };
-    snap::snap_shapes(&mut shapes, tolerance);
-    Ok(dissolve_shapes(shapes, frame))
 }
 
 // --- exactness gate --------------------------------------------------------

--- a/engine/runtime/geometry/src/overlay/mod.rs
+++ b/engine/runtime/geometry/src/overlay/mod.rs
@@ -8,6 +8,9 @@
 //! - [`overlay()`] and its [`union()`] / [`intersection()`] / [`difference()`]
 //!   / [`xor()`] shorthands: areal boolean overlay, backed by the `i_overlay`
 //!   pure-Rust backend.
+//! - [`dissolve()`]: one areal geometry's own leaves merged into each other,
+//!   the unary case of a union, with optional vertex snapping to close the
+//!   gaps left where boundaries meant to coincide do not quite.
 //! - [`clip()`]: the portion of a set of polylines inside (or, inverted,
 //!   outside) an areal geometry.
 //! - [`segment_intersections()`]: the pairwise segment × segment
@@ -53,6 +56,7 @@
 
 mod segments;
 mod shapes;
+mod snap;
 #[cfg(test)]
 mod tests;
 
@@ -68,7 +72,7 @@ use crate::ops::Aabb;
 use crate::polygon::Polygon2D;
 use crate::predicates::relate::relate_leaves;
 use crate::predicates::view::{flatten_2d, require_common_frame_leaves, Leaf2D};
-use crate::predicates::{flatten_2d_pair, PredicateError, Result};
+use crate::predicates::{flatten_2d_pair, flatten_2d_single, PredicateError, Result};
 use crate::{Euclidean2DGeometry, Geometry};
 
 pub use crate::predicates::kernel::SegmentIntersection;
@@ -137,6 +141,25 @@ pub fn overlay_2d(
     overlay_leaves(&a_leaves, &b_leaves, op)
 }
 
+/// The union of `g`'s own leaves, as disjoint polygons in their common frame
+/// (empty when `g` encloses no area).
+///
+/// Vertices closer together than `tolerance` are snapped onto one position
+/// before the union, closing sliver gaps where boundaries nearly coincide; a
+/// non-positive tolerance snaps nothing. Only vertices move, so a gap between
+/// two edges with no vertices facing each other stays open.
+pub fn dissolve(g: &Geometry, tolerance: f64) -> Result<Vec<Polygon2D>> {
+    let leaves = flatten_2d_single(g)?;
+    dissolve_leaves(&leaves, tolerance)
+}
+
+/// [`dissolve`] over a 2D geometry.
+pub fn dissolve_2d(g: &Euclidean2DGeometry, tolerance: f64) -> Result<Vec<Polygon2D>> {
+    let mut leaves = Vec::new();
+    flatten_2d(g, &mut leaves);
+    dissolve_leaves(&leaves, tolerance)
+}
+
 /// The portion of the polylines of `lines` inside the areal geometry `area`,
 /// or, with `invert`, the portion outside it. Points exactly on `area`'s
 /// boundary count as inside either way.
@@ -183,9 +206,8 @@ pub fn segment_intersections_2d(
 /// Dissolve `shapes`, each a list of rings (outer contour first, then holes,
 /// every ring wound to Flow's convention and implicitly closed), into disjoint
 /// polygons in `frame` under the non-zero fill rule.
-#[cfg(feature = "new-geometry")]
 pub(crate) fn dissolve_shapes(
-    shapes: Vec<Vec<Vec<[f64; 2]>>>,
+    shapes: Vec<shapes::Shape>,
     frame: &CoordinateFrame,
 ) -> Vec<Polygon2D> {
     let empty: Vec<shapes::Shape> = Vec::new();
@@ -205,20 +227,13 @@ fn overlay_leaves(a: &[Leaf2D<'_>], b: &[Leaf2D<'_>], op: OverlayOp) -> Result<V
     let Some(frame) = common_frame(a, b) else {
         return Ok(Vec::new());
     };
-    let dissolve = |shapes: &Vec<shapes::Shape>| {
-        let empty: Vec<shapes::Shape> = Vec::new();
-        shapes::shapes_to_polygons(
-            shapes.overlay(&empty, OverlayRule::Union, FillRule::NonZero),
-            frame,
-        )
-    };
     match exact_plan(a, b, op) {
         Plan::Empty => Ok(Vec::new()),
-        Plan::DissolveA => Ok(dissolve(&subject)),
-        Plan::DissolveB => Ok(dissolve(&clip)),
+        Plan::DissolveA => Ok(dissolve_shapes(subject, frame)),
+        Plan::DissolveB => Ok(dissolve_shapes(clip, frame)),
         Plan::DissolveBoth => {
-            let mut out = dissolve(&subject);
-            out.extend(dissolve(&clip));
+            let mut out = dissolve_shapes(subject, frame);
+            out.extend(dissolve_shapes(clip, frame));
             Ok(out)
         }
         Plan::Run(op) => {
@@ -226,6 +241,18 @@ fn overlay_leaves(a: &[Leaf2D<'_>], b: &[Leaf2D<'_>], op: OverlayOp) -> Result<V
             Ok(shapes::shapes_to_polygons(result, frame))
         }
     }
+}
+
+fn dissolve_leaves(leaves: &[Leaf2D<'_>], tolerance: f64) -> Result<Vec<Polygon2D>> {
+    require_common_frame_leaves(leaves, &[])?;
+    let mut shapes = shapes::areal_shapes(leaves).map_err(|_| PredicateError::Unsupported {
+        geometry: operand_name(leaves, is_areal),
+    })?;
+    let Some(frame) = leaves.first().map(Leaf2D::frame) else {
+        return Ok(Vec::new());
+    };
+    snap::snap_shapes(&mut shapes, tolerance);
+    Ok(dissolve_shapes(shapes, frame))
 }
 
 // --- exactness gate --------------------------------------------------------

--- a/engine/runtime/geometry/src/overlay/mod.rs
+++ b/engine/runtime/geometry/src/overlay/mod.rs
@@ -8,9 +8,9 @@
 //! - [`overlay()`] and its [`union()`] / [`intersection()`] / [`difference()`]
 //!   / [`xor()`] shorthands: areal boolean overlay, backed by the `i_overlay`
 //!   pure-Rust backend.
-//! - [`dissolve()`]: one areal geometry's own leaves merged into each other,
-//!   the unary case of a union, with optional vertex snapping to close the
-//!   gaps left where boundaries meant to coincide do not quite.
+//! - [`dissolve_leaves()`]: one areal operand's own leaves merged into each
+//!   other, the unary case of a union, with optional vertex snapping to close
+//!   the gaps left where boundaries meant to coincide do not quite.
 //! - [`clip()`]: the portion of a set of polylines inside (or, inverted,
 //!   outside) an areal geometry.
 //! - [`segment_intersections()`]: the pairwise segment × segment
@@ -72,7 +72,7 @@ use crate::ops::Aabb;
 use crate::polygon::Polygon2D;
 use crate::predicates::relate::relate_leaves;
 use crate::predicates::view::{flatten_2d, require_common_frame_leaves, Leaf2D};
-use crate::predicates::{flatten_2d_pair, flatten_2d_single, PredicateError, Result};
+use crate::predicates::{flatten_2d_pair, PredicateError, Result};
 use crate::{Euclidean2DGeometry, Geometry};
 
 pub use crate::predicates::kernel::SegmentIntersection;
@@ -141,21 +141,15 @@ pub fn overlay_2d(
     overlay_leaves(&a_leaves, &b_leaves, op)
 }
 
-/// The union of `g`'s own leaves, as disjoint polygons in their common frame
-/// (empty when `g` encloses no area).
+/// The union of one areal operand's own leaves, as disjoint polygons in their
+/// common frame (empty when they enclose no area). The caller flattens, so
+/// several geometries can dissolve as one operand without being copied into a
+/// collection first.
 ///
 /// Vertices closer together than `tolerance` are snapped onto one position
 /// before the union, closing sliver gaps where boundaries nearly coincide; a
 /// non-positive tolerance snaps nothing. Only vertices move, so a gap between
 /// two edges with no vertices facing each other stays open.
-pub fn dissolve(g: &Geometry, tolerance: f64) -> Result<Vec<Polygon2D>> {
-    let leaves = flatten_2d_single(g)?;
-    dissolve_leaves(&leaves, tolerance)
-}
-
-/// [`dissolve`] over leaves already flattened by the caller, letting several
-/// geometries dissolve as one operand without being copied into a collection
-/// first.
 pub fn dissolve_leaves(leaves: &[Leaf2D<'_>], tolerance: f64) -> Result<Vec<Polygon2D>> {
     require_common_frame_leaves(leaves, &[])?;
     let mut shapes = shapes::areal_shapes(leaves).map_err(|_| PredicateError::Unsupported {

--- a/engine/runtime/geometry/src/overlay/mod.rs
+++ b/engine/runtime/geometry/src/overlay/mod.rs
@@ -8,9 +8,8 @@
 //! - [`overlay()`] and its [`union()`] / [`intersection()`] / [`difference()`]
 //!   / [`xor()`] shorthands: areal boolean overlay, backed by the `i_overlay`
 //!   pure-Rust backend.
-//! - [`dissolve_leaves()`]: one areal operand's own leaves merged into each
-//!   other, the unary case of a union, with optional vertex snapping to close
-//!   the gaps left where boundaries meant to coincide do not quite.
+//! - [`dissolve_leaves()`]: the unary case of a union, one areal operand's own
+//!   leaves merged into each other, with optional vertex snapping.
 //! - [`clip()`]: the portion of a set of polylines inside (or, inverted,
 //!   outside) an areal geometry.
 //! - [`segment_intersections()`]: the pairwise segment × segment
@@ -142,14 +141,10 @@ pub fn overlay_2d(
 }
 
 /// The union of one areal operand's own leaves, as disjoint polygons in their
-/// common frame (empty when they enclose no area). The caller flattens, so
-/// several geometries can dissolve as one operand without being copied into a
-/// collection first.
-///
-/// Vertices closer together than `tolerance` are snapped onto one position
-/// before the union, closing sliver gaps where boundaries nearly coincide; a
-/// non-positive tolerance snaps nothing. Only vertices move, so a gap between
-/// two edges with no vertices facing each other stays open.
+/// common frame (empty when they enclose no area). Taking leaves lets several
+/// geometries dissolve as one operand. Vertices closer together than
+/// `tolerance` are snapped onto one position first, closing sliver gaps where
+/// boundaries nearly coincide; a non-positive tolerance snaps nothing.
 pub fn dissolve_leaves(leaves: &[Leaf2D<'_>], tolerance: f64) -> Result<Vec<Polygon2D>> {
     require_common_frame_leaves(leaves, &[])?;
     let mut shapes = shapes::areal_shapes(leaves).map_err(|_| PredicateError::Unsupported {

--- a/engine/runtime/geometry/src/overlay/snap.rs
+++ b/engine/runtime/geometry/src/overlay/snap.rs
@@ -1,0 +1,133 @@
+//! Vertex snapping for overlay operands.
+//!
+//! Boundaries that were meant to coincide often do not, by a hair: a shared
+//! edge digitized twice, coordinates round-tripped through a lower precision,
+//! neighbouring tiles cut from slightly different sources. The overlay backend
+//! reads those as real geometry and leaves a sliver gap where the caller wanted
+//! one face. Pulling near-coincident vertices onto one position first closes
+//! the gap before the boolean ever runs.
+//!
+//! The adjustment is anchored: a vertex claims every unclaimed vertex within
+//! the tolerance and they take *its* position, so no vertex moves further than
+//! the tolerance and existing coordinates stay put rather than drifting to a
+//! computed average.
+
+use kiddo::{ImmutableKdTree, SquaredEuclidean};
+
+use super::shapes::Shape;
+
+/// Pull the vertices of `shapes` that lie closer together than `tolerance` onto
+/// one shared position, in place. A non-positive tolerance snaps nothing.
+///
+/// Vertex to vertex only: a gap between two edges that have no vertices facing
+/// each other is left open, however narrow.
+pub(super) fn snap_shapes(shapes: &mut [Shape], tolerance: f64) {
+    if tolerance <= 0.0 {
+        return;
+    }
+    let points: Vec<[f64; 2]> = shapes
+        .iter()
+        .flat_map(|shape| shape.iter().flat_map(|path| path.iter().copied()))
+        .collect();
+    let Some(snapped) = snapped_positions(&points, tolerance) else {
+        return;
+    };
+    let mut i = 0;
+    for shape in shapes {
+        for path in shape {
+            for coord in path {
+                *coord = snapped[i];
+                i += 1;
+            }
+        }
+    }
+}
+
+/// The position each of `points` snaps to, or `None` when there is nothing to
+/// snap. Scanning in index order, a point not yet claimed becomes an anchor and
+/// claims every later unclaimed point within `tolerance` of it.
+fn snapped_positions(points: &[[f64; 2]], tolerance: f64) -> Option<Vec<[f64; 2]>> {
+    let n = points.len();
+    if n <= 1 {
+        return None;
+    }
+    // ImmutableKdTree handles degenerate point distributions (many points
+    // sharing one axis coordinate, as rectilinear rings do) without panicking,
+    // unlike the mutable KdTree.
+    let tree: ImmutableKdTree<f64, 2> = ImmutableKdTree::new_from_slice(points);
+    let squared_tolerance = tolerance * tolerance;
+
+    let mut snapped = points.to_vec();
+    let mut claimed = vec![false; n];
+    for i in 0..n {
+        if claimed[i] {
+            continue;
+        }
+        for neighbour in tree.within::<SquaredEuclidean>(&points[i], squared_tolerance) {
+            let j = neighbour.item as usize;
+            if j <= i || claimed[j] || neighbour.distance >= squared_tolerance {
+                continue;
+            }
+            snapped[j] = points[i];
+            claimed[j] = true;
+        }
+    }
+    Some(snapped)
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn near_coincident_vertices_take_the_anchors_position() {
+        let mut shapes = vec![
+            vec![vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]]],
+            vec![vec![[1.0005, 0.0], [2.0, 0.0], [1.0005, 1.0004]]],
+        ];
+        snap_shapes(&mut shapes, 0.01);
+
+        assert_eq!(shapes[1][0][0], [1.0, 0.0]);
+        assert_eq!(shapes[1][0][2], [1.0, 1.0]);
+        // Far vertices keep their own position.
+        assert_eq!(shapes[1][0][1], [2.0, 0.0]);
+    }
+
+    #[test]
+    fn vertices_further_apart_than_the_tolerance_stay_put() {
+        let original = vec![vec![vec![[0.0, 0.0], [1.0, 0.0]]], vec![vec![[1.5, 0.0]]]];
+        let mut shapes = original.clone();
+        snap_shapes(&mut shapes, 0.1);
+        assert_eq!(shapes, original);
+    }
+
+    #[test]
+    fn a_non_positive_tolerance_snaps_nothing() {
+        let original = vec![vec![vec![
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [1.0 + f64::EPSILON, 0.0],
+        ]]];
+        let mut shapes = original.clone();
+        snap_shapes(&mut shapes, 0.0);
+        assert_eq!(shapes, original);
+        snap_shapes(&mut shapes, -1.0);
+        assert_eq!(shapes, original);
+    }
+
+    #[test]
+    fn no_vertex_moves_further_than_the_tolerance() {
+        // A chain of steps each under the tolerance: anchoring must not walk a
+        // vertex along the chain by more than the tolerance.
+        let mut shapes = vec![vec![(0..10).map(|i| [i as f64 * 0.004, 0.0]).collect()]];
+        let original = shapes.clone();
+        snap_shapes(&mut shapes, 0.01);
+
+        for (moved, before) in shapes[0][0].iter().zip(&original[0][0]) {
+            let d = ((moved[0] - before[0]).powi(2) + (moved[1] - before[1]).powi(2)).sqrt();
+            assert!(d < 0.01, "vertex moved {d} > tolerance");
+        }
+    }
+}

--- a/engine/runtime/geometry/src/overlay/tests.rs
+++ b/engine/runtime/geometry/src/overlay/tests.rs
@@ -856,21 +856,6 @@ fn the_tolerance_leaves_a_gap_with_no_facing_vertices_open() {
 }
 
 #[test]
-fn dissolve_2d_matches_dissolve_on_the_same_members() {
-    let strip = collection([
-        polygon(&rect(0.0, 0.0, 2.0, 2.0), &[]),
-        nudged_square([2.0, 0.0], 0.001),
-    ]);
-    let Geometry::Euclidean2D(strip_2d) = &strip else {
-        unreachable!();
-    };
-    assert_eq!(
-        dissolve_2d(strip_2d, 0.01).unwrap(),
-        dissolve(&strip, 0.01).unwrap()
-    );
-}
-
-#[test]
 fn dissolve_refuses_a_three_dimensional_operand() {
     let solid = Geometry::Euclidean3D(crate::Euclidean3DGeometry::LineString(
         crate::line_string::LineString3D::from_coords(e(), [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]),

--- a/engine/runtime/geometry/src/overlay/tests.rs
+++ b/engine/runtime/geometry/src/overlay/tests.rs
@@ -676,3 +676,209 @@ fn gate_keeps_nearly_touching_operands_separate() {
     assert_eq!(u.len(), 2);
     assert!(intersection(&a, &b).unwrap().is_empty());
 }
+
+// --- dissolve ------------------------------------------------------------------
+
+/// A collection of the given 2D geometries, the operand shape a dissolve takes.
+fn collection(members: impl IntoIterator<Item = Geometry>) -> Geometry {
+    Geometry::Euclidean2D(Euclidean2DGeometry::Collection(Collection2D::new(
+        members.into_iter().map(|g| match g {
+            Geometry::Euclidean2D(g) => g,
+            _ => unreachable!("2D members only"),
+        }),
+    )))
+}
+
+/// A square with the corner at `min`, side 2, whose vertices are all offset by
+/// `nudge` — a stand-in for a boundary digitized at a slightly different
+/// precision than its neighbour's.
+fn nudged_square(min: [f64; 2], nudge: f64) -> Geometry {
+    polygon(
+        &rect(
+            min[0] + nudge,
+            min[1] + nudge,
+            min[0] + 2.0 + nudge,
+            min[1] + 2.0 + nudge,
+        ),
+        &[],
+    )
+}
+
+#[test]
+fn edge_adjacent_members_dissolve_into_one_face() {
+    let strip = collection([
+        polygon(&rect(0.0, 0.0, 2.0, 2.0), &[]),
+        polygon(&rect(2.0, 0.0, 4.0, 2.0), &[]),
+    ]);
+    let dissolved = dissolve(&strip, 0.0).unwrap();
+    assert_eq!(dissolved.len(), 1);
+    assert_eq!(area(&dissolved), 8.0);
+}
+
+#[test]
+fn overlapping_members_dissolve_and_lose_the_interior_edge() {
+    let overlapping = collection([
+        polygon(&rect(0.0, 0.0, 3.0, 2.0), &[]),
+        polygon(&rect(1.0, 0.0, 4.0, 2.0), &[]),
+    ]);
+    let dissolved = dissolve(&overlapping, 0.0).unwrap();
+    assert_eq!(dissolved.len(), 1);
+    assert_eq!(area(&dissolved), 8.0);
+    assert_eq!(dissolved[0].exterior().len(), 5); // a plain rect, closed
+}
+
+#[test]
+fn separate_members_stay_separate() {
+    let apart = collection([
+        polygon(&rect(0.0, 0.0, 2.0, 2.0), &[]),
+        polygon(&rect(5.0, 5.0, 7.0, 7.0), &[]),
+    ]);
+    let dissolved = dissolve(&apart, 0.0).unwrap();
+    assert_eq!(dissolved.len(), 2);
+    assert_eq!(area(&dissolved), 8.0);
+}
+
+#[test]
+fn a_member_filling_a_hole_closes_it() {
+    let donut_and_plug = collection([
+        polygon(&rect(0.0, 0.0, 4.0, 4.0), &[rect_cw(1.0, 1.0, 3.0, 3.0)]),
+        polygon(&rect(1.0, 1.0, 3.0, 3.0), &[]),
+    ]);
+    let dissolved = dissolve(&donut_and_plug, 0.0).unwrap();
+    assert_eq!(dissolved.len(), 1);
+    assert_eq!(polygon2d_rings(&dissolved[0]).count(), 1);
+    assert_eq!(area(&dissolved), 16.0);
+}
+
+#[test]
+fn a_lone_member_dissolves_to_itself() {
+    let single = polygon(&rect(0.0, 0.0, 2.0, 2.0), &[]);
+    let dissolved = dissolve(&single, 0.0).unwrap();
+    assert_eq!(dissolved.len(), 1);
+    assert_eq!(area(&dissolved), 4.0);
+}
+
+#[test]
+fn mesh_members_dissolve_with_polygon_members() {
+    // Two quads sharing x = 2 cover [0,4] x [0,2]; the polygon extends it to 6.
+    let mesh = PolygonMesh2D::from_parts(
+        e(),
+        vec![
+            [0.0, 0.0],
+            [2.0, 0.0],
+            [2.0, 2.0],
+            [0.0, 2.0],
+            [4.0, 0.0],
+            [4.0, 2.0],
+        ],
+        vec![vec![0u32, 1, 2, 3], vec![1, 4, 5, 2]],
+    )
+    .unwrap();
+    let mixed = collection([
+        Geometry::Euclidean2D(Euclidean2DGeometry::PolygonMesh(Box::new(mesh))),
+        polygon(&rect(4.0, 0.0, 6.0, 2.0), &[]),
+    ]);
+    let dissolved = dissolve(&mixed, 0.0).unwrap();
+    assert_eq!(dissolved.len(), 1);
+    assert_eq!(area(&dissolved), 12.0);
+}
+
+#[test]
+fn nothing_dissolves_to_nothing() {
+    let empty = Geometry::Euclidean2D(Euclidean2DGeometry::Collection(Collection2D::new([])));
+    assert!(dissolve(&Geometry::None, 0.0).unwrap().is_empty());
+    assert!(dissolve(&empty, 0.0).unwrap().is_empty());
+    assert!(dissolve(&empty, 0.5).unwrap().is_empty());
+}
+
+#[test]
+fn dissolve_refuses_mixed_frames_and_non_areal_members() {
+    let in_crs = Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(Box::new(
+        Polygon2D::from_rings(
+            CoordinateFrame::Crs(EpsgCode::new(6677)),
+            rect(0.0, 0.0, 1.0, 1.0),
+            Vec::<Vec<[f64; 2]>>::new(),
+        ),
+    )));
+    let mixed_frames = collection([polygon(&rect(0.0, 0.0, 1.0, 1.0), &[]), in_crs]);
+    assert_eq!(
+        dissolve(&mixed_frames, 0.0),
+        Err(PredicateError::MixedFrames)
+    );
+
+    let with_a_line = collection([
+        polygon(&rect(0.0, 0.0, 2.0, 2.0), &[]),
+        line(&[[0.0, 0.0], [2.0, 2.0]]),
+    ]);
+    assert_eq!(
+        dissolve(&with_a_line, 0.0),
+        Err(PredicateError::Unsupported {
+            geometry: "LineString2D"
+        })
+    );
+    assert_eq!(
+        dissolve(&point([0.0, 0.0]), 0.0),
+        Err(PredicateError::Unsupported {
+            geometry: "Point2D"
+        })
+    );
+}
+
+#[test]
+fn the_tolerance_merges_boundaries_that_nearly_coincide() {
+    // Neighbours meant to share the edge x = 2, one digitized 0.001 off.
+    let nearly_adjacent = collection([
+        polygon(&rect(0.0, 0.0, 2.0, 2.0), &[]),
+        nudged_square([2.0, 0.0], 0.001),
+    ]);
+
+    // Without a tolerance the sliver gap survives as a second face.
+    let untouched = dissolve(&nearly_adjacent, 0.0).unwrap();
+    assert_eq!(untouched.len(), 2);
+
+    // With one, the near-coincident vertices snap together and the pair merges.
+    let dissolved = dissolve(&nearly_adjacent, 0.01).unwrap();
+    assert_eq!(dissolved.len(), 1);
+}
+
+#[test]
+fn the_tolerance_leaves_a_gap_with_no_facing_vertices_open() {
+    // The documented limit: snapping is vertex to vertex, so a corridor between
+    // two long parallel edges stays open even though it is narrower than the
+    // tolerance. The upper slab is inset in x so that no corner of one is
+    // within the tolerance of a corner of the other.
+    let across_a_corridor = collection([
+        polygon(&rect(0.0, 0.0, 100.0, 2.0), &[]),
+        polygon(&rect(20.0, 2.5, 80.0, 4.0), &[]),
+    ]);
+    let dissolved = dissolve(&across_a_corridor, 1.0).unwrap();
+    assert_eq!(dissolved.len(), 2);
+}
+
+#[test]
+fn dissolve_2d_matches_dissolve_on_the_same_members() {
+    let strip = collection([
+        polygon(&rect(0.0, 0.0, 2.0, 2.0), &[]),
+        nudged_square([2.0, 0.0], 0.001),
+    ]);
+    let Geometry::Euclidean2D(strip_2d) = &strip else {
+        unreachable!();
+    };
+    assert_eq!(
+        dissolve_2d(strip_2d, 0.01).unwrap(),
+        dissolve(&strip, 0.01).unwrap()
+    );
+}
+
+#[test]
+fn dissolve_refuses_a_three_dimensional_operand() {
+    let solid = Geometry::Euclidean3D(crate::Euclidean3DGeometry::LineString(
+        crate::line_string::LineString3D::from_coords(e(), [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]),
+    ));
+    assert_eq!(
+        dissolve(&solid, 0.0),
+        Err(PredicateError::Unsupported {
+            geometry: "LineString3D"
+        })
+    );
+}

--- a/engine/runtime/geometry/src/overlay/tests.rs
+++ b/engine/runtime/geometry/src/overlay/tests.rs
@@ -679,7 +679,7 @@ fn gate_keeps_nearly_touching_operands_separate() {
 
 // --- dissolve ------------------------------------------------------------------
 
-/// A collection of the given 2D geometries, the operand shape a dissolve takes.
+/// A collection of the given 2D geometries.
 fn collection(members: impl IntoIterator<Item = Geometry>) -> Geometry {
     Geometry::Euclidean2D(Euclidean2DGeometry::Collection(Collection2D::new(
         members.into_iter().map(|g| match g {
@@ -689,39 +689,43 @@ fn collection(members: impl IntoIterator<Item = Geometry>) -> Geometry {
     )))
 }
 
-/// A square with the corner at `min`, side 2, whose vertices are all offset by
-/// `nudge` — a stand-in for a boundary digitized at a slightly different
-/// precision than its neighbour's.
-fn nudged_square(min: [f64; 2], nudge: f64) -> Geometry {
-    polygon(
-        &rect(
-            min[0] + nudge,
-            min[1] + nudge,
-            min[0] + 2.0 + nudge,
-            min[1] + 2.0 + nudge,
-        ),
-        &[],
-    )
+/// Dissolve `members` as one operand: every member's leaves go in together,
+/// the shape a caller merging several features builds.
+fn dissolve_all(members: &[Geometry], tolerance: f64) -> Result<Vec<Polygon2D>> {
+    let mut leaves = Vec::new();
+    for member in members {
+        match member {
+            Geometry::Euclidean2D(g) => flatten_2d(g, &mut leaves),
+            _ => unreachable!("2D members only"),
+        }
+    }
+    dissolve_leaves(&leaves, tolerance)
 }
 
 #[test]
 fn edge_adjacent_members_dissolve_into_one_face() {
-    let strip = collection([
-        polygon(&rect(0.0, 0.0, 2.0, 2.0), &[]),
-        polygon(&rect(2.0, 0.0, 4.0, 2.0), &[]),
-    ]);
-    let dissolved = dissolve(&strip, 0.0).unwrap();
+    let dissolved = dissolve_all(
+        &[
+            polygon(&rect(0.0, 0.0, 2.0, 2.0), &[]),
+            polygon(&rect(2.0, 0.0, 4.0, 2.0), &[]),
+        ],
+        0.0,
+    )
+    .unwrap();
     assert_eq!(dissolved.len(), 1);
     assert_eq!(area(&dissolved), 8.0);
 }
 
 #[test]
 fn overlapping_members_dissolve_and_lose_the_interior_edge() {
-    let overlapping = collection([
-        polygon(&rect(0.0, 0.0, 3.0, 2.0), &[]),
-        polygon(&rect(1.0, 0.0, 4.0, 2.0), &[]),
-    ]);
-    let dissolved = dissolve(&overlapping, 0.0).unwrap();
+    let dissolved = dissolve_all(
+        &[
+            polygon(&rect(0.0, 0.0, 3.0, 2.0), &[]),
+            polygon(&rect(1.0, 0.0, 4.0, 2.0), &[]),
+        ],
+        0.0,
+    )
+    .unwrap();
     assert_eq!(dissolved.len(), 1);
     assert_eq!(area(&dissolved), 8.0);
     assert_eq!(dissolved[0].exterior().len(), 5); // a plain rect, closed
@@ -729,22 +733,28 @@ fn overlapping_members_dissolve_and_lose_the_interior_edge() {
 
 #[test]
 fn separate_members_stay_separate() {
-    let apart = collection([
-        polygon(&rect(0.0, 0.0, 2.0, 2.0), &[]),
-        polygon(&rect(5.0, 5.0, 7.0, 7.0), &[]),
-    ]);
-    let dissolved = dissolve(&apart, 0.0).unwrap();
+    let dissolved = dissolve_all(
+        &[
+            polygon(&rect(0.0, 0.0, 2.0, 2.0), &[]),
+            polygon(&rect(5.0, 5.0, 7.0, 7.0), &[]),
+        ],
+        0.0,
+    )
+    .unwrap();
     assert_eq!(dissolved.len(), 2);
     assert_eq!(area(&dissolved), 8.0);
 }
 
 #[test]
 fn a_member_filling_a_hole_closes_it() {
-    let donut_and_plug = collection([
-        polygon(&rect(0.0, 0.0, 4.0, 4.0), &[rect_cw(1.0, 1.0, 3.0, 3.0)]),
-        polygon(&rect(1.0, 1.0, 3.0, 3.0), &[]),
-    ]);
-    let dissolved = dissolve(&donut_and_plug, 0.0).unwrap();
+    let dissolved = dissolve_all(
+        &[
+            polygon(&rect(0.0, 0.0, 4.0, 4.0), &[rect_cw(1.0, 1.0, 3.0, 3.0)]),
+            polygon(&rect(1.0, 1.0, 3.0, 3.0), &[]),
+        ],
+        0.0,
+    )
+    .unwrap();
     assert_eq!(dissolved.len(), 1);
     assert_eq!(polygon2d_rings(&dissolved[0]).count(), 1);
     assert_eq!(area(&dissolved), 16.0);
@@ -752,10 +762,20 @@ fn a_member_filling_a_hole_closes_it() {
 
 #[test]
 fn a_lone_member_dissolves_to_itself() {
-    let single = polygon(&rect(0.0, 0.0, 2.0, 2.0), &[]);
-    let dissolved = dissolve(&single, 0.0).unwrap();
+    let dissolved = dissolve_all(&[polygon(&rect(0.0, 0.0, 2.0, 2.0), &[])], 0.0).unwrap();
     assert_eq!(dissolved.len(), 1);
     assert_eq!(area(&dissolved), 4.0);
+}
+
+#[test]
+fn members_nested_in_a_collection_dissolve_like_flat_ones() {
+    let members = [
+        polygon(&rect(0.0, 0.0, 2.0, 2.0), &[]),
+        polygon(&rect(2.0, 0.0, 4.0, 2.0), &[]),
+    ];
+    let nested = dissolve_all(&[collection(members.clone())], 0.0).unwrap();
+    assert_eq!(nested.len(), 1);
+    assert_eq!(area(&nested), area(&dissolve_all(&members, 0.0).unwrap()));
 }
 
 #[test]
@@ -774,21 +794,23 @@ fn mesh_members_dissolve_with_polygon_members() {
         vec![vec![0u32, 1, 2, 3], vec![1, 4, 5, 2]],
     )
     .unwrap();
-    let mixed = collection([
-        Geometry::Euclidean2D(Euclidean2DGeometry::PolygonMesh(Box::new(mesh))),
-        polygon(&rect(4.0, 0.0, 6.0, 2.0), &[]),
-    ]);
-    let dissolved = dissolve(&mixed, 0.0).unwrap();
+    let dissolved = dissolve_all(
+        &[
+            Geometry::Euclidean2D(Euclidean2DGeometry::PolygonMesh(Box::new(mesh))),
+            polygon(&rect(4.0, 0.0, 6.0, 2.0), &[]),
+        ],
+        0.0,
+    )
+    .unwrap();
     assert_eq!(dissolved.len(), 1);
     assert_eq!(area(&dissolved), 12.0);
 }
 
 #[test]
 fn nothing_dissolves_to_nothing() {
-    let empty = Geometry::Euclidean2D(Euclidean2DGeometry::Collection(Collection2D::new([])));
-    assert!(dissolve(&Geometry::None, 0.0).unwrap().is_empty());
-    assert!(dissolve(&empty, 0.0).unwrap().is_empty());
-    assert!(dissolve(&empty, 0.5).unwrap().is_empty());
+    assert!(dissolve_leaves(&[], 0.0).unwrap().is_empty());
+    assert!(dissolve_leaves(&[], 0.5).unwrap().is_empty());
+    assert!(dissolve_all(&[collection([])], 0.0).unwrap().is_empty());
 }
 
 #[test]
@@ -800,24 +822,25 @@ fn dissolve_refuses_mixed_frames_and_non_areal_members() {
             Vec::<Vec<[f64; 2]>>::new(),
         ),
     )));
-    let mixed_frames = collection([polygon(&rect(0.0, 0.0, 1.0, 1.0), &[]), in_crs]);
     assert_eq!(
-        dissolve(&mixed_frames, 0.0),
+        dissolve_all(&[polygon(&rect(0.0, 0.0, 1.0, 1.0), &[]), in_crs], 0.0),
         Err(PredicateError::MixedFrames)
     );
 
-    let with_a_line = collection([
-        polygon(&rect(0.0, 0.0, 2.0, 2.0), &[]),
-        line(&[[0.0, 0.0], [2.0, 2.0]]),
-    ]);
     assert_eq!(
-        dissolve(&with_a_line, 0.0),
+        dissolve_all(
+            &[
+                polygon(&rect(0.0, 0.0, 2.0, 2.0), &[]),
+                line(&[[0.0, 0.0], [2.0, 2.0]]),
+            ],
+            0.0
+        ),
         Err(PredicateError::Unsupported {
             geometry: "LineString2D"
         })
     );
     assert_eq!(
-        dissolve(&point([0.0, 0.0]), 0.0),
+        dissolve_all(&[point([0.0, 0.0])], 0.0),
         Err(PredicateError::Unsupported {
             geometry: "Point2D"
         })
@@ -827,17 +850,17 @@ fn dissolve_refuses_mixed_frames_and_non_areal_members() {
 #[test]
 fn the_tolerance_merges_boundaries_that_nearly_coincide() {
     // Neighbours meant to share the edge x = 2, one digitized 0.001 off.
-    let nearly_adjacent = collection([
+    let nearly_adjacent = [
         polygon(&rect(0.0, 0.0, 2.0, 2.0), &[]),
-        nudged_square([2.0, 0.0], 0.001),
-    ]);
+        polygon(&rect(2.001, 0.001, 4.001, 2.001), &[]),
+    ];
 
     // Without a tolerance the sliver gap survives as a second face.
-    let untouched = dissolve(&nearly_adjacent, 0.0).unwrap();
+    let untouched = dissolve_all(&nearly_adjacent, 0.0).unwrap();
     assert_eq!(untouched.len(), 2);
 
     // With one, the near-coincident vertices snap together and the pair merges.
-    let dissolved = dissolve(&nearly_adjacent, 0.01).unwrap();
+    let dissolved = dissolve_all(&nearly_adjacent, 0.01).unwrap();
     assert_eq!(dissolved.len(), 1);
 }
 
@@ -847,23 +870,13 @@ fn the_tolerance_leaves_a_gap_with_no_facing_vertices_open() {
     // two long parallel edges stays open even though it is narrower than the
     // tolerance. The upper slab is inset in x so that no corner of one is
     // within the tolerance of a corner of the other.
-    let across_a_corridor = collection([
-        polygon(&rect(0.0, 0.0, 100.0, 2.0), &[]),
-        polygon(&rect(20.0, 2.5, 80.0, 4.0), &[]),
-    ]);
-    let dissolved = dissolve(&across_a_corridor, 1.0).unwrap();
+    let dissolved = dissolve_all(
+        &[
+            polygon(&rect(0.0, 0.0, 100.0, 2.0), &[]),
+            polygon(&rect(20.0, 2.5, 80.0, 4.0), &[]),
+        ],
+        1.0,
+    )
+    .unwrap();
     assert_eq!(dissolved.len(), 2);
-}
-
-#[test]
-fn dissolve_refuses_a_three_dimensional_operand() {
-    let solid = Geometry::Euclidean3D(crate::Euclidean3DGeometry::LineString(
-        crate::line_string::LineString3D::from_coords(e(), [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]),
-    ));
-    assert_eq!(
-        dissolve(&solid, 0.0),
-        Err(PredicateError::Unsupported {
-            geometry: "LineString3D"
-        })
-    );
 }

--- a/engine/runtime/geometry/src/predicates/mod.rs
+++ b/engine/runtime/geometry/src/predicates/mod.rs
@@ -180,20 +180,6 @@ pub(crate) fn flatten_2d_pair<'a>(
     }
 }
 
-/// Flatten the single operand of a **2D-only** unary operation (the dissolve)
-/// into its 2D leaves under the same dimension policy: a purely 3D operand is
-/// [`Unsupported`](PredicateError::Unsupported) and one mixing 2D and 3D
-/// members is [`CrossDimension`](PredicateError::CrossDimension).
-/// `Geometry::None` and empty collections flatten to no leaves.
-pub(crate) fn flatten_2d_single(geometry: &Geometry) -> Result<Vec<Leaf2D<'_>>> {
-    let (leaves, three_d) = contains::flatten_geometry(geometry);
-    match three_d {
-        None => Ok(leaves),
-        Some(geometry) if leaves.is_empty() => Err(PredicateError::Unsupported { geometry }),
-        Some(_) => Err(PredicateError::CrossDimension),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/predicates/mod.rs
+++ b/engine/runtime/geometry/src/predicates/mod.rs
@@ -180,6 +180,20 @@ pub(crate) fn flatten_2d_pair<'a>(
     }
 }
 
+/// Flatten the single operand of a **2D-only** unary operation (the dissolve)
+/// into its 2D leaves under the same dimension policy: a purely 3D operand is
+/// [`Unsupported`](PredicateError::Unsupported) and one mixing 2D and 3D
+/// members is [`CrossDimension`](PredicateError::CrossDimension).
+/// `Geometry::None` and empty collections flatten to no leaves.
+pub(crate) fn flatten_2d_single(geometry: &Geometry) -> Result<Vec<Leaf2D<'_>>> {
+    let (leaves, three_d) = contains::flatten_geometry(geometry);
+    match three_d {
+        None => Ok(leaves),
+        Some(geometry) if leaves.is_empty() => Err(PredicateError::Unsupported { geometry }),
+        Some(_) => Err(PredicateError::CrossDimension),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/predicates/view.rs
+++ b/engine/runtime/geometry/src/predicates/view.rs
@@ -338,6 +338,17 @@ impl<'a> AreaView<'a> {
     pub fn edges(&self) -> impl Iterator<Item = ([f64; 2], [f64; 2])> + '_ {
         self.faces().flat_map(FaceView::edges)
     }
+
+    /// The unsigned planar area the view covers: the shoelace sum over every
+    /// boundary edge, so wound-CW holes subtract themselves and a mesh's
+    /// non-overlapping faces add up. Elevation does not contribute.
+    pub fn area(&self) -> f64 {
+        let doubled: f64 = self
+            .edges()
+            .map(|(a, b)| a[0] * b[1] - b[0] * a[1])
+            .sum::<f64>();
+        (doubled / 2.0).abs()
+    }
 }
 
 // --- flattened leaf normal form ----------------------------------------------
@@ -373,6 +384,11 @@ impl<'a> Leaf2D<'a> {
             Leaf2D::PolygonMesh(m) => Some(AreaView::from_polygon_mesh(m)),
             Leaf2D::TriangularMesh(m) => Some(AreaView::from_triangular_mesh(m)),
         }
+    }
+
+    /// The unsigned planar area the leaf covers; zero for a point or a line.
+    pub fn area(&self) -> f64 {
+        self.area_view().map_or(0.0, |area| area.area())
     }
 
     /// The leaf's bounding box, `None` for an empty leaf.

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -3285,7 +3285,7 @@
               },
               {
                 "title": "Use Attributes From One Feature",
-                "description": "The output inherits the attributes of one representative feature (the last feature in the group)",
+                "description": "The output inherits the attributes of one representative feature of the group",
                 "type": "string",
                 "enum": [
                   "useOneFeature"

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.114"
+version = "0.2.115"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.304"
+version = "0.1.305"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
# Overview

Makes `Dissolver` work under the new geometry world.

## What I've done

- Accept 2D areal geometry (polygons and meshes) in a single coordinate frame; send non-areal, elevated, 3D, and out-of-frame features to `rejected`, as FME's `Dissolver` rejects invalid area geometry.
- `tolerance` snaps near-coincident vertices together before the merge, following FME's tolerance and the legacy `glue_vertices_closer_than` step.
- `useOneFeature` takes attributes from the group's largest member, which is FME's specification; `groupBy`, `dropAttributes`, and `mergeAttributes` keep the existing semantics.
- Fix the invalid `attributeAccumulationMode: useOne` parameter in the plateau4 `02-tran-rwy-trk-squr-wwy` workflows.

## What I haven't done

- FME's remnants and shared-edge outputs, attribute statistics, list generation, and `Connect Z Mode` remain unimplemented, as before.
- Snapping is vertex to vertex, so a gap between two edges with no vertices facing each other stays open.

## How I tested

Unit tests for the dissolve operation and for the processor, the latter under both the default and the `new-geometry` feature.

## Which point I want you to review particularly

- A frame mismatch within a group rejects the feature and warns once, rather than failing the node.
- Legacy behavior is deliberately untouched: it still takes `useOneFeature` attributes from the last member.

## Memo

`Dissolver` is used only in plateau4 `02-tran-rwy-trk-squr-wwy` and quality-check `03-tran`. The misspelled parameter was silently ignored and fell back to the same default, so fixing it changes nothing for the legacy world. Output is a single `Polygon` when the group dissolves to one face and a collection otherwise, where the legacy world always emitted a `MultiPolygon`.