### PR TITLE
feat(engine): boundary extractor in new geometry

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.119"
+version = "0.2.120"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "Inflector",
  "approx",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5012,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "bytes",
  "clap",
@@ -5065,7 +5065,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5108,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-diagnostics"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5121,7 +5121,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5149,7 +5149,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5179,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "approx",
  "bvh",
@@ -5220,7 +5220,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5264,7 +5264,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5333,7 +5333,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5350,7 +5350,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5364,7 +5364,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "bytes",
  "futures",
@@ -5381,7 +5381,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "bytes",
  "futures",
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5414,7 +5414,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "ahash",
  "bytes",
@@ -5488,7 +5488,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.496"
+version = "0.0.497"
 dependencies = [
  "async-trait",
  "axum",
@@ -8256,7 +8256,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.309"
+version = "0.1.310"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.496"
+version = "0.0.497"
 
 [profile.dev]
 opt-level = 0

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -1042,7 +1042,7 @@ Replaces a geometry with its boundary: the endpoints of a curve, the boundary ri
 ### Input Ports
 * features
 ### Output Ports
-* features
+* boundary
 * no-boundary
 * rejected
 ### Category

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -1036,32 +1036,15 @@ Moves values between nested map/list attribute paths, following a table of sourc
 ### Type
 * processor
 ### Description
-Extracts the boundary of geometries. For solids/meshes returns bounding surfaces, for surfaces returns boundary edges, for closed surfaces returns empty geometry
+Replaces a geometry with its boundary: the endpoints of a curve, the boundary rings of a surface, and the bounding shells of a volume.
 ### Parameters
-```json
-{
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Boundary Extractor Parameters",
-  "description": "Configuration for extracting boundaries from geometries.",
-  "type": "object",
-  "properties": {
-    "keepEmptyBoundaries": {
-      "description": "Whether to keep features with empty boundaries (default: false)",
-      "default": false,
-      "type": "boolean"
-    },
-    "exteriorOnly": {
-      "description": "Whether to extract only exterior boundaries (ignoring holes) for polygons (default: false)",
-      "default": false,
-      "type": "boolean"
-    }
-  }
-}
-```
+* No parameters
 ### Input Ports
 * features
 ### Output Ports
 * features
+* no-boundary
+* rejected
 ### Category
 * Geometry
 

--- a/engine/runtime/action-processor/src/geometry/boundary_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/boundary_extractor.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 #[cfg(not(feature = "new-geometry"))]
 use std::sync::Arc;
 
-#[cfg(feature = "new-geometry")]
 use once_cell::sync::Lazy;
 #[cfg(feature = "new-geometry")]
 use reearth_flow_geometry::ops::ExtractBoundary;
@@ -35,6 +34,8 @@ use serde_json::Value;
 
 use super::errors::GeometryProcessorError;
 
+/// The boundary itself.
+pub static BOUNDARY_PORT: Lazy<Port> = Lazy::new(|| Port::new("boundary"));
 /// Geometry that closes on itself, or carries no extent to bound, leaves here
 /// with the geometry it arrived with.
 #[cfg(feature = "new-geometry")]
@@ -80,7 +81,7 @@ impl ProcessorFactory for BoundaryExtractorFactory {
     #[cfg(feature = "new-geometry")]
     fn get_output_ports(&self) -> Vec<Port> {
         vec![
-            FEATURES_PORT.clone(),
+            BOUNDARY_PORT.clone(),
             NO_BOUNDARY_PORT.clone(),
             REJECTED_PORT.clone(),
         ]
@@ -88,7 +89,7 @@ impl ProcessorFactory for BoundaryExtractorFactory {
 
     #[cfg(not(feature = "new-geometry"))]
     fn get_output_ports(&self) -> Vec<Port> {
-        vec![FEATURES_PORT.clone()]
+        vec![BOUNDARY_PORT.clone()]
     }
 
     fn build(
@@ -190,7 +191,7 @@ impl Processor for BoundaryExtractor {
             Ok(boundary) => {
                 let mut feature = ctx.feature.clone();
                 feature.set_geometry(boundary);
-                fw.send(ctx.new_with_feature_and_port(feature, FEATURES_PORT.clone()));
+                fw.send(ctx.new_with_feature_and_port(feature, BOUNDARY_PORT.clone()));
             }
             Err(e) => {
                 // This port's normal business, so not worth a warning per feature.
@@ -215,7 +216,7 @@ impl Processor for BoundaryExtractor {
 
         if geometry.is_empty() {
             if self.params.keep_empty_boundaries {
-                fw.send(ctx.new_with_feature_and_port(ctx.feature.clone(), FEATURES_PORT.clone()));
+                fw.send(ctx.new_with_feature_and_port(ctx.feature.clone(), BOUNDARY_PORT.clone()));
             }
             return Ok(());
         }
@@ -252,11 +253,11 @@ impl Processor for BoundaryExtractor {
         if let Some(new_geo) = new_geometry {
             let mut new_feature = feature.clone();
             new_feature.geometry = new_geo;
-            fw.send(ctx.new_with_feature_and_port(new_feature, FEATURES_PORT.clone()));
+            fw.send(ctx.new_with_feature_and_port(new_feature, BOUNDARY_PORT.clone()));
         } else if self.params.keep_empty_boundaries {
             let mut new_feature = feature.clone();
             new_feature.geometry = Arc::new(Geometry::default());
-            fw.send(ctx.new_with_feature_and_port(new_feature, FEATURES_PORT.clone()));
+            fw.send(ctx.new_with_feature_and_port(new_feature, BOUNDARY_PORT.clone()));
         }
 
         Ok(())
@@ -791,7 +792,7 @@ mod tests {
         let input = feature(area());
         let sent = extract(&input);
 
-        assert_eq!(ports(&sent), ["features"]);
+        assert_eq!(ports(&sent), ["boundary"]);
         let NextGeometry::Euclidean3D(Euclidean3DGeometry::LineString(ring)) = &*sent[0].1.geometry
         else {
             panic!("expected one ring, got {:?}", sent[0].1.geometry);

--- a/engine/runtime/action-processor/src/geometry/boundary_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/boundary_extractor.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use once_cell::sync::Lazy;
 #[cfg(feature = "new-geometry")]
-use reearth_flow_geometry::ops::ExtractBoundary;
+use reearth_flow_geometry::ops::{Boundary, ExtractBoundary};
 #[cfg(not(feature = "new-geometry"))]
 use reearth_flow_geometry::types::geometry::Geometry2D;
 #[cfg(not(feature = "new-geometry"))]
@@ -15,8 +15,6 @@ use reearth_flow_geometry::types::line_string::{LineString2D, LineString3D};
 use reearth_flow_geometry::types::multi_line_string::{MultiLineString2D, MultiLineString3D};
 #[cfg(not(feature = "new-geometry"))]
 use reearth_flow_geometry::types::triangular_mesh::TriangularMesh;
-#[cfg(feature = "new-geometry")]
-use reearth_flow_geometry::Geometry as NextGeometry;
 #[cfg(feature = "new-geometry")]
 use reearth_flow_runtime::node::REJECTED_PORT;
 use reearth_flow_runtime::{
@@ -37,7 +35,8 @@ use super::errors::GeometryProcessorError;
 /// The boundary itself.
 pub static BOUNDARY_PORT: Lazy<Port> = Lazy::new(|| Port::new("boundary"));
 /// Geometry that closes on itself, or carries no extent to bound, leaves here
-/// with the geometry it arrived with.
+/// with the geometry it arrived with, minus any part that had no boundary to
+/// give.
 #[cfg(feature = "new-geometry")]
 pub static NO_BOUNDARY_PORT: Lazy<Port> = Lazy::new(|| Port::new("no-boundary"));
 
@@ -174,6 +173,10 @@ impl Processor for BoundaryExtractor {
     /// arrived with, so a workflow can tell "closed" from "not a surface". A
     /// feature with no geometry, or one whose type has no boundary to give,
     /// leaves via `rejected`.
+    ///
+    /// A container is bounded member by member, and a member with no boundary to
+    /// give drops out of it, from the boundary and from the geometry `no-boundary`
+    /// carries alike: an empty boundary is a claim about parts that were bounded.
     #[cfg(feature = "new-geometry")]
     fn process(
         &mut self,
@@ -181,17 +184,19 @@ impl Processor for BoundaryExtractor {
         fw: &ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
         match ctx.feature.geometry.extract_boundary() {
-            // An answer, not a failure, so the feature goes on with the geometry
-            // it came in with.
-            Ok(NextGeometry::None) => {
-                fw.send(
-                    ctx.new_with_feature_and_port(ctx.feature.clone(), NO_BOUNDARY_PORT.clone()),
-                );
-            }
-            Ok(boundary) => {
+            Ok(Boundary::Bounded(boundary)) => {
                 let mut feature = ctx.feature.clone();
                 feature.set_geometry(boundary);
                 fw.send(ctx.new_with_feature_and_port(feature, BOUNDARY_PORT.clone()));
+            }
+            // An answer, not a failure, so the feature goes on with the geometry
+            // it came in with, narrowed only where a part of it was not bounded.
+            Ok(Boundary::Empty { evaluated }) => {
+                let mut feature = ctx.feature.clone();
+                if let Some(evaluated) = evaluated {
+                    feature.set_geometry(evaluated);
+                }
+                fw.send(ctx.new_with_feature_and_port(feature, NO_BOUNDARY_PORT.clone()));
             }
             Err(e) => {
                 // This port's normal business, so not worth a warning per feature.
@@ -709,6 +714,7 @@ mod tests {
     use reearth_flow_geometry::solid::Solid;
     use reearth_flow_geometry::triangular_mesh::TriangularMesh3D;
     use reearth_flow_geometry::Euclidean3DGeometry;
+    use reearth_flow_geometry::Geometry as NextGeometry;
     use reearth_flow_runtime::forwarder::NoopChannelForwarder;
     use reearth_flow_types::{Attribute, AttributeValue, Feature};
 

--- a/engine/runtime/action-processor/src/geometry/boundary_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/boundary_extractor.rs
@@ -1,24 +1,32 @@
 use std::collections::HashMap;
-use std::sync::Arc;
 
+use once_cell::sync::Lazy;
+#[cfg(not(feature = "new-geometry"))]
 use reearth_flow_geometry::types::geometry::Geometry2D;
+#[cfg(not(feature = "new-geometry"))]
 use reearth_flow_geometry::types::geometry::Geometry3D;
+#[cfg(not(feature = "new-geometry"))]
 use reearth_flow_geometry::types::line_string::{LineString2D, LineString3D};
+#[cfg(not(feature = "new-geometry"))]
 use reearth_flow_geometry::types::multi_line_string::{MultiLineString2D, MultiLineString3D};
+#[cfg(not(feature = "new-geometry"))]
 use reearth_flow_geometry::types::triangular_mesh::TriangularMesh;
+#[cfg(feature = "new-geometry")]
+use reearth_flow_geometry::{ops::ExtractBoundary, Geometry};
 use reearth_flow_runtime::{
     errors::BoxedError,
     event::EventHub,
     executor_operation::{ExecutorContext, NodeContext},
     forwarder::ProcessorChannelForwarder,
-    node::{Port, Processor, ProcessorFactory, FEATURES_PORT},
+    node::{Port, Processor, ProcessorFactory, FEATURES_PORT, REJECTED_PORT},
 };
-use reearth_flow_types::{Geometry, GeometryValue};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+#[cfg(not(feature = "new-geometry"))]
+use reearth_flow_types::GeometryValue;
 use serde_json::Value;
 
-use super::errors::GeometryProcessorError;
+/// Geometry that closes on itself, or carries no extent to bound, leaves here
+/// with the geometry it arrived with.
+pub static NO_BOUNDARY_PORT: Lazy<Port> = Lazy::new(|| Port::new("no-boundary"));
 
 #[derive(Debug, Clone, Default)]
 pub(super) struct BoundaryExtractorFactory;
@@ -29,15 +37,19 @@ impl ProcessorFactory for BoundaryExtractorFactory {
     }
 
     fn description(&self) -> &str {
-        "Extracts the boundary of geometries. For solids/meshes returns bounding surfaces, for surfaces returns boundary edges, for closed surfaces returns empty geometry"
+        "Replaces a geometry with its boundary: the endpoints of a curve, the boundary rings of a surface, and the bounding shells of a volume."
     }
 
     fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
-        Some(schemars::schema_for!(BoundaryExtractorParams))
+        None
     }
 
     fn categories(&self) -> &[&'static str] {
         &["Geometry"]
+    }
+
+    fn tags(&self) -> &[&'static str] {
+        &["3d", "spatial"]
     }
 
     fn get_input_ports(&self) -> Vec<Port> {
@@ -45,7 +57,11 @@ impl ProcessorFactory for BoundaryExtractorFactory {
     }
 
     fn get_output_ports(&self) -> Vec<Port> {
-        vec![FEATURES_PORT.clone()]
+        vec![
+            FEATURES_PORT.clone(),
+            NO_BOUNDARY_PORT.clone(),
+            REJECTED_PORT.clone(),
+        ]
     }
 
     fn build(
@@ -53,74 +69,55 @@ impl ProcessorFactory for BoundaryExtractorFactory {
         _ctx: NodeContext,
         _event_hub: EventHub,
         _action: String,
-        with: Option<HashMap<String, Value>>,
+        _with: Option<HashMap<String, Value>>,
     ) -> Result<Box<dyn Processor>, BoxedError> {
-        let params: BoundaryExtractorParams = if let Some(with) = with {
-            let value: Value = serde_json::to_value(with).map_err(|e| {
-                GeometryProcessorError::BoundaryExtractorFactory(format!(
-                    "Failed to serialize 'with' parameter: {e}"
-                ))
-            })?;
-            serde_json::from_value(value).map_err(|e| {
-                GeometryProcessorError::BoundaryExtractorFactory(format!(
-                    "Failed to deserialize 'with' parameter: {e}"
-                ))
-            })?
-        } else {
-            BoundaryExtractorParams::default()
-        };
-        Ok(Box::new(BoundaryExtractor { params }))
+        Ok(Box::new(BoundaryExtractor))
     }
 }
 
-// AUDIT NOTE (left by the Geometry A batch, 2026-07-30). This action has not been
-// audited yet. The observations below came from reading this file while deciding
-// something else, so treat them as leads to CHECK, not conclusions to apply —
-// verify each against the code and the standard before acting, and disagree freely
-// if the reading is wrong.
-//
-// 1. Suspected silent data loss. When `keepEmptyBoundaries` is false — the default —
-//    a feature whose boundary cannot be extracted appears to be dropped entirely:
-//    no port receives it and there is no `rejected` port. CityGML geometry looks
-//    worst affected, since the match arm for it extracts nothing at all, so every
-//    CityGML feature may vanish by default. Confirm by tracing each `None` branch
-//    in `process`. If it holds, §4.3 wants a `rejected` port.
-// 2. If `rejected` is added, re-examine whether `keepEmptyBoundaries` should exist
-//    at all. It reads as a routing decision expressed as a parameter, which ports
-//    already express; §3.5 would call that implementation leakage. Check whether any
-//    workflow relies on it before removing.
-// 3. `exteriorOnly` looks like a genuine semantic choice worth keeping, but it is
-//    negatively framed. Consider inverting it to `includeHoles` (default true).
-// 4. The description is three sentences, has no terminating period, and leaks
-//    implementation detail — see §2.
-//
-// Cross-check before consolidating this with any other action: its shape is one
-// feature in, one feature out with the geometry replaced. Geometry Part Extractor
-// and Hole Extractor instead emit one feature per part. Ports are declared
-// statically by the factory and cannot vary by parameter, so merging actions of
-// different shapes forces dead ports onto the node.
-
-/// # Boundary Extractor Parameters
-///
-/// Configuration for extracting boundaries from geometries.
-#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct BoundaryExtractorParams {
-    /// Whether to keep features with empty boundaries (default: false)
-    #[serde(default)]
-    keep_empty_boundaries: bool,
-
-    /// Whether to extract only exterior boundaries (ignoring holes) for polygons (default: false)
-    #[serde(default)]
-    exterior_only: bool,
-}
-
 #[derive(Debug, Clone)]
-struct BoundaryExtractor {
-    params: BoundaryExtractorParams,
-}
+struct BoundaryExtractor;
 
 impl Processor for BoundaryExtractor {
+    /// Replace the geometry with what bounds it, one dimension down: a volume
+    /// with its shells, a surface with the rings around it, a curve with its two
+    /// ends.
+    ///
+    /// Geometry bounded by nothing leaves via `no-boundary` with the geometry it
+    /// arrived with, so a workflow can tell "closed" from "not a surface". A
+    /// feature with no geometry, or one whose type has no boundary to give,
+    /// leaves via `rejected`.
+    #[cfg(feature = "new-geometry")]
+    fn process(
+        &mut self,
+        ctx: ExecutorContext,
+        fw: &ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        match ctx.feature.geometry.extract_boundary() {
+            // An answer, not a failure, so the feature goes on with the
+            // geometry it came in with.
+            Ok(Geometry::None) => {
+                fw.send(
+                    ctx.new_with_feature_and_port(ctx.feature.clone(), NO_BOUNDARY_PORT.clone()),
+                );
+            }
+            Ok(boundary) => {
+                let mut feature = ctx.feature.clone();
+                feature.set_geometry(boundary);
+                fw.send(ctx.new_with_feature_and_port(feature, FEATURES_PORT.clone()));
+            }
+            Err(e) => {
+                // This port's normal business, so not worth a warning per feature.
+                ctx.event_hub.debug_log(
+                    Some(ctx.error_span()),
+                    format!("boundary extraction rejected: {e}"),
+                );
+                fw.send(ctx.new_with_feature_and_port(ctx.feature.clone(), REJECTED_PORT.clone()));
+            }
+        }
+        Ok(())
+    }
+
     #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
@@ -131,55 +128,39 @@ impl Processor for BoundaryExtractor {
         let geometry = &feature.geometry;
 
         if geometry.is_empty() {
-            if self.params.keep_empty_boundaries {
-                fw.send(ctx.new_with_feature_and_port(ctx.feature.clone(), FEATURES_PORT.clone()));
-            }
+            fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
             return Ok(());
         }
 
-        let new_geometry = match &geometry.value {
-            GeometryValue::None => {
-                if self.params.keep_empty_boundaries {
-                    Some(geometry.clone())
-                } else {
-                    None
-                }
+        let boundary = match &geometry.value {
+            GeometryValue::FlowGeometry2D(geo) => {
+                extract_2d_boundary(geo).map(GeometryValue::FlowGeometry2D)
             }
-            GeometryValue::FlowGeometry2D(geo) => self.extract_2d_boundary(geo).map(|g| {
-                let mut new_geo = (**geometry).clone();
-                new_geo.value = GeometryValue::FlowGeometry2D(g);
-                Arc::new(new_geo)
-            }),
-            GeometryValue::FlowGeometry3D(geo) => self.extract_3d_boundary(geo).map(|g| {
-                let mut new_geo = (**geometry).clone();
-                new_geo.value = GeometryValue::FlowGeometry3D(g);
-                Arc::new(new_geo)
-            }),
-            GeometryValue::CityGmlGeometry(_) => {
-                // For CityGML geometries, we don't extract boundaries directly
-                // They should be converted to regular geometries first
-                if self.params.keep_empty_boundaries {
-                    Some(geometry.clone())
-                } else {
-                    None
-                }
+            GeometryValue::FlowGeometry3D(geo) => {
+                extract_3d_boundary(geo).map(GeometryValue::FlowGeometry3D)
             }
+            // CityGML geometry has to be converted to a plain geometry first.
+            GeometryValue::None | GeometryValue::CityGmlGeometry(_) => LegacyBoundary::None,
         };
 
-        if let Some(new_geo) = new_geometry {
-            let mut new_feature = feature.clone();
-            new_feature.geometry = new_geo;
-            fw.send(ctx.new_with_feature_and_port(new_feature, FEATURES_PORT.clone()));
-        } else if self.params.keep_empty_boundaries {
-            let mut new_feature = feature.clone();
-            new_feature.geometry = Arc::new(Geometry::default());
-            fw.send(ctx.new_with_feature_and_port(new_feature, FEATURES_PORT.clone()));
+        match boundary {
+            LegacyBoundary::Boundary(value) => {
+                let mut new_geometry = (**geometry).clone();
+                new_geometry.value = value;
+                let mut new_feature = feature.clone();
+                new_feature.geometry = std::sync::Arc::new(new_geometry);
+                fw.send(ctx.new_with_feature_and_port(new_feature, FEATURES_PORT.clone()));
+            }
+            LegacyBoundary::Empty => {
+                fw.send(ctx.new_with_feature_and_port(feature.clone(), NO_BOUNDARY_PORT.clone()));
+            }
+            LegacyBoundary::None => {
+                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+            }
         }
-
         Ok(())
     }
 
-    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,
@@ -197,335 +178,295 @@ impl Processor for BoundaryExtractor {
     }
 }
 
-impl BoundaryExtractor {
-    fn extract_2d_boundary(&self, geo: &Geometry2D) -> Option<Geometry2D> {
-        match geo {
-            // Point has no boundary
-            Geometry2D::Point(_) => None,
+/// What a geometry turned out to be bounded by, so the three cases the ports
+/// distinguish cannot be collapsed into one another.
+#[cfg(not(feature = "new-geometry"))]
+enum LegacyBoundary<T> {
+    /// The geometry it is bounded by.
+    Boundary(T),
+    /// Bounded by nothing: it closes on itself, or has no extent to bound.
+    Empty,
+    /// A type with no boundary to give.
+    None,
+}
 
-            // Line boundary is its endpoints
-            Geometry2D::Line(line) => {
-                let points = vec![
-                    Geometry2D::Point(line.start_point()),
-                    Geometry2D::Point(line.end_point()),
-                ];
-                Some(Geometry2D::GeometryCollection(points))
+#[cfg(not(feature = "new-geometry"))]
+impl<T> LegacyBoundary<T> {
+    fn map<U>(self, f: impl FnOnce(T) -> U) -> LegacyBoundary<U> {
+        match self {
+            LegacyBoundary::Boundary(t) => LegacyBoundary::Boundary(f(t)),
+            LegacyBoundary::Empty => LegacyBoundary::Empty,
+            LegacyBoundary::None => LegacyBoundary::None,
+        }
+    }
+}
+
+/// The rings of every face, exterior then holes, as one geometry.
+#[cfg(not(feature = "new-geometry"))]
+fn rings_2d(rings: Vec<LineString2D<f64>>) -> LegacyBoundary<Geometry2D<f64>> {
+    match rings.len() {
+        0 => LegacyBoundary::Empty,
+        1 => LegacyBoundary::Boundary(Geometry2D::LineString(rings.into_iter().next().unwrap())),
+        _ => LegacyBoundary::Boundary(Geometry2D::MultiLineString(MultiLineString2D::new(rings))),
+    }
+}
+
+#[cfg(not(feature = "new-geometry"))]
+fn rings_3d(rings: Vec<LineString3D<f64>>) -> LegacyBoundary<Geometry3D<f64>> {
+    match rings.len() {
+        0 => LegacyBoundary::Empty,
+        1 => LegacyBoundary::Boundary(Geometry3D::LineString(rings.into_iter().next().unwrap())),
+        _ => LegacyBoundary::Boundary(Geometry3D::MultiLineString(MultiLineString3D::new(rings))),
+    }
+}
+
+#[cfg(not(feature = "new-geometry"))]
+fn extract_2d_boundary(geo: &Geometry2D<f64>) -> LegacyBoundary<Geometry2D<f64>> {
+    match geo {
+        // Positions have no extent, so nothing bounds them.
+        Geometry2D::Point(_) | Geometry2D::MultiPoint(_) => LegacyBoundary::Empty,
+
+        Geometry2D::Line(line) => LegacyBoundary::Boundary(Geometry2D::GeometryCollection(vec![
+            Geometry2D::Point(line.start_point()),
+            Geometry2D::Point(line.end_point()),
+        ])),
+
+        // A chain is bounded by its two ends; one that closes has none.
+        Geometry2D::LineString(ls) => match chain_ends_2d(ls) {
+            Some(points) => LegacyBoundary::Boundary(Geometry2D::GeometryCollection(points)),
+            None => LegacyBoundary::Empty,
+        },
+
+        Geometry2D::Polygon(polygon) => rings_2d(polygon.rings().to_vec()),
+
+        Geometry2D::MultiLineString(mls) => {
+            let ends: Vec<_> = mls.iter().filter_map(chain_ends_2d).flatten().collect();
+            if ends.is_empty() {
+                LegacyBoundary::Empty
+            } else {
+                LegacyBoundary::Boundary(Geometry2D::GeometryCollection(ends))
             }
+        }
 
-            // LineString boundary is its endpoints if not closed
-            Geometry2D::LineString(ls) => {
-                if ls.is_closed() {
-                    None // Closed curve has no boundary
-                } else {
-                    let coords: Vec<_> = ls.coords().cloned().collect();
-                    if coords.len() >= 2 {
-                        let points = vec![
-                            Geometry2D::Point(coords[0].into()),
-                            Geometry2D::Point(coords[coords.len() - 1].into()),
-                        ];
-                        Some(Geometry2D::GeometryCollection(points))
-                    } else {
-                        None
+        Geometry2D::MultiPolygon(mp) => {
+            rings_2d(mp.iter().flat_map(|p| p.rings().to_vec()).collect())
+        }
+
+        Geometry2D::Rect(rect) => {
+            LegacyBoundary::Boundary(Geometry2D::LineString(rect.to_polygon().exterior().clone()))
+        }
+
+        Geometry2D::Triangle(triangle) => {
+            let c = triangle.to_array();
+            LegacyBoundary::Boundary(Geometry2D::LineString(LineString2D::from(vec![
+                c[0], c[1], c[2], c[0],
+            ])))
+        }
+
+        _ => LegacyBoundary::None,
+    }
+}
+
+#[cfg(not(feature = "new-geometry"))]
+fn extract_3d_boundary(geo: &Geometry3D<f64>) -> LegacyBoundary<Geometry3D<f64>> {
+    match geo {
+        Geometry3D::Point(_) | Geometry3D::MultiPoint(_) => LegacyBoundary::Empty,
+
+        Geometry3D::Line(line) => LegacyBoundary::Boundary(Geometry3D::GeometryCollection(vec![
+            Geometry3D::Point(line.start_point()),
+            Geometry3D::Point(line.end_point()),
+        ])),
+
+        Geometry3D::LineString(ls) => match chain_ends_3d(ls) {
+            Some(points) => LegacyBoundary::Boundary(Geometry3D::GeometryCollection(points)),
+            None => LegacyBoundary::Empty,
+        },
+
+        Geometry3D::Polygon(polygon) => rings_3d(polygon.rings().to_vec()),
+
+        Geometry3D::MultiLineString(mls) => {
+            let ends: Vec<_> = mls.iter().filter_map(chain_ends_3d).flatten().collect();
+            if ends.is_empty() {
+                LegacyBoundary::Empty
+            } else {
+                LegacyBoundary::Boundary(Geometry3D::GeometryCollection(ends))
+            }
+        }
+
+        Geometry3D::MultiPolygon(mp) => {
+            rings_3d(mp.iter().flat_map(|p| p.rings().to_vec()).collect())
+        }
+
+        Geometry3D::Rect(rect) => {
+            LegacyBoundary::Boundary(Geometry3D::MultiPolygon(rect.to_multi_polygon()))
+        }
+
+        Geometry3D::Triangle(triangle) => {
+            let c = triangle.to_array();
+            LegacyBoundary::Boundary(Geometry3D::LineString(LineString3D::from(vec![
+                c[0], c[1], c[2], c[0],
+            ])))
+        }
+
+        Geometry3D::TriangularMesh(mesh) => {
+            extract_mesh_boundary(mesh).map(Geometry3D::MultiLineString)
+        }
+
+        // A volume is bounded by its surface.
+        Geometry3D::Solid(solid) => match solid.clone().as_triangle_mesh(None) {
+            Ok(mesh) => LegacyBoundary::Boundary(Geometry3D::TriangularMesh(mesh)),
+            Err(_) => LegacyBoundary::None,
+        },
+
+        Geometry3D::GeometryCollection(collection) => {
+            let mut bounded = Vec::new();
+            let mut any = false;
+            for member in collection {
+                match extract_3d_boundary(member) {
+                    LegacyBoundary::Boundary(b) => {
+                        any = true;
+                        bounded.push(b);
                     }
+                    LegacyBoundary::Empty => any = true,
+                    LegacyBoundary::None => {}
                 }
             }
-
-            // Polygon boundary is its rings (exterior + holes)
-            Geometry2D::Polygon(polygon) => {
-                let rings = if self.params.exterior_only {
-                    vec![polygon.exterior().clone()]
-                } else {
-                    polygon.rings().to_vec()
-                };
-
-                if rings.is_empty() {
-                    None
-                } else if rings.len() == 1 {
-                    Some(Geometry2D::LineString(rings[0].clone()))
-                } else {
-                    Some(Geometry2D::MultiLineString(MultiLineString2D::new(rings)))
-                }
+            if !any && !collection.is_empty() {
+                LegacyBoundary::None
+            } else if bounded.is_empty() {
+                LegacyBoundary::Empty
+            } else if bounded.len() == 1 {
+                LegacyBoundary::Boundary(bounded.into_iter().next().unwrap())
+            } else {
+                LegacyBoundary::Boundary(Geometry3D::GeometryCollection(bounded))
             }
+        }
 
-            // MultiPoint has no boundary
-            Geometry2D::MultiPoint(_) => None,
+        _ => LegacyBoundary::None,
+    }
+}
 
-            // MultiLineString boundary is the set of endpoints of non-closed linestrings
-            Geometry2D::MultiLineString(mls) => {
-                let mut endpoints = Vec::new();
-                for ls in mls.iter() {
-                    if !ls.is_closed() {
-                        let coords: Vec<_> = ls.coords().cloned().collect();
-                        if coords.len() >= 2 {
-                            endpoints.push(Geometry2D::Point(coords[0].into()));
-                            endpoints.push(Geometry2D::Point(coords[coords.len() - 1].into()));
-                        }
-                    }
-                }
+/// The two ends of an open chain, as points. A chain that closes on itself, or
+/// that spans nothing, has no ends to give.
+#[cfg(not(feature = "new-geometry"))]
+fn chain_ends_2d(ls: &LineString2D<f64>) -> Option<Vec<Geometry2D<f64>>> {
+    let coords: Vec<_> = ls.coords().cloned().collect();
+    if ls.is_closed() || coords.len() < 2 {
+        return None;
+    }
+    Some(vec![
+        Geometry2D::Point(coords[0].into()),
+        Geometry2D::Point(coords[coords.len() - 1].into()),
+    ])
+}
 
-                if endpoints.is_empty() {
-                    None
-                } else {
-                    Some(Geometry2D::GeometryCollection(endpoints))
-                }
-            }
+#[cfg(not(feature = "new-geometry"))]
+fn chain_ends_3d(ls: &LineString3D<f64>) -> Option<Vec<Geometry3D<f64>>> {
+    let coords: Vec<_> = ls.coords().cloned().collect();
+    if ls.is_closed() || coords.len() < 2 {
+        return None;
+    }
+    Some(vec![
+        Geometry3D::Point(coords[0].into()),
+        Geometry3D::Point(coords[coords.len() - 1].into()),
+    ])
+}
 
-            // MultiPolygon boundary is the union of all polygon boundaries
-            Geometry2D::MultiPolygon(mp) => {
-                let mut all_rings = Vec::new();
-                for polygon in mp.iter() {
-                    if self.params.exterior_only {
-                        all_rings.push(polygon.exterior().clone());
-                    } else {
-                        all_rings.extend_from_slice(&polygon.rings());
-                    }
-                }
-
-                if all_rings.is_empty() {
-                    None
-                } else if all_rings.len() == 1 {
-                    Some(Geometry2D::LineString(all_rings[0].clone()))
-                } else {
-                    Some(Geometry2D::MultiLineString(MultiLineString2D::new(
-                        all_rings,
-                    )))
-                }
-            }
-
-            // Rectangle boundary is its perimeter
-            Geometry2D::Rect(rect) => {
-                let polygon = rect.to_polygon();
-                Some(Geometry2D::LineString(polygon.exterior().clone()))
-            }
-
-            // Triangle boundary is its perimeter
-            Geometry2D::Triangle(triangle) => {
-                let coords = triangle.to_array();
-                let ls = LineString2D::from(vec![
-                    coords[0], coords[1], coords[2], coords[0], // Close the triangle
-                ]);
-                Some(Geometry2D::LineString(ls))
-            }
-
-            // For other geometry types, return None
-            _ => None,
+/// The edges only one triangle walks, chained into rings.
+#[cfg(not(feature = "new-geometry"))]
+fn extract_mesh_boundary(
+    mesh: &TriangularMesh<f64, f64>,
+) -> LegacyBoundary<MultiLineString3D<f64>> {
+    let mut walks: HashMap<(usize, usize), usize> = HashMap::new();
+    for triangle in mesh.get_triangles() {
+        for edge in [
+            (triangle[0].min(triangle[1]), triangle[0].max(triangle[1])),
+            (triangle[1].min(triangle[2]), triangle[1].max(triangle[2])),
+            (triangle[0].min(triangle[2]), triangle[0].max(triangle[2])),
+        ] {
+            *walks.entry(edge).or_insert(0) += 1;
         }
     }
 
-    fn extract_3d_boundary(&self, geo: &Geometry3D) -> Option<Geometry3D> {
-        match geo {
-            // Point has no boundary
-            Geometry3D::Point(_) => None,
+    let mut edges = walks
+        .into_iter()
+        .filter_map(|(edge, count)| (count == 1).then_some(edge))
+        .collect::<Vec<_>>();
+    if edges.is_empty() {
+        return LegacyBoundary::Empty;
+    }
+    edges.sort_unstable();
 
-            // Line boundary is its endpoints
-            Geometry3D::Line(line) => {
-                let points = vec![
-                    Geometry3D::Point(line.start_point()),
-                    Geometry3D::Point(line.end_point()),
-                ];
-                Some(Geometry3D::GeometryCollection(points))
-            }
+    let edge_idx: HashMap<_, _> = edges
+        .iter()
+        .enumerate()
+        .map(|(idx, &edge)| (edge, idx))
+        .collect();
 
-            // LineString boundary is its endpoints if not closed
-            Geometry3D::LineString(ls) => {
-                if ls.is_closed() {
-                    None // Closed curve has no boundary
-                } else {
-                    let coords: Vec<_> = ls.coords().cloned().collect();
-                    if coords.len() >= 2 {
-                        let points = vec![
-                            Geometry3D::Point(coords[0].into()),
-                            Geometry3D::Point(coords[coords.len() - 1].into()),
-                        ];
-                        Some(Geometry3D::GeometryCollection(points))
-                    } else {
-                        None
-                    }
-                }
-            }
-
-            // Polygon boundary is its rings (exterior + holes)
-            Geometry3D::Polygon(polygon) => {
-                let rings = if self.params.exterior_only {
-                    vec![polygon.exterior().clone()]
-                } else {
-                    polygon.rings().to_vec()
-                };
-
-                if rings.is_empty() {
-                    None
-                } else if rings.len() == 1 {
-                    Some(Geometry3D::LineString(rings[0].clone()))
-                } else {
-                    Some(Geometry3D::MultiLineString(MultiLineString3D::new(rings)))
-                }
-            }
-
-            // MultiPoint has no boundary
-            Geometry3D::MultiPoint(_) => None,
-
-            // MultiLineString boundary is the set of endpoints of non-closed linestrings
-            Geometry3D::MultiLineString(mls) => {
-                let mut endpoints = Vec::new();
-                for ls in mls.iter() {
-                    if !ls.is_closed() {
-                        let coords: Vec<_> = ls.coords().cloned().collect();
-                        if coords.len() >= 2 {
-                            endpoints.push(Geometry3D::Point(coords[0].into()));
-                            endpoints.push(Geometry3D::Point(coords[coords.len() - 1].into()));
-                        }
-                    }
-                }
-
-                if endpoints.is_empty() {
-                    None
-                } else {
-                    Some(Geometry3D::GeometryCollection(endpoints))
-                }
-            }
-
-            // MultiPolygon boundary is the union of all polygon boundaries
-            Geometry3D::MultiPolygon(mp) => {
-                let mut all_rings = Vec::new();
-                for polygon in mp.iter() {
-                    if self.params.exterior_only {
-                        all_rings.push(polygon.exterior().clone());
-                    } else {
-                        all_rings.extend_from_slice(&polygon.rings());
-                    }
-                }
-
-                if all_rings.is_empty() {
-                    None
-                } else if all_rings.len() == 1 {
-                    Some(Geometry3D::LineString(all_rings[0].clone()))
-                } else {
-                    Some(Geometry3D::MultiLineString(MultiLineString3D::new(
-                        all_rings,
-                    )))
-                }
-            }
-
-            // Rectangle boundary is its perimeter
-            Geometry3D::Rect(rect) => Some(Geometry3D::MultiPolygon(rect.to_multi_polygon())),
-
-            // Triangle boundary is its perimeter
-            Geometry3D::Triangle(triangle) => {
-                let coords = triangle.to_array();
-                let ls = LineString3D::from(vec![
-                    coords[0], coords[1], coords[2], coords[0], // Close the triangle
-                ]);
-                Some(Geometry3D::LineString(ls))
-            }
-
-            // TriangularMesh boundary is the set of boundary edges
-            Geometry3D::TriangularMesh(mesh) => self
-                .extract_mesh_boundary(mesh)
-                .map(Geometry3D::MultiLineString),
-
-            // Solid boundary is the triangular mesh representing its surface
-            Geometry3D::Solid(solid) => {
-                // A solid's boundary is its surface mesh
-                // Try to convert to triangular mesh with default tolerance
-                match solid.clone().as_triangle_mesh(None) {
-                    Ok(mesh) => Some(Geometry3D::TriangularMesh(mesh)),
-                    Err(_) => {
-                        // If conversion fails, the solid might be represented as faces
-                        // In this case, we cannot easily extract the boundary
-                        None
-                    }
-                }
-            }
-
-            // GeometryCollection: extract boundaries of each geometry
-            Geometry3D::GeometryCollection(collection) => {
-                let mut boundaries = Vec::new();
-                for geom in collection {
-                    if let Some(boundary) = self.extract_3d_boundary(geom) {
-                        boundaries.push(boundary);
-                    }
-                }
-
-                if boundaries.is_empty() {
-                    None
-                } else if boundaries.len() == 1 {
-                    Some(boundaries.into_iter().next().unwrap())
-                } else {
-                    Some(Geometry3D::GeometryCollection(boundaries))
-                }
-            }
-
-            // For other geometry types like CSG, return None
-            _ => None,
-        }
+    let mut adjacency: Vec<Vec<usize>> = vec![Vec::new(); mesh.get_vertices().len()];
+    for (v1, v2) in &edges {
+        adjacency[*v1].push(*v2);
+        adjacency[*v2].push(*v1);
     }
 
-    fn extract_mesh_boundary(
-        &self,
-        mesh: &TriangularMesh<f64, f64>,
-    ) -> Option<MultiLineString3D<f64>> {
-        // Extract boundary edges from the triangular mesh
-        // Boundary edges are those that belong to only one triangle
-        let mut edge_count: HashMap<(usize, usize), usize> = HashMap::new();
-        let triangles = mesh.get_triangles();
+    let mut used_edges = vec![false; edges.len()];
+    let mut chains = Vec::new();
 
-        // Count how many triangles each edge belongs to
-        for triangle in triangles {
-            let edges = [
-                (triangle[0].min(triangle[1]), triangle[0].max(triangle[1])),
-                (triangle[1].min(triangle[2]), triangle[1].max(triangle[2])),
-                (triangle[0].min(triangle[2]), triangle[0].max(triangle[2])),
-            ];
+    for start_idx in 0..edges.len() {
+        if used_edges[start_idx] {
+            continue;
+        }
 
-            for edge in &edges {
-                *edge_count.entry(*edge).or_insert(0) += 1;
+        used_edges[start_idx] = true;
+
+        let start_v0 = edges[start_idx].0;
+        let start_v1 = edges[start_idx].1;
+
+        let mut chain = vec![mesh.get_vertices()[start_v0], mesh.get_vertices()[start_v1]];
+
+        let mut prev_vertex = start_v0;
+        let mut current_vertex = start_v1;
+
+        loop {
+            if adjacency[current_vertex].len() != 2 {
+                break;
             }
-        }
+            let next_vertex = *adjacency[current_vertex]
+                .iter()
+                .find(|&&v| v != prev_vertex)
+                .unwrap();
 
-        let mut edges = edge_count
-            .into_iter()
-            .filter_map(|(edge, count)| if count == 1 { Some(edge) } else { None })
-            .collect::<Vec<_>>();
-
-        if edges.is_empty() {
-            return None; // Closed surface has no boundary
-        }
-
-        edges.sort_unstable();
-        let edges = edges;
-
-        let edge_idx: HashMap<_, _> = edges
-            .iter()
-            .enumerate()
-            .map(|(idx, &edge)| (edge, idx))
-            .collect();
-
-        // Build adjacency map: vertex -> list of connected vertices
-        let mut adjacency: Vec<Vec<usize>> = vec![Vec::new(); mesh.get_vertices().len()];
-        for (v1, v2) in &edges {
-            adjacency[*v1].push(*v2);
-            adjacency[*v2].push(*v1);
-        }
-
-        // Chain boundary edges into connected linestrings
-        let mut used_edges = vec![false; edges.len()];
-        let mut chains = Vec::new();
-
-        for start_idx in 0..edges.len() {
-            if used_edges[start_idx] {
-                continue;
+            if next_vertex == start_v0 {
+                chain.push(mesh.get_vertices()[next_vertex]);
+                let idx = edge_idx
+                    .get(&(
+                        current_vertex.min(next_vertex),
+                        current_vertex.max(next_vertex),
+                    ))
+                    .unwrap();
+                used_edges[*idx] = true;
+                break;
             }
 
-            used_edges[start_idx] = true;
+            let idx = edge_idx
+                .get(&(
+                    current_vertex.min(next_vertex),
+                    current_vertex.max(next_vertex),
+                ))
+                .unwrap();
+            if used_edges[*idx] {
+                break;
+            }
+            used_edges[*idx] = true;
 
-            let start_v0 = edges[start_idx].0;
-            let start_v1 = edges[start_idx].1;
+            chain.push(mesh.get_vertices()[next_vertex]);
+            prev_vertex = current_vertex;
+            current_vertex = next_vertex;
+        }
 
-            let mut chain = vec![mesh.get_vertices()[start_v0], mesh.get_vertices()[start_v1]];
-
-            // Traverse forward from start_v1
-            let mut prev_vertex = start_v0;
-            let mut current_vertex = start_v1;
+        if chain.first() != chain.last() {
+            prev_vertex = start_v1;
+            current_vertex = start_v0;
 
             loop {
                 if adjacency[current_vertex].len() != 2 {
@@ -536,19 +477,6 @@ impl BoundaryExtractor {
                     .find(|&&v| v != prev_vertex)
                     .unwrap();
 
-                // Check if we've closed the loop
-                if next_vertex == start_v0 {
-                    chain.push(mesh.get_vertices()[next_vertex]);
-                    let idx = edge_idx
-                        .get(&(
-                            current_vertex.min(next_vertex),
-                            current_vertex.max(next_vertex),
-                        ))
-                        .unwrap();
-                    used_edges[*idx] = true;
-                    break;
-                }
-
                 let idx = edge_idx
                     .get(&(
                         current_vertex.min(next_vertex),
@@ -556,57 +484,178 @@ impl BoundaryExtractor {
                     ))
                     .unwrap();
                 if used_edges[*idx] {
-                    // Already visited this edge
                     break;
                 }
                 used_edges[*idx] = true;
 
-                chain.push(mesh.get_vertices()[next_vertex]);
+                chain.insert(0, mesh.get_vertices()[next_vertex]);
                 prev_vertex = current_vertex;
                 current_vertex = next_vertex;
             }
-
-            // Traverse backward from start_v0 only if we didn't close a loop
-            if chain.first() != chain.last() {
-                prev_vertex = start_v1;
-                current_vertex = start_v0;
-
-                loop {
-                    if adjacency[current_vertex].len() != 2 {
-                        break;
-                    }
-                    let next_vertex = *adjacency[current_vertex]
-                        .iter()
-                        .find(|&&v| v != prev_vertex)
-                        .unwrap();
-
-                    let idx = edge_idx
-                        .get(&(
-                            current_vertex.min(next_vertex),
-                            current_vertex.max(next_vertex),
-                        ))
-                        .unwrap();
-                    if used_edges[*idx] {
-                        break;
-                    }
-                    used_edges[*idx] = true;
-
-                    // Prepend to chain
-                    chain.insert(0, mesh.get_vertices()[next_vertex]);
-                    prev_vertex = current_vertex;
-                    current_vertex = next_vertex;
-                }
-            }
-
-            if chain.len() >= 2 {
-                chains.push(LineString3D::from(chain));
-            }
         }
 
-        if chains.is_empty() {
-            None
-        } else {
-            Some(MultiLineString3D::new(chains))
+        if chain.len() >= 2 {
+            chains.push(LineString3D::from(chain));
+        }
+    }
+
+    if chains.is_empty() {
+        LegacyBoundary::Empty
+    } else {
+        LegacyBoundary::Boundary(MultiLineString3D::new(chains))
+    }
+}
+
+#[cfg(all(test, feature = "new-geometry"))]
+mod tests {
+    use super::*;
+    use crate::tests::utils::create_default_execute_context;
+    use pretty_assertions::assert_eq;
+    use reearth_flow_geometry::coordinate::CoordinateFrame;
+    use reearth_flow_geometry::csg::Csg;
+    use reearth_flow_geometry::line_string::LineString3D;
+    use reearth_flow_geometry::point::Point3D;
+    use reearth_flow_geometry::polygon::Polygon3D;
+    use reearth_flow_geometry::polygon_mesh::PolygonMesh3DData;
+    use reearth_flow_geometry::solid::Solid;
+    use reearth_flow_geometry::triangular_mesh::TriangularMesh3D;
+    use reearth_flow_geometry::Euclidean3DGeometry;
+    use reearth_flow_runtime::forwarder::NoopChannelForwarder;
+    use reearth_flow_types::{Attribute, AttributeValue, Feature};
+
+    /// A closed 4x4 square, as an exterior ring.
+    const SQUARE: [[f64; 3]; 5] = [
+        [0.0, 0.0, 0.0],
+        [4.0, 0.0, 0.0],
+        [4.0, 4.0, 0.0],
+        [0.0, 4.0, 0.0],
+        [0.0, 0.0, 0.0],
+    ];
+
+    fn face() -> Polygon3D {
+        Polygon3D::from_rings(
+            CoordinateFrame::Euclidean,
+            SQUARE,
+            Vec::<Vec<[f64; 3]>>::new(),
+        )
+    }
+
+    fn area() -> Geometry {
+        Geometry::Euclidean3D(Euclidean3DGeometry::Polygon(Box::new(face())))
+    }
+
+    /// A closed tetrahedron: bounded by nothing.
+    fn closed_shell() -> Geometry {
+        Geometry::Euclidean3D(Euclidean3DGeometry::TriangularMesh(Box::new(
+            TriangularMesh3D::from_parts(
+                CoordinateFrame::Euclidean,
+                vec![
+                    [0.0, 0.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0],
+                    [0.0, 0.0, 1.0],
+                ],
+                [0u32, 2, 1, 0, 1, 3, 0, 3, 2, 1, 2, 3],
+            )
+            .unwrap(),
+        )))
+    }
+
+    fn boolean_tree() -> Geometry {
+        let solid = || {
+            Solid::from_exterior(
+                CoordinateFrame::Euclidean,
+                PolygonMesh3DData::from_polygons([&face()]),
+            )
+        };
+        Geometry::Euclidean3D(Euclidean3DGeometry::Csg(Csg::union(solid(), solid())))
+    }
+
+    /// A feature carrying `geometry` and one attribute to trace through.
+    fn feature(geometry: Geometry) -> Feature {
+        let mut feature = Feature::from(geometry);
+        feature.insert("surfaceId", AttributeValue::Number(7.into()));
+        feature
+    }
+
+    /// Run the processor over `feature`, returning what it sent, port by port.
+    fn extract(feature: &Feature) -> Vec<(Port, Feature)> {
+        let fw = ProcessorChannelForwarder::Noop(NoopChannelForwarder::default());
+        BoundaryExtractor
+            .process(create_default_execute_context(feature), &fw)
+            .unwrap();
+        let ProcessorChannelForwarder::Noop(noop) = fw else {
+            unreachable!("built as a noop forwarder");
+        };
+        let ports = noop.send_ports.lock().unwrap().clone();
+        let features = noop.send_features.lock().unwrap().clone();
+        ports.into_iter().zip(features).collect()
+    }
+
+    fn ports(sent: &[(Port, Feature)]) -> Vec<String> {
+        sent.iter().map(|(port, _)| port.to_string()).collect()
+    }
+
+    #[test]
+    fn an_area_leaves_with_the_curve_that_bounds_it() {
+        let input = feature(area());
+        let sent = extract(&input);
+
+        assert_eq!(ports(&sent), ["features"]);
+        let Geometry::Euclidean3D(Euclidean3DGeometry::LineString(ring)) = &*sent[0].1.geometry
+        else {
+            panic!("expected one ring, got {:?}", sent[0].1.geometry);
+        };
+        assert_eq!(ring.coords(), SQUARE);
+    }
+
+    // One feature in, one feature out, so nothing has to be traced back: the id
+    // and the attributes are the ones it arrived with.
+    #[test]
+    fn the_boundary_leaves_on_the_feature_it_came_from() {
+        let input = feature(area());
+        let sent = extract(&input);
+
+        assert_eq!(sent[0].1.id, input.id);
+        assert_eq!(
+            sent[0].1.attributes.get(&Attribute::new("surfaceId")),
+            Some(&AttributeValue::Number(7.into()))
+        );
+    }
+
+    // Closed geometry keeps what it came in with, so a workflow can go on using
+    // it after learning that it closes.
+    #[test]
+    fn geometry_bounded_by_nothing_leaves_intact() {
+        for geometry in [
+            closed_shell(),
+            Geometry::Euclidean3D(Euclidean3DGeometry::LineString(LineString3D::from_coords(
+                CoordinateFrame::Euclidean,
+                SQUARE,
+            ))),
+            Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
+                CoordinateFrame::Euclidean,
+                [1.0, 2.0, 3.0],
+            ))),
+        ] {
+            let input = feature(geometry);
+            let sent = extract(&input);
+            assert_eq!(ports(&sent), ["no-boundary"]);
+            assert_eq!(sent[0].1.id, input.id);
+            assert_eq!(&*sent[0].1.geometry, &*input.geometry);
+        }
+    }
+
+    // An unevaluated tree has no boundary to give, and a feature with no geometry
+    // has nothing to bound. Neither fails the run.
+    #[test]
+    fn geometry_with_no_boundary_to_give_is_rejected_intact() {
+        for geometry in [boolean_tree(), Geometry::None] {
+            let input = feature(geometry);
+            let sent = extract(&input);
+            assert_eq!(ports(&sent), ["rejected"]);
+            assert_eq!(sent[0].1.id, input.id);
+            assert_eq!(&*sent[0].1.geometry, &*input.geometry);
         }
     }
 }

--- a/engine/runtime/action-processor/src/geometry/boundary_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/boundary_extractor.rs
@@ -67,8 +67,6 @@ impl ProcessorFactory for BoundaryExtractorFactory {
         ]
     }
 
-    // The old geometry world cannot tell geometry that is bounded by nothing from
-    // geometry that has no boundary to give, so it reports both as rejected.
     #[cfg(not(feature = "new-geometry"))]
     fn get_output_ports(&self) -> Vec<Port> {
         vec![FEATURES_PORT.clone(), REJECTED_PORT.clone()]

--- a/engine/runtime/action-processor/src/geometry/boundary_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/boundary_extractor.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+#[cfg(feature = "new-geometry")]
 use once_cell::sync::Lazy;
 #[cfg(not(feature = "new-geometry"))]
 use reearth_flow_geometry::types::geometry::Geometry2D;
@@ -26,6 +27,7 @@ use serde_json::Value;
 
 /// Geometry that closes on itself, or carries no extent to bound, leaves here
 /// with the geometry it arrived with.
+#[cfg(feature = "new-geometry")]
 pub static NO_BOUNDARY_PORT: Lazy<Port> = Lazy::new(|| Port::new("no-boundary"));
 
 #[derive(Debug, Clone, Default)]
@@ -56,12 +58,20 @@ impl ProcessorFactory for BoundaryExtractorFactory {
         vec![FEATURES_PORT.clone()]
     }
 
+    #[cfg(feature = "new-geometry")]
     fn get_output_ports(&self) -> Vec<Port> {
         vec![
             FEATURES_PORT.clone(),
             NO_BOUNDARY_PORT.clone(),
             REJECTED_PORT.clone(),
         ]
+    }
+
+    // The old geometry world cannot tell geometry that is bounded by nothing from
+    // geometry that has no boundary to give, so it reports both as rejected.
+    #[cfg(not(feature = "new-geometry"))]
+    fn get_output_ports(&self) -> Vec<Port> {
+        vec![FEATURES_PORT.clone(), REJECTED_PORT.clone()]
     }
 
     fn build(
@@ -79,14 +89,6 @@ impl ProcessorFactory for BoundaryExtractorFactory {
 struct BoundaryExtractor;
 
 impl Processor for BoundaryExtractor {
-    /// Replace the geometry with what bounds it, one dimension down: a volume
-    /// with its shells, a surface with the rings around it, a curve with its two
-    /// ends.
-    ///
-    /// Geometry bounded by nothing leaves via `no-boundary` with the geometry it
-    /// arrived with, so a workflow can tell "closed" from "not a surface". A
-    /// feature with no geometry, or one whose type has no boundary to give,
-    /// leaves via `rejected`.
     #[cfg(feature = "new-geometry")]
     fn process(
         &mut self,
@@ -127,34 +129,30 @@ impl Processor for BoundaryExtractor {
         let feature = &ctx.feature;
         let geometry = &feature.geometry;
 
-        if geometry.is_empty() {
-            fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
-            return Ok(());
-        }
-
-        let boundary = match &geometry.value {
-            GeometryValue::FlowGeometry2D(geo) => {
-                extract_2d_boundary(geo).map(GeometryValue::FlowGeometry2D)
+        let boundary = if geometry.is_empty() {
+            None
+        } else {
+            match &geometry.value {
+                GeometryValue::FlowGeometry2D(geo) => {
+                    extract_2d_boundary(geo).map(GeometryValue::FlowGeometry2D)
+                }
+                GeometryValue::FlowGeometry3D(geo) => {
+                    extract_3d_boundary(geo).map(GeometryValue::FlowGeometry3D)
+                }
+                // CityGML geometry has to be converted to a plain geometry first.
+                GeometryValue::None | GeometryValue::CityGmlGeometry(_) => None,
             }
-            GeometryValue::FlowGeometry3D(geo) => {
-                extract_3d_boundary(geo).map(GeometryValue::FlowGeometry3D)
-            }
-            // CityGML geometry has to be converted to a plain geometry first.
-            GeometryValue::None | GeometryValue::CityGmlGeometry(_) => LegacyBoundary::None,
         };
 
         match boundary {
-            LegacyBoundary::Boundary(value) => {
+            Some(value) => {
                 let mut new_geometry = (**geometry).clone();
                 new_geometry.value = value;
                 let mut new_feature = feature.clone();
                 new_feature.geometry = std::sync::Arc::new(new_geometry);
                 fw.send(ctx.new_with_feature_and_port(new_feature, FEATURES_PORT.clone()));
             }
-            LegacyBoundary::Empty => {
-                fw.send(ctx.new_with_feature_and_port(feature.clone(), NO_BOUNDARY_PORT.clone()));
-            }
-            LegacyBoundary::None => {
+            None => {
                 fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
             }
         }
@@ -178,63 +176,40 @@ impl Processor for BoundaryExtractor {
     }
 }
 
-/// What a geometry turned out to be bounded by, so the three cases the ports
-/// distinguish cannot be collapsed into one another.
-#[cfg(not(feature = "new-geometry"))]
-enum LegacyBoundary<T> {
-    /// The geometry it is bounded by.
-    Boundary(T),
-    /// Bounded by nothing: it closes on itself, or has no extent to bound.
-    Empty,
-    /// A type with no boundary to give.
-    None,
-}
-
-#[cfg(not(feature = "new-geometry"))]
-impl<T> LegacyBoundary<T> {
-    fn map<U>(self, f: impl FnOnce(T) -> U) -> LegacyBoundary<U> {
-        match self {
-            LegacyBoundary::Boundary(t) => LegacyBoundary::Boundary(f(t)),
-            LegacyBoundary::Empty => LegacyBoundary::Empty,
-            LegacyBoundary::None => LegacyBoundary::None,
-        }
-    }
-}
-
 /// The rings of every face, exterior then holes, as one geometry.
 #[cfg(not(feature = "new-geometry"))]
-fn rings_2d(rings: Vec<LineString2D<f64>>) -> LegacyBoundary<Geometry2D<f64>> {
+fn rings_2d(rings: Vec<LineString2D<f64>>) -> Option<Geometry2D<f64>> {
     match rings.len() {
-        0 => LegacyBoundary::Empty,
-        1 => LegacyBoundary::Boundary(Geometry2D::LineString(rings.into_iter().next().unwrap())),
-        _ => LegacyBoundary::Boundary(Geometry2D::MultiLineString(MultiLineString2D::new(rings))),
+        0 => None,
+        1 => Some(Geometry2D::LineString(rings.into_iter().next().unwrap())),
+        _ => Some(Geometry2D::MultiLineString(MultiLineString2D::new(rings))),
     }
 }
 
 #[cfg(not(feature = "new-geometry"))]
-fn rings_3d(rings: Vec<LineString3D<f64>>) -> LegacyBoundary<Geometry3D<f64>> {
+fn rings_3d(rings: Vec<LineString3D<f64>>) -> Option<Geometry3D<f64>> {
     match rings.len() {
-        0 => LegacyBoundary::Empty,
-        1 => LegacyBoundary::Boundary(Geometry3D::LineString(rings.into_iter().next().unwrap())),
-        _ => LegacyBoundary::Boundary(Geometry3D::MultiLineString(MultiLineString3D::new(rings))),
+        0 => None,
+        1 => Some(Geometry3D::LineString(rings.into_iter().next().unwrap())),
+        _ => Some(Geometry3D::MultiLineString(MultiLineString3D::new(rings))),
     }
 }
 
 #[cfg(not(feature = "new-geometry"))]
-fn extract_2d_boundary(geo: &Geometry2D<f64>) -> LegacyBoundary<Geometry2D<f64>> {
+fn extract_2d_boundary(geo: &Geometry2D<f64>) -> Option<Geometry2D<f64>> {
     match geo {
         // Positions have no extent, so nothing bounds them.
-        Geometry2D::Point(_) | Geometry2D::MultiPoint(_) => LegacyBoundary::Empty,
+        Geometry2D::Point(_) | Geometry2D::MultiPoint(_) => None,
 
-        Geometry2D::Line(line) => LegacyBoundary::Boundary(Geometry2D::GeometryCollection(vec![
+        Geometry2D::Line(line) => Some(Geometry2D::GeometryCollection(vec![
             Geometry2D::Point(line.start_point()),
             Geometry2D::Point(line.end_point()),
         ])),
 
         // A chain is bounded by its two ends; one that closes has none.
         Geometry2D::LineString(ls) => match chain_ends_2d(ls) {
-            Some(points) => LegacyBoundary::Boundary(Geometry2D::GeometryCollection(points)),
-            None => LegacyBoundary::Empty,
+            Some(points) => Some(Geometry2D::GeometryCollection(points)),
+            None => None,
         },
 
         Geometry2D::Polygon(polygon) => rings_2d(polygon.rings().to_vec()),
@@ -242,9 +217,9 @@ fn extract_2d_boundary(geo: &Geometry2D<f64>) -> LegacyBoundary<Geometry2D<f64>>
         Geometry2D::MultiLineString(mls) => {
             let ends: Vec<_> = mls.iter().filter_map(chain_ends_2d).flatten().collect();
             if ends.is_empty() {
-                LegacyBoundary::Empty
+                None
             } else {
-                LegacyBoundary::Boundary(Geometry2D::GeometryCollection(ends))
+                Some(Geometry2D::GeometryCollection(ends))
             }
         }
 
@@ -253,33 +228,33 @@ fn extract_2d_boundary(geo: &Geometry2D<f64>) -> LegacyBoundary<Geometry2D<f64>>
         }
 
         Geometry2D::Rect(rect) => {
-            LegacyBoundary::Boundary(Geometry2D::LineString(rect.to_polygon().exterior().clone()))
+            Some(Geometry2D::LineString(rect.to_polygon().exterior().clone()))
         }
 
         Geometry2D::Triangle(triangle) => {
             let c = triangle.to_array();
-            LegacyBoundary::Boundary(Geometry2D::LineString(LineString2D::from(vec![
+            Some(Geometry2D::LineString(LineString2D::from(vec![
                 c[0], c[1], c[2], c[0],
             ])))
         }
 
-        _ => LegacyBoundary::None,
+        _ => None,
     }
 }
 
 #[cfg(not(feature = "new-geometry"))]
-fn extract_3d_boundary(geo: &Geometry3D<f64>) -> LegacyBoundary<Geometry3D<f64>> {
+fn extract_3d_boundary(geo: &Geometry3D<f64>) -> Option<Geometry3D<f64>> {
     match geo {
-        Geometry3D::Point(_) | Geometry3D::MultiPoint(_) => LegacyBoundary::Empty,
+        Geometry3D::Point(_) | Geometry3D::MultiPoint(_) => None,
 
-        Geometry3D::Line(line) => LegacyBoundary::Boundary(Geometry3D::GeometryCollection(vec![
+        Geometry3D::Line(line) => Some(Geometry3D::GeometryCollection(vec![
             Geometry3D::Point(line.start_point()),
             Geometry3D::Point(line.end_point()),
         ])),
 
         Geometry3D::LineString(ls) => match chain_ends_3d(ls) {
-            Some(points) => LegacyBoundary::Boundary(Geometry3D::GeometryCollection(points)),
-            None => LegacyBoundary::Empty,
+            Some(points) => Some(Geometry3D::GeometryCollection(points)),
+            None => None,
         },
 
         Geometry3D::Polygon(polygon) => rings_3d(polygon.rings().to_vec()),
@@ -287,9 +262,9 @@ fn extract_3d_boundary(geo: &Geometry3D<f64>) -> LegacyBoundary<Geometry3D<f64>>
         Geometry3D::MultiLineString(mls) => {
             let ends: Vec<_> = mls.iter().filter_map(chain_ends_3d).flatten().collect();
             if ends.is_empty() {
-                LegacyBoundary::Empty
+                None
             } else {
-                LegacyBoundary::Boundary(Geometry3D::GeometryCollection(ends))
+                Some(Geometry3D::GeometryCollection(ends))
             }
         }
 
@@ -297,13 +272,11 @@ fn extract_3d_boundary(geo: &Geometry3D<f64>) -> LegacyBoundary<Geometry3D<f64>>
             rings_3d(mp.iter().flat_map(|p| p.rings().to_vec()).collect())
         }
 
-        Geometry3D::Rect(rect) => {
-            LegacyBoundary::Boundary(Geometry3D::MultiPolygon(rect.to_multi_polygon()))
-        }
+        Geometry3D::Rect(rect) => Some(Geometry3D::MultiPolygon(rect.to_multi_polygon())),
 
         Geometry3D::Triangle(triangle) => {
             let c = triangle.to_array();
-            LegacyBoundary::Boundary(Geometry3D::LineString(LineString3D::from(vec![
+            Some(Geometry3D::LineString(LineString3D::from(vec![
                 c[0], c[1], c[2], c[0],
             ])))
         }
@@ -314,35 +287,20 @@ fn extract_3d_boundary(geo: &Geometry3D<f64>) -> LegacyBoundary<Geometry3D<f64>>
 
         // A volume is bounded by its surface.
         Geometry3D::Solid(solid) => match solid.clone().as_triangle_mesh(None) {
-            Ok(mesh) => LegacyBoundary::Boundary(Geometry3D::TriangularMesh(mesh)),
-            Err(_) => LegacyBoundary::None,
+            Ok(mesh) => Some(Geometry3D::TriangularMesh(mesh)),
+            Err(_) => None,
         },
 
         Geometry3D::GeometryCollection(collection) => {
-            let mut bounded = Vec::new();
-            let mut any = false;
-            for member in collection {
-                match extract_3d_boundary(member) {
-                    LegacyBoundary::Boundary(b) => {
-                        any = true;
-                        bounded.push(b);
-                    }
-                    LegacyBoundary::Empty => any = true,
-                    LegacyBoundary::None => {}
-                }
-            }
-            if !any && !collection.is_empty() {
-                LegacyBoundary::None
-            } else if bounded.is_empty() {
-                LegacyBoundary::Empty
-            } else if bounded.len() == 1 {
-                LegacyBoundary::Boundary(bounded.into_iter().next().unwrap())
-            } else {
-                LegacyBoundary::Boundary(Geometry3D::GeometryCollection(bounded))
+            let bounded: Vec<_> = collection.iter().filter_map(extract_3d_boundary).collect();
+            match bounded.len() {
+                0 => None,
+                1 => Some(bounded.into_iter().next().unwrap()),
+                _ => Some(Geometry3D::GeometryCollection(bounded)),
             }
         }
 
-        _ => LegacyBoundary::None,
+        _ => None,
     }
 }
 
@@ -374,9 +332,7 @@ fn chain_ends_3d(ls: &LineString3D<f64>) -> Option<Vec<Geometry3D<f64>>> {
 
 /// The edges only one triangle walks, chained into rings.
 #[cfg(not(feature = "new-geometry"))]
-fn extract_mesh_boundary(
-    mesh: &TriangularMesh<f64, f64>,
-) -> LegacyBoundary<MultiLineString3D<f64>> {
+fn extract_mesh_boundary(mesh: &TriangularMesh<f64, f64>) -> Option<MultiLineString3D<f64>> {
     let mut walks: HashMap<(usize, usize), usize> = HashMap::new();
     for triangle in mesh.get_triangles() {
         for edge in [
@@ -393,7 +349,7 @@ fn extract_mesh_boundary(
         .filter_map(|(edge, count)| (count == 1).then_some(edge))
         .collect::<Vec<_>>();
     if edges.is_empty() {
-        return LegacyBoundary::Empty;
+        return None;
     }
     edges.sort_unstable();
 
@@ -500,9 +456,9 @@ fn extract_mesh_boundary(
     }
 
     if chains.is_empty() {
-        LegacyBoundary::Empty
+        None
     } else {
-        LegacyBoundary::Boundary(MultiLineString3D::new(chains))
+        Some(MultiLineString3D::new(chains))
     }
 }
 

--- a/engine/runtime/action-processor/src/geometry/boundary_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/boundary_extractor.rs
@@ -1,7 +1,11 @@
 use std::collections::HashMap;
+#[cfg(not(feature = "new-geometry"))]
+use std::sync::Arc;
 
 #[cfg(feature = "new-geometry")]
 use once_cell::sync::Lazy;
+#[cfg(feature = "new-geometry")]
+use reearth_flow_geometry::ops::ExtractBoundary;
 #[cfg(not(feature = "new-geometry"))]
 use reearth_flow_geometry::types::geometry::Geometry2D;
 #[cfg(not(feature = "new-geometry"))]
@@ -13,17 +17,23 @@ use reearth_flow_geometry::types::multi_line_string::{MultiLineString2D, MultiLi
 #[cfg(not(feature = "new-geometry"))]
 use reearth_flow_geometry::types::triangular_mesh::TriangularMesh;
 #[cfg(feature = "new-geometry")]
-use reearth_flow_geometry::{ops::ExtractBoundary, Geometry};
+use reearth_flow_geometry::Geometry as NextGeometry;
+#[cfg(feature = "new-geometry")]
+use reearth_flow_runtime::node::REJECTED_PORT;
 use reearth_flow_runtime::{
     errors::BoxedError,
     event::EventHub,
     executor_operation::{ExecutorContext, NodeContext},
     forwarder::ProcessorChannelForwarder,
-    node::{Port, Processor, ProcessorFactory, FEATURES_PORT, REJECTED_PORT},
+    node::{Port, Processor, ProcessorFactory, FEATURES_PORT},
 };
 #[cfg(not(feature = "new-geometry"))]
-use reearth_flow_types::GeometryValue;
+use reearth_flow_types::{Geometry, GeometryValue};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
+
+use super::errors::GeometryProcessorError;
 
 /// Geometry that closes on itself, or carries no extent to bound, leaves here
 /// with the geometry it arrived with.
@@ -42,8 +52,17 @@ impl ProcessorFactory for BoundaryExtractorFactory {
         "Replaces a geometry with its boundary: the endpoints of a curve, the boundary rings of a surface, and the bounding shells of a volume."
     }
 
+    // The ports carry what `keepEmptyBoundaries` used to, and a boundary includes
+    // the interior rings `exteriorOnly` dropped, so the new world takes no
+    // parameters. The old world keeps its own, unchanged.
+    #[cfg(feature = "new-geometry")]
     fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
+    }
+
+    #[cfg(not(feature = "new-geometry"))]
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+        Some(schemars::schema_for!(BoundaryExtractorParams))
     }
 
     fn categories(&self) -> &[&'static str] {
@@ -69,7 +88,7 @@ impl ProcessorFactory for BoundaryExtractorFactory {
 
     #[cfg(not(feature = "new-geometry"))]
     fn get_output_ports(&self) -> Vec<Port> {
-        vec![FEATURES_PORT.clone(), REJECTED_PORT.clone()]
+        vec![FEATURES_PORT.clone()]
     }
 
     fn build(
@@ -77,16 +96,83 @@ impl ProcessorFactory for BoundaryExtractorFactory {
         _ctx: NodeContext,
         _event_hub: EventHub,
         _action: String,
-        _with: Option<HashMap<String, Value>>,
+        with: Option<HashMap<String, Value>>,
     ) -> Result<Box<dyn Processor>, BoxedError> {
-        Ok(Box::new(BoundaryExtractor))
+        let params: BoundaryExtractorParams = if let Some(with) = with {
+            let value: Value = serde_json::to_value(with).map_err(|e| {
+                GeometryProcessorError::BoundaryExtractorFactory(format!(
+                    "Failed to serialize 'with' parameter: {e}"
+                ))
+            })?;
+            serde_json::from_value(value).map_err(|e| {
+                GeometryProcessorError::BoundaryExtractorFactory(format!(
+                    "Failed to deserialize 'with' parameter: {e}"
+                ))
+            })?
+        } else {
+            BoundaryExtractorParams::default()
+        };
+        Ok(Box::new(BoundaryExtractor { params }))
     }
 }
 
+// AUDIT NOTE (left by the Geometry A batch, 2026-07-30). This action has not been
+// audited yet. The observations below came from reading this file while deciding
+// something else, so treat them as leads to CHECK, not conclusions to apply —
+// verify each against the code and the standard before acting, and disagree freely
+// if the reading is wrong.
+//
+// 1. Suspected silent data loss. When `keepEmptyBoundaries` is false — the default —
+//    a feature whose boundary cannot be extracted appears to be dropped entirely:
+//    no port receives it and there is no `rejected` port. CityGML geometry looks
+//    worst affected, since the match arm for it extracts nothing at all, so every
+//    CityGML feature may vanish by default. Confirm by tracing each `None` branch
+//    in `process`. If it holds, §4.3 wants a `rejected` port.
+// 2. If `rejected` is added, re-examine whether `keepEmptyBoundaries` should exist
+//    at all. It reads as a routing decision expressed as a parameter, which ports
+//    already express; §3.5 would call that implementation leakage. Check whether any
+//    workflow relies on it before removing.
+// 3. `exteriorOnly` looks like a genuine semantic choice worth keeping, but it is
+//    negatively framed. Consider inverting it to `includeHoles` (default true).
+// 4. The description is three sentences, has no terminating period, and leaks
+//    implementation detail — see §2.
+//
+// Cross-check before consolidating this with any other action: its shape is one
+// feature in, one feature out with the geometry replaced. Geometry Part Extractor
+// and Hole Extractor instead emit one feature per part. Ports are declared
+// statically by the factory and cannot vary by parameter, so merging actions of
+// different shapes forces dead ports onto the node.
+
+/// # Boundary Extractor Parameters
+///
+/// Configuration for extracting boundaries from geometries.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct BoundaryExtractorParams {
+    /// Whether to keep features with empty boundaries (default: false)
+    #[serde(default)]
+    keep_empty_boundaries: bool,
+
+    /// Whether to extract only exterior boundaries (ignoring holes) for polygons (default: false)
+    #[serde(default)]
+    exterior_only: bool,
+}
+
 #[derive(Debug, Clone)]
-struct BoundaryExtractor;
+struct BoundaryExtractor {
+    #[cfg_attr(feature = "new-geometry", allow(dead_code))]
+    params: BoundaryExtractorParams,
+}
 
 impl Processor for BoundaryExtractor {
+    /// Replace the geometry with what bounds it, one dimension down: a volume
+    /// with its shells, a surface with the rings around it, a curve with its two
+    /// ends.
+    ///
+    /// Geometry bounded by nothing leaves via `no-boundary` with the geometry it
+    /// arrived with, so a workflow can tell "closed" from "not a surface". A
+    /// feature with no geometry, or one whose type has no boundary to give,
+    /// leaves via `rejected`.
     #[cfg(feature = "new-geometry")]
     fn process(
         &mut self,
@@ -94,9 +180,9 @@ impl Processor for BoundaryExtractor {
         fw: &ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
         match ctx.feature.geometry.extract_boundary() {
-            // An answer, not a failure, so the feature goes on with the
-            // geometry it came in with.
-            Ok(Geometry::None) => {
+            // An answer, not a failure, so the feature goes on with the geometry
+            // it came in with.
+            Ok(NextGeometry::None) => {
                 fw.send(
                     ctx.new_with_feature_and_port(ctx.feature.clone(), NO_BOUNDARY_PORT.clone()),
                 );
@@ -127,33 +213,52 @@ impl Processor for BoundaryExtractor {
         let feature = &ctx.feature;
         let geometry = &feature.geometry;
 
-        let boundary = if geometry.is_empty() {
-            None
-        } else {
-            match &geometry.value {
-                GeometryValue::FlowGeometry2D(geo) => {
-                    extract_2d_boundary(geo).map(GeometryValue::FlowGeometry2D)
+        if geometry.is_empty() {
+            if self.params.keep_empty_boundaries {
+                fw.send(ctx.new_with_feature_and_port(ctx.feature.clone(), FEATURES_PORT.clone()));
+            }
+            return Ok(());
+        }
+
+        let new_geometry = match &geometry.value {
+            GeometryValue::None => {
+                if self.params.keep_empty_boundaries {
+                    Some(geometry.clone())
+                } else {
+                    None
                 }
-                GeometryValue::FlowGeometry3D(geo) => {
-                    extract_3d_boundary(geo).map(GeometryValue::FlowGeometry3D)
+            }
+            GeometryValue::FlowGeometry2D(geo) => self.extract_2d_boundary(geo).map(|g| {
+                let mut new_geo = (**geometry).clone();
+                new_geo.value = GeometryValue::FlowGeometry2D(g);
+                Arc::new(new_geo)
+            }),
+            GeometryValue::FlowGeometry3D(geo) => self.extract_3d_boundary(geo).map(|g| {
+                let mut new_geo = (**geometry).clone();
+                new_geo.value = GeometryValue::FlowGeometry3D(g);
+                Arc::new(new_geo)
+            }),
+            GeometryValue::CityGmlGeometry(_) => {
+                // For CityGML geometries, we don't extract boundaries directly
+                // They should be converted to regular geometries first
+                if self.params.keep_empty_boundaries {
+                    Some(geometry.clone())
+                } else {
+                    None
                 }
-                // CityGML geometry has to be converted to a plain geometry first.
-                GeometryValue::None | GeometryValue::CityGmlGeometry(_) => None,
             }
         };
 
-        match boundary {
-            Some(value) => {
-                let mut new_geometry = (**geometry).clone();
-                new_geometry.value = value;
-                let mut new_feature = feature.clone();
-                new_feature.geometry = std::sync::Arc::new(new_geometry);
-                fw.send(ctx.new_with_feature_and_port(new_feature, FEATURES_PORT.clone()));
-            }
-            None => {
-                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
-            }
+        if let Some(new_geo) = new_geometry {
+            let mut new_feature = feature.clone();
+            new_feature.geometry = new_geo;
+            fw.send(ctx.new_with_feature_and_port(new_feature, FEATURES_PORT.clone()));
+        } else if self.params.keep_empty_boundaries {
+            let mut new_feature = feature.clone();
+            new_feature.geometry = Arc::new(Geometry::default());
+            fw.send(ctx.new_with_feature_and_port(new_feature, FEATURES_PORT.clone()));
         }
+
         Ok(())
     }
 
@@ -174,253 +279,336 @@ impl Processor for BoundaryExtractor {
     }
 }
 
-/// The rings of every face, exterior then holes, as one geometry.
 #[cfg(not(feature = "new-geometry"))]
-fn rings_2d(rings: Vec<LineString2D<f64>>) -> Option<Geometry2D<f64>> {
-    match rings.len() {
-        0 => None,
-        1 => Some(Geometry2D::LineString(rings.into_iter().next().unwrap())),
-        _ => Some(Geometry2D::MultiLineString(MultiLineString2D::new(rings))),
+impl BoundaryExtractor {
+    fn extract_2d_boundary(&self, geo: &Geometry2D) -> Option<Geometry2D> {
+        match geo {
+            // Point has no boundary
+            Geometry2D::Point(_) => None,
+
+            // Line boundary is its endpoints
+            Geometry2D::Line(line) => {
+                let points = vec![
+                    Geometry2D::Point(line.start_point()),
+                    Geometry2D::Point(line.end_point()),
+                ];
+                Some(Geometry2D::GeometryCollection(points))
+            }
+
+            // LineString boundary is its endpoints if not closed
+            Geometry2D::LineString(ls) => {
+                if ls.is_closed() {
+                    None // Closed curve has no boundary
+                } else {
+                    let coords: Vec<_> = ls.coords().cloned().collect();
+                    if coords.len() >= 2 {
+                        let points = vec![
+                            Geometry2D::Point(coords[0].into()),
+                            Geometry2D::Point(coords[coords.len() - 1].into()),
+                        ];
+                        Some(Geometry2D::GeometryCollection(points))
+                    } else {
+                        None
+                    }
+                }
+            }
+
+            // Polygon boundary is its rings (exterior + holes)
+            Geometry2D::Polygon(polygon) => {
+                let rings = if self.params.exterior_only {
+                    vec![polygon.exterior().clone()]
+                } else {
+                    polygon.rings().to_vec()
+                };
+
+                if rings.is_empty() {
+                    None
+                } else if rings.len() == 1 {
+                    Some(Geometry2D::LineString(rings[0].clone()))
+                } else {
+                    Some(Geometry2D::MultiLineString(MultiLineString2D::new(rings)))
+                }
+            }
+
+            // MultiPoint has no boundary
+            Geometry2D::MultiPoint(_) => None,
+
+            // MultiLineString boundary is the set of endpoints of non-closed linestrings
+            Geometry2D::MultiLineString(mls) => {
+                let mut endpoints = Vec::new();
+                for ls in mls.iter() {
+                    if !ls.is_closed() {
+                        let coords: Vec<_> = ls.coords().cloned().collect();
+                        if coords.len() >= 2 {
+                            endpoints.push(Geometry2D::Point(coords[0].into()));
+                            endpoints.push(Geometry2D::Point(coords[coords.len() - 1].into()));
+                        }
+                    }
+                }
+
+                if endpoints.is_empty() {
+                    None
+                } else {
+                    Some(Geometry2D::GeometryCollection(endpoints))
+                }
+            }
+
+            // MultiPolygon boundary is the union of all polygon boundaries
+            Geometry2D::MultiPolygon(mp) => {
+                let mut all_rings = Vec::new();
+                for polygon in mp.iter() {
+                    if self.params.exterior_only {
+                        all_rings.push(polygon.exterior().clone());
+                    } else {
+                        all_rings.extend_from_slice(&polygon.rings());
+                    }
+                }
+
+                if all_rings.is_empty() {
+                    None
+                } else if all_rings.len() == 1 {
+                    Some(Geometry2D::LineString(all_rings[0].clone()))
+                } else {
+                    Some(Geometry2D::MultiLineString(MultiLineString2D::new(
+                        all_rings,
+                    )))
+                }
+            }
+
+            // Rectangle boundary is its perimeter
+            Geometry2D::Rect(rect) => {
+                let polygon = rect.to_polygon();
+                Some(Geometry2D::LineString(polygon.exterior().clone()))
+            }
+
+            // Triangle boundary is its perimeter
+            Geometry2D::Triangle(triangle) => {
+                let coords = triangle.to_array();
+                let ls = LineString2D::from(vec![
+                    coords[0], coords[1], coords[2], coords[0], // Close the triangle
+                ]);
+                Some(Geometry2D::LineString(ls))
+            }
+
+            // For other geometry types, return None
+            _ => None,
+        }
     }
-}
 
-#[cfg(not(feature = "new-geometry"))]
-fn rings_3d(rings: Vec<LineString3D<f64>>) -> Option<Geometry3D<f64>> {
-    match rings.len() {
-        0 => None,
-        1 => Some(Geometry3D::LineString(rings.into_iter().next().unwrap())),
-        _ => Some(Geometry3D::MultiLineString(MultiLineString3D::new(rings))),
+    fn extract_3d_boundary(&self, geo: &Geometry3D) -> Option<Geometry3D> {
+        match geo {
+            // Point has no boundary
+            Geometry3D::Point(_) => None,
+
+            // Line boundary is its endpoints
+            Geometry3D::Line(line) => {
+                let points = vec![
+                    Geometry3D::Point(line.start_point()),
+                    Geometry3D::Point(line.end_point()),
+                ];
+                Some(Geometry3D::GeometryCollection(points))
+            }
+
+            // LineString boundary is its endpoints if not closed
+            Geometry3D::LineString(ls) => {
+                if ls.is_closed() {
+                    None // Closed curve has no boundary
+                } else {
+                    let coords: Vec<_> = ls.coords().cloned().collect();
+                    if coords.len() >= 2 {
+                        let points = vec![
+                            Geometry3D::Point(coords[0].into()),
+                            Geometry3D::Point(coords[coords.len() - 1].into()),
+                        ];
+                        Some(Geometry3D::GeometryCollection(points))
+                    } else {
+                        None
+                    }
+                }
+            }
+
+            // Polygon boundary is its rings (exterior + holes)
+            Geometry3D::Polygon(polygon) => {
+                let rings = if self.params.exterior_only {
+                    vec![polygon.exterior().clone()]
+                } else {
+                    polygon.rings().to_vec()
+                };
+
+                if rings.is_empty() {
+                    None
+                } else if rings.len() == 1 {
+                    Some(Geometry3D::LineString(rings[0].clone()))
+                } else {
+                    Some(Geometry3D::MultiLineString(MultiLineString3D::new(rings)))
+                }
+            }
+
+            // MultiPoint has no boundary
+            Geometry3D::MultiPoint(_) => None,
+
+            // MultiLineString boundary is the set of endpoints of non-closed linestrings
+            Geometry3D::MultiLineString(mls) => {
+                let mut endpoints = Vec::new();
+                for ls in mls.iter() {
+                    if !ls.is_closed() {
+                        let coords: Vec<_> = ls.coords().cloned().collect();
+                        if coords.len() >= 2 {
+                            endpoints.push(Geometry3D::Point(coords[0].into()));
+                            endpoints.push(Geometry3D::Point(coords[coords.len() - 1].into()));
+                        }
+                    }
+                }
+
+                if endpoints.is_empty() {
+                    None
+                } else {
+                    Some(Geometry3D::GeometryCollection(endpoints))
+                }
+            }
+
+            // MultiPolygon boundary is the union of all polygon boundaries
+            Geometry3D::MultiPolygon(mp) => {
+                let mut all_rings = Vec::new();
+                for polygon in mp.iter() {
+                    if self.params.exterior_only {
+                        all_rings.push(polygon.exterior().clone());
+                    } else {
+                        all_rings.extend_from_slice(&polygon.rings());
+                    }
+                }
+
+                if all_rings.is_empty() {
+                    None
+                } else if all_rings.len() == 1 {
+                    Some(Geometry3D::LineString(all_rings[0].clone()))
+                } else {
+                    Some(Geometry3D::MultiLineString(MultiLineString3D::new(
+                        all_rings,
+                    )))
+                }
+            }
+
+            // Rectangle boundary is its perimeter
+            Geometry3D::Rect(rect) => Some(Geometry3D::MultiPolygon(rect.to_multi_polygon())),
+
+            // Triangle boundary is its perimeter
+            Geometry3D::Triangle(triangle) => {
+                let coords = triangle.to_array();
+                let ls = LineString3D::from(vec![
+                    coords[0], coords[1], coords[2], coords[0], // Close the triangle
+                ]);
+                Some(Geometry3D::LineString(ls))
+            }
+
+            // TriangularMesh boundary is the set of boundary edges
+            Geometry3D::TriangularMesh(mesh) => self
+                .extract_mesh_boundary(mesh)
+                .map(Geometry3D::MultiLineString),
+
+            // Solid boundary is the triangular mesh representing its surface
+            Geometry3D::Solid(solid) => {
+                // A solid's boundary is its surface mesh
+                // Try to convert to triangular mesh with default tolerance
+                match solid.clone().as_triangle_mesh(None) {
+                    Ok(mesh) => Some(Geometry3D::TriangularMesh(mesh)),
+                    Err(_) => {
+                        // If conversion fails, the solid might be represented as faces
+                        // In this case, we cannot easily extract the boundary
+                        None
+                    }
+                }
+            }
+
+            // GeometryCollection: extract boundaries of each geometry
+            Geometry3D::GeometryCollection(collection) => {
+                let mut boundaries = Vec::new();
+                for geom in collection {
+                    if let Some(boundary) = self.extract_3d_boundary(geom) {
+                        boundaries.push(boundary);
+                    }
+                }
+
+                if boundaries.is_empty() {
+                    None
+                } else if boundaries.len() == 1 {
+                    Some(boundaries.into_iter().next().unwrap())
+                } else {
+                    Some(Geometry3D::GeometryCollection(boundaries))
+                }
+            }
+
+            // For other geometry types like CSG, return None
+            _ => None,
+        }
     }
-}
 
-#[cfg(not(feature = "new-geometry"))]
-fn extract_2d_boundary(geo: &Geometry2D<f64>) -> Option<Geometry2D<f64>> {
-    match geo {
-        // Positions have no extent, so nothing bounds them.
-        Geometry2D::Point(_) | Geometry2D::MultiPoint(_) => None,
+    fn extract_mesh_boundary(
+        &self,
+        mesh: &TriangularMesh<f64, f64>,
+    ) -> Option<MultiLineString3D<f64>> {
+        // Extract boundary edges from the triangular mesh
+        // Boundary edges are those that belong to only one triangle
+        let mut edge_count: HashMap<(usize, usize), usize> = HashMap::new();
+        let triangles = mesh.get_triangles();
 
-        Geometry2D::Line(line) => Some(Geometry2D::GeometryCollection(vec![
-            Geometry2D::Point(line.start_point()),
-            Geometry2D::Point(line.end_point()),
-        ])),
+        // Count how many triangles each edge belongs to
+        for triangle in triangles {
+            let edges = [
+                (triangle[0].min(triangle[1]), triangle[0].max(triangle[1])),
+                (triangle[1].min(triangle[2]), triangle[1].max(triangle[2])),
+                (triangle[0].min(triangle[2]), triangle[0].max(triangle[2])),
+            ];
 
-        // A chain is bounded by its two ends; one that closes has none.
-        Geometry2D::LineString(ls) => match chain_ends_2d(ls) {
-            Some(points) => Some(Geometry2D::GeometryCollection(points)),
-            None => None,
-        },
-
-        Geometry2D::Polygon(polygon) => rings_2d(polygon.rings().to_vec()),
-
-        Geometry2D::MultiLineString(mls) => {
-            let ends: Vec<_> = mls.iter().filter_map(chain_ends_2d).flatten().collect();
-            if ends.is_empty() {
-                None
-            } else {
-                Some(Geometry2D::GeometryCollection(ends))
+            for edge in &edges {
+                *edge_count.entry(*edge).or_insert(0) += 1;
             }
         }
 
-        Geometry2D::MultiPolygon(mp) => {
-            rings_2d(mp.iter().flat_map(|p| p.rings().to_vec()).collect())
+        let mut edges = edge_count
+            .into_iter()
+            .filter_map(|(edge, count)| if count == 1 { Some(edge) } else { None })
+            .collect::<Vec<_>>();
+
+        if edges.is_empty() {
+            return None; // Closed surface has no boundary
         }
 
-        Geometry2D::Rect(rect) => {
-            Some(Geometry2D::LineString(rect.to_polygon().exterior().clone()))
+        edges.sort_unstable();
+        let edges = edges;
+
+        let edge_idx: HashMap<_, _> = edges
+            .iter()
+            .enumerate()
+            .map(|(idx, &edge)| (edge, idx))
+            .collect();
+
+        // Build adjacency map: vertex -> list of connected vertices
+        let mut adjacency: Vec<Vec<usize>> = vec![Vec::new(); mesh.get_vertices().len()];
+        for (v1, v2) in &edges {
+            adjacency[*v1].push(*v2);
+            adjacency[*v2].push(*v1);
         }
 
-        Geometry2D::Triangle(triangle) => {
-            let c = triangle.to_array();
-            Some(Geometry2D::LineString(LineString2D::from(vec![
-                c[0], c[1], c[2], c[0],
-            ])))
-        }
+        // Chain boundary edges into connected linestrings
+        let mut used_edges = vec![false; edges.len()];
+        let mut chains = Vec::new();
 
-        _ => None,
-    }
-}
-
-#[cfg(not(feature = "new-geometry"))]
-fn extract_3d_boundary(geo: &Geometry3D<f64>) -> Option<Geometry3D<f64>> {
-    match geo {
-        Geometry3D::Point(_) | Geometry3D::MultiPoint(_) => None,
-
-        Geometry3D::Line(line) => Some(Geometry3D::GeometryCollection(vec![
-            Geometry3D::Point(line.start_point()),
-            Geometry3D::Point(line.end_point()),
-        ])),
-
-        Geometry3D::LineString(ls) => match chain_ends_3d(ls) {
-            Some(points) => Some(Geometry3D::GeometryCollection(points)),
-            None => None,
-        },
-
-        Geometry3D::Polygon(polygon) => rings_3d(polygon.rings().to_vec()),
-
-        Geometry3D::MultiLineString(mls) => {
-            let ends: Vec<_> = mls.iter().filter_map(chain_ends_3d).flatten().collect();
-            if ends.is_empty() {
-                None
-            } else {
-                Some(Geometry3D::GeometryCollection(ends))
-            }
-        }
-
-        Geometry3D::MultiPolygon(mp) => {
-            rings_3d(mp.iter().flat_map(|p| p.rings().to_vec()).collect())
-        }
-
-        Geometry3D::Rect(rect) => Some(Geometry3D::MultiPolygon(rect.to_multi_polygon())),
-
-        Geometry3D::Triangle(triangle) => {
-            let c = triangle.to_array();
-            Some(Geometry3D::LineString(LineString3D::from(vec![
-                c[0], c[1], c[2], c[0],
-            ])))
-        }
-
-        Geometry3D::TriangularMesh(mesh) => {
-            extract_mesh_boundary(mesh).map(Geometry3D::MultiLineString)
-        }
-
-        // A volume is bounded by its surface.
-        Geometry3D::Solid(solid) => match solid.clone().as_triangle_mesh(None) {
-            Ok(mesh) => Some(Geometry3D::TriangularMesh(mesh)),
-            Err(_) => None,
-        },
-
-        Geometry3D::GeometryCollection(collection) => {
-            let bounded: Vec<_> = collection.iter().filter_map(extract_3d_boundary).collect();
-            match bounded.len() {
-                0 => None,
-                1 => Some(bounded.into_iter().next().unwrap()),
-                _ => Some(Geometry3D::GeometryCollection(bounded)),
-            }
-        }
-
-        _ => None,
-    }
-}
-
-/// The two ends of an open chain, as points. A chain that closes on itself, or
-/// that spans nothing, has no ends to give.
-#[cfg(not(feature = "new-geometry"))]
-fn chain_ends_2d(ls: &LineString2D<f64>) -> Option<Vec<Geometry2D<f64>>> {
-    let coords: Vec<_> = ls.coords().cloned().collect();
-    if ls.is_closed() || coords.len() < 2 {
-        return None;
-    }
-    Some(vec![
-        Geometry2D::Point(coords[0].into()),
-        Geometry2D::Point(coords[coords.len() - 1].into()),
-    ])
-}
-
-#[cfg(not(feature = "new-geometry"))]
-fn chain_ends_3d(ls: &LineString3D<f64>) -> Option<Vec<Geometry3D<f64>>> {
-    let coords: Vec<_> = ls.coords().cloned().collect();
-    if ls.is_closed() || coords.len() < 2 {
-        return None;
-    }
-    Some(vec![
-        Geometry3D::Point(coords[0].into()),
-        Geometry3D::Point(coords[coords.len() - 1].into()),
-    ])
-}
-
-/// The edges only one triangle walks, chained into rings.
-#[cfg(not(feature = "new-geometry"))]
-fn extract_mesh_boundary(mesh: &TriangularMesh<f64, f64>) -> Option<MultiLineString3D<f64>> {
-    let mut walks: HashMap<(usize, usize), usize> = HashMap::new();
-    for triangle in mesh.get_triangles() {
-        for edge in [
-            (triangle[0].min(triangle[1]), triangle[0].max(triangle[1])),
-            (triangle[1].min(triangle[2]), triangle[1].max(triangle[2])),
-            (triangle[0].min(triangle[2]), triangle[0].max(triangle[2])),
-        ] {
-            *walks.entry(edge).or_insert(0) += 1;
-        }
-    }
-
-    let mut edges = walks
-        .into_iter()
-        .filter_map(|(edge, count)| (count == 1).then_some(edge))
-        .collect::<Vec<_>>();
-    if edges.is_empty() {
-        return None;
-    }
-    edges.sort_unstable();
-
-    let edge_idx: HashMap<_, _> = edges
-        .iter()
-        .enumerate()
-        .map(|(idx, &edge)| (edge, idx))
-        .collect();
-
-    let mut adjacency: Vec<Vec<usize>> = vec![Vec::new(); mesh.get_vertices().len()];
-    for (v1, v2) in &edges {
-        adjacency[*v1].push(*v2);
-        adjacency[*v2].push(*v1);
-    }
-
-    let mut used_edges = vec![false; edges.len()];
-    let mut chains = Vec::new();
-
-    for start_idx in 0..edges.len() {
-        if used_edges[start_idx] {
-            continue;
-        }
-
-        used_edges[start_idx] = true;
-
-        let start_v0 = edges[start_idx].0;
-        let start_v1 = edges[start_idx].1;
-
-        let mut chain = vec![mesh.get_vertices()[start_v0], mesh.get_vertices()[start_v1]];
-
-        let mut prev_vertex = start_v0;
-        let mut current_vertex = start_v1;
-
-        loop {
-            if adjacency[current_vertex].len() != 2 {
-                break;
-            }
-            let next_vertex = *adjacency[current_vertex]
-                .iter()
-                .find(|&&v| v != prev_vertex)
-                .unwrap();
-
-            if next_vertex == start_v0 {
-                chain.push(mesh.get_vertices()[next_vertex]);
-                let idx = edge_idx
-                    .get(&(
-                        current_vertex.min(next_vertex),
-                        current_vertex.max(next_vertex),
-                    ))
-                    .unwrap();
-                used_edges[*idx] = true;
-                break;
+        for start_idx in 0..edges.len() {
+            if used_edges[start_idx] {
+                continue;
             }
 
-            let idx = edge_idx
-                .get(&(
-                    current_vertex.min(next_vertex),
-                    current_vertex.max(next_vertex),
-                ))
-                .unwrap();
-            if used_edges[*idx] {
-                break;
-            }
-            used_edges[*idx] = true;
+            used_edges[start_idx] = true;
 
-            chain.push(mesh.get_vertices()[next_vertex]);
-            prev_vertex = current_vertex;
-            current_vertex = next_vertex;
-        }
+            let start_v0 = edges[start_idx].0;
+            let start_v1 = edges[start_idx].1;
 
-        if chain.first() != chain.last() {
-            prev_vertex = start_v1;
-            current_vertex = start_v0;
+            let mut chain = vec![mesh.get_vertices()[start_v0], mesh.get_vertices()[start_v1]];
+
+            // Traverse forward from start_v1
+            let mut prev_vertex = start_v0;
+            let mut current_vertex = start_v1;
 
             loop {
                 if adjacency[current_vertex].len() != 2 {
@@ -431,6 +619,19 @@ fn extract_mesh_boundary(mesh: &TriangularMesh<f64, f64>) -> Option<MultiLineStr
                     .find(|&&v| v != prev_vertex)
                     .unwrap();
 
+                // Check if we've closed the loop
+                if next_vertex == start_v0 {
+                    chain.push(mesh.get_vertices()[next_vertex]);
+                    let idx = edge_idx
+                        .get(&(
+                            current_vertex.min(next_vertex),
+                            current_vertex.max(next_vertex),
+                        ))
+                        .unwrap();
+                    used_edges[*idx] = true;
+                    break;
+                }
+
                 let idx = edge_idx
                     .get(&(
                         current_vertex.min(next_vertex),
@@ -438,25 +639,58 @@ fn extract_mesh_boundary(mesh: &TriangularMesh<f64, f64>) -> Option<MultiLineStr
                     ))
                     .unwrap();
                 if used_edges[*idx] {
+                    // Already visited this edge
                     break;
                 }
                 used_edges[*idx] = true;
 
-                chain.insert(0, mesh.get_vertices()[next_vertex]);
+                chain.push(mesh.get_vertices()[next_vertex]);
                 prev_vertex = current_vertex;
                 current_vertex = next_vertex;
             }
+
+            // Traverse backward from start_v0 only if we didn't close a loop
+            if chain.first() != chain.last() {
+                prev_vertex = start_v1;
+                current_vertex = start_v0;
+
+                loop {
+                    if adjacency[current_vertex].len() != 2 {
+                        break;
+                    }
+                    let next_vertex = *adjacency[current_vertex]
+                        .iter()
+                        .find(|&&v| v != prev_vertex)
+                        .unwrap();
+
+                    let idx = edge_idx
+                        .get(&(
+                            current_vertex.min(next_vertex),
+                            current_vertex.max(next_vertex),
+                        ))
+                        .unwrap();
+                    if used_edges[*idx] {
+                        break;
+                    }
+                    used_edges[*idx] = true;
+
+                    // Prepend to chain
+                    chain.insert(0, mesh.get_vertices()[next_vertex]);
+                    prev_vertex = current_vertex;
+                    current_vertex = next_vertex;
+                }
+            }
+
+            if chain.len() >= 2 {
+                chains.push(LineString3D::from(chain));
+            }
         }
 
-        if chain.len() >= 2 {
-            chains.push(LineString3D::from(chain));
+        if chains.is_empty() {
+            None
+        } else {
+            Some(MultiLineString3D::new(chains))
         }
-    }
-
-    if chains.is_empty() {
-        None
-    } else {
-        Some(MultiLineString3D::new(chains))
     }
 }
 
@@ -494,13 +728,13 @@ mod tests {
         )
     }
 
-    fn area() -> Geometry {
-        Geometry::Euclidean3D(Euclidean3DGeometry::Polygon(Box::new(face())))
+    fn area() -> NextGeometry {
+        NextGeometry::Euclidean3D(Euclidean3DGeometry::Polygon(Box::new(face())))
     }
 
     /// A closed tetrahedron: bounded by nothing.
-    fn closed_shell() -> Geometry {
-        Geometry::Euclidean3D(Euclidean3DGeometry::TriangularMesh(Box::new(
+    fn closed_shell() -> NextGeometry {
+        NextGeometry::Euclidean3D(Euclidean3DGeometry::TriangularMesh(Box::new(
             TriangularMesh3D::from_parts(
                 CoordinateFrame::Euclidean,
                 vec![
@@ -515,18 +749,18 @@ mod tests {
         )))
     }
 
-    fn boolean_tree() -> Geometry {
+    fn boolean_tree() -> NextGeometry {
         let solid = || {
             Solid::from_exterior(
                 CoordinateFrame::Euclidean,
                 PolygonMesh3DData::from_polygons([&face()]),
             )
         };
-        Geometry::Euclidean3D(Euclidean3DGeometry::Csg(Csg::union(solid(), solid())))
+        NextGeometry::Euclidean3D(Euclidean3DGeometry::Csg(Csg::union(solid(), solid())))
     }
 
     /// A feature carrying `geometry` and one attribute to trace through.
-    fn feature(geometry: Geometry) -> Feature {
+    fn feature(geometry: NextGeometry) -> Feature {
         let mut feature = Feature::from(geometry);
         feature.insert("surfaceId", AttributeValue::Number(7.into()));
         feature
@@ -535,9 +769,11 @@ mod tests {
     /// Run the processor over `feature`, returning what it sent, port by port.
     fn extract(feature: &Feature) -> Vec<(Port, Feature)> {
         let fw = ProcessorChannelForwarder::Noop(NoopChannelForwarder::default());
-        BoundaryExtractor
-            .process(create_default_execute_context(feature), &fw)
-            .unwrap();
+        BoundaryExtractor {
+            params: Default::default(),
+        }
+        .process(create_default_execute_context(feature), &fw)
+        .unwrap();
         let ProcessorChannelForwarder::Noop(noop) = fw else {
             unreachable!("built as a noop forwarder");
         };
@@ -556,7 +792,7 @@ mod tests {
         let sent = extract(&input);
 
         assert_eq!(ports(&sent), ["features"]);
-        let Geometry::Euclidean3D(Euclidean3DGeometry::LineString(ring)) = &*sent[0].1.geometry
+        let NextGeometry::Euclidean3D(Euclidean3DGeometry::LineString(ring)) = &*sent[0].1.geometry
         else {
             panic!("expected one ring, got {:?}", sent[0].1.geometry);
         };
@@ -583,11 +819,11 @@ mod tests {
     fn geometry_bounded_by_nothing_leaves_intact() {
         for geometry in [
             closed_shell(),
-            Geometry::Euclidean3D(Euclidean3DGeometry::LineString(LineString3D::from_coords(
+            NextGeometry::Euclidean3D(Euclidean3DGeometry::LineString(LineString3D::from_coords(
                 CoordinateFrame::Euclidean,
                 SQUARE,
             ))),
-            Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
+            NextGeometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
                 CoordinateFrame::Euclidean,
                 [1.0, 2.0, 3.0],
             ))),
@@ -604,7 +840,7 @@ mod tests {
     // has nothing to bound. Neither fails the run.
     #[test]
     fn geometry_with_no_boundary_to_give_is_rejected_intact() {
-        for geometry in [boolean_tree(), Geometry::None] {
+        for geometry in [boolean_tree(), NextGeometry::None] {
             let input = feature(geometry);
             let sent = extract(&input);
             assert_eq!(ports(&sent), ["rejected"]);

--- a/engine/runtime/action-processor/src/geometry/errors.rs
+++ b/engine/runtime/action-processor/src/geometry/errors.rs
@@ -15,6 +15,10 @@ pub(super) enum GeometryProcessorError {
     ThreeDimensionBoxReplacerFactory(String),
     #[error("ThreeDimensionBoxReplacer error: {0}")]
     ThreeDimensionBoxReplacer(String),
+    #[error("BoundaryExtractor Factory error: {0}")]
+    BoundaryExtractorFactory(String),
+    #[error("BoundaryExtractor error: {0}")]
+    BoundaryExtractor(String),
     #[error("CoordinateSystemSetter Factory error: {0}")]
     CoordinateSystemSetterFactory(String),
     #[error("CoordinateSystemSetter error: {0}")]

--- a/engine/runtime/action-processor/src/geometry/errors.rs
+++ b/engine/runtime/action-processor/src/geometry/errors.rs
@@ -15,10 +15,6 @@ pub(super) enum GeometryProcessorError {
     ThreeDimensionBoxReplacerFactory(String),
     #[error("ThreeDimensionBoxReplacer error: {0}")]
     ThreeDimensionBoxReplacer(String),
-    #[error("BoundaryExtractor Factory error: {0}")]
-    BoundaryExtractorFactory(String),
-    #[error("BoundaryExtractor error: {0}")]
-    BoundaryExtractor(String),
     #[error("CoordinateSystemSetter Factory error: {0}")]
     CoordinateSystemSetterFactory(String),
     #[error("CoordinateSystemSetter error: {0}")]

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem.yml
@@ -2251,7 +2251,7 @@ graphs:
   - id: 0457d126-6700-481c-8847-707fb2d9c739
     from: ee6d9226-6ff1-4deb-ba68-55d9a6b0429a
     to: 1e969309-8ff7-46d2-bb7a-7b3666ac7a4e
-    fromPort: features
+    fromPort: boundary
     toPort: features
   - id: 268b55bf-aa4e-48b5-8a9f-338ae6194165
     from: 1e969309-8ff7-46d2-bb7a-7b3666ac7a4e

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem/workflow.yml
@@ -624,7 +624,7 @@ graphs:
       - id: 0457d126-6700-481c-8847-707fb2d9c739
         from: ee6d9226-6ff1-4deb-ba68-55d9a6b0429a
         to: 1e969309-8ff7-46d2-bb7a-7b3666ac7a4e
-        fromPort: features
+        fromPort: boundary
         toPort: features
       - id: 268b55bf-aa4e-48b5-8a9f-338ae6194165
         from: 1e969309-8ff7-46d2-bb7a-7b3666ac7a4e

--- a/engine/runtime/geometry/src/collection.rs
+++ b/engine/runtime/geometry/src/collection.rs
@@ -508,58 +508,38 @@ impl Coerce for Collection3D {
 }
 
 impl crate::ops::ExtractBoundary for Collection2D {
-    fn extract_boundary(&self) -> Result<crate::Geometry, crate::ops::UnsupportedOperation> {
-        let mut members = Vec::new();
-        let mut attrs = Vec::new();
-        let mut any = false;
-        for (i, member) in self.members().iter().enumerate() {
-            let Ok(boundary) = member.extract_boundary() else {
-                continue;
-            };
-            any = true;
-            // A 2D member is bounded by 2D geometry; `Geometry::None` is the
-            // empty boundary and drops out here.
-            if let crate::Geometry::Euclidean2D(g) = boundary {
-                members.push(g);
-                if let Some(a) = self.member_attributes().get(i) {
-                    attrs.push(a.clone());
-                }
-            }
-        }
-        if !any && !self.members().is_empty() {
-            return Err(crate::ops::boundary::unsupported::<Self>());
-        }
-        Ok(wrap_members_2d(members, attrs))
+    fn extract_boundary(&self) -> Result<crate::ops::Boundary, crate::ops::UnsupportedOperation> {
+        crate::ops::container_boundary(
+            self.members(),
+            self.member_attributes(),
+            |geometry| match geometry {
+                crate::Geometry::Euclidean2D(g) => Some(g),
+                _ => None,
+            },
+            wrap_members_2d,
+        )
+        .ok_or_else(crate::ops::boundary::unsupported::<Self>)
     }
 }
 
 impl crate::ops::ExtractBoundary for Collection3D {
-    fn extract_boundary(&self) -> Result<crate::Geometry, crate::ops::UnsupportedOperation> {
-        let mut members = Vec::new();
-        let mut attrs = Vec::new();
-        let mut any = false;
-        for (i, member) in self.members().iter().enumerate() {
-            let Ok(boundary) = member.extract_boundary() else {
-                continue;
-            };
-            any = true;
-            if let crate::Geometry::Euclidean3D(g) = boundary {
-                members.push(g);
-                if let Some(a) = self.member_attributes().get(i) {
-                    attrs.push(a.clone());
-                }
-            }
-        }
-        if !any && !self.members().is_empty() {
-            return Err(crate::ops::boundary::unsupported::<Self>());
-        }
-        Ok(wrap_members_3d(members, attrs))
+    fn extract_boundary(&self) -> Result<crate::ops::Boundary, crate::ops::UnsupportedOperation> {
+        crate::ops::container_boundary(
+            self.members(),
+            self.member_attributes(),
+            |geometry| match geometry {
+                crate::Geometry::Euclidean3D(g) => Some(g),
+                _ => None,
+            },
+            wrap_members_3d,
+        )
+        .ok_or_else(crate::ops::boundary::unsupported::<Self>)
     }
 }
 
-/// Gather boundary members into a collection, keeping their attributes when the
-/// source carried any. A collection's boundary stays a collection even when one
-/// member gave it, so the shape does not turn on how many members contributed.
+/// Gather members into a collection, keeping their attributes when the source
+/// carried any. A collection's boundary stays a collection even when one member
+/// gave it, so the shape does not turn on how many members contributed.
 fn wrap_members_2d(members: Vec<Euclidean2DGeometry>, attrs: Vec<Attributes>) -> crate::Geometry {
     if members.is_empty() {
         return crate::Geometry::None;

--- a/engine/runtime/geometry/src/collection.rs
+++ b/engine/runtime/geometry/src/collection.rs
@@ -507,6 +507,90 @@ impl Coerce for Collection3D {
     }
 }
 
+impl crate::ops::ExtractBoundary for Collection2D {
+    fn extract_boundary(&self) -> Result<crate::Geometry, crate::ops::UnsupportedOperation> {
+        let mut members = Vec::new();
+        let mut attrs = Vec::new();
+        let mut any = false;
+        for (i, member) in self.members().iter().enumerate() {
+            let Ok(boundary) = member.extract_boundary() else {
+                continue;
+            };
+            any = true;
+            // A 2D member is bounded by 2D geometry; `Geometry::None` is the
+            // empty boundary and drops out here.
+            if let crate::Geometry::Euclidean2D(g) = boundary {
+                members.push(g);
+                if let Some(a) = self.member_attributes().get(i) {
+                    attrs.push(a.clone());
+                }
+            }
+        }
+        if !any && !self.members().is_empty() {
+            return Err(crate::ops::boundary::unsupported::<Self>());
+        }
+        Ok(wrap_members_2d(members, attrs))
+    }
+}
+
+impl crate::ops::ExtractBoundary for Collection3D {
+    fn extract_boundary(&self) -> Result<crate::Geometry, crate::ops::UnsupportedOperation> {
+        let mut members = Vec::new();
+        let mut attrs = Vec::new();
+        let mut any = false;
+        for (i, member) in self.members().iter().enumerate() {
+            let Ok(boundary) = member.extract_boundary() else {
+                continue;
+            };
+            any = true;
+            if let crate::Geometry::Euclidean3D(g) = boundary {
+                members.push(g);
+                if let Some(a) = self.member_attributes().get(i) {
+                    attrs.push(a.clone());
+                }
+            }
+        }
+        if !any && !self.members().is_empty() {
+            return Err(crate::ops::boundary::unsupported::<Self>());
+        }
+        Ok(wrap_members_3d(members, attrs))
+    }
+}
+
+/// Gather boundary members into a collection, keeping their attributes when the
+/// source carried any. A collection's boundary stays a collection even when one
+/// member gave it, so the shape does not turn on how many members contributed.
+fn wrap_members_2d(members: Vec<Euclidean2DGeometry>, attrs: Vec<Attributes>) -> crate::Geometry {
+    if members.is_empty() {
+        return crate::Geometry::None;
+    }
+    let attrs = if attrs.len() == members.len() {
+        attrs
+    } else {
+        Vec::new()
+    };
+    crate::Geometry::Euclidean2D(Euclidean2DGeometry::Collection(Collection2D {
+        members,
+        attrs,
+    }))
+}
+
+/// The 3D counterpart of [`wrap_members_2d`].
+fn wrap_members_3d(members: Vec<Euclidean3DGeometry>, attrs: Vec<Attributes>) -> crate::Geometry {
+    if members.is_empty() {
+        return crate::Geometry::None;
+    }
+    let attrs = if attrs.len() == members.len() {
+        attrs
+    } else {
+        Vec::new()
+    };
+    crate::Geometry::Euclidean3D(Euclidean3DGeometry::Collection(Collection3D {
+        members,
+        attrs,
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/csg/mod.rs
+++ b/engine/runtime/geometry/src/csg/mod.rs
@@ -55,3 +55,7 @@ crate::unsupported!(Csg: Split);
 
 // The tree is unevaluated, so it has no boundary of its own to re-represent.
 crate::unsupported!(Csg: Coerce);
+
+// The tree is unevaluated, so the surface it would bound does not exist yet and
+// its operands' shells are not it.
+crate::unsupported!(Csg: ExtractBoundary);

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -59,7 +59,7 @@ use serde::{Deserialize, Serialize};
 
 use ops::triangulation::Cache;
 use ops::{
-    Aabb, BoundingBox, Coerce, CoercionTarget, ConvertFrame, CountHoles, ExtractBoundary,
+    Aabb, Boundary, BoundingBox, Coerce, CoercionTarget, ConvertFrame, CountHoles, ExtractBoundary,
     ExtractHoles, ExtractedPart, ForceTwoDimension, ForceTwoDimensionError, RemoveAppearance,
     Reproject, ReprojectionCache, Translate, Triangulate, UnsupportedOperation,
 };
@@ -549,7 +549,7 @@ impl ExtractHoles for GeometryCollection {
 }
 
 impl ExtractBoundary for Geometry {
-    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+    fn extract_boundary(&self) -> Result<Boundary, UnsupportedOperation> {
         match self {
             // An absent geometry has no extent, so there is nothing to bound —
             // which is not the same as being bounded by nothing.
@@ -565,36 +565,17 @@ impl ExtractBoundary for Geometry {
 }
 
 impl ExtractBoundary for GeometryCollection {
-    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
-        let mut members = Vec::new();
-        let mut attrs = Vec::new();
-        let mut any = false;
-        for (i, member) in self.members.iter().enumerate() {
-            let Ok(boundary) = member.extract_boundary() else {
-                continue;
-            };
-            any = true;
-            if matches!(boundary, Geometry::None) {
-                continue;
+    fn extract_boundary(&self) -> Result<Boundary, UnsupportedOperation> {
+        ops::container_boundary(&self.members, &self.attrs, Some, |members, mut attrs| {
+            if members.is_empty() {
+                return Geometry::None;
             }
-            members.push(boundary);
-            if let Some(a) = self.attrs.get(i) {
-                attrs.push(a.clone());
+            if attrs.len() != members.len() {
+                attrs.clear();
             }
-        }
-        if !any && !self.members.is_empty() {
-            return Err(ops::boundary::unsupported::<Self>());
-        }
-        if members.is_empty() {
-            return Ok(Geometry::None);
-        }
-        if attrs.len() != members.len() {
-            attrs.clear();
-        }
-        Ok(Geometry::GeometryCollection(GeometryCollection {
-            members,
-            attrs,
-        }))
+            Geometry::GeometryCollection(GeometryCollection { members, attrs })
+        })
+        .ok_or_else(ops::boundary::unsupported::<Self>)
     }
 }
 

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -59,9 +59,9 @@ use serde::{Deserialize, Serialize};
 
 use ops::triangulation::Cache;
 use ops::{
-    Aabb, BoundingBox, Coerce, CoercionTarget, ConvertFrame, CountHoles, ExtractHoles,
-    ExtractedPart, ForceTwoDimension, ForceTwoDimensionError, RemoveAppearance, Reproject,
-    ReprojectionCache, Translate, Triangulate, UnsupportedOperation,
+    Aabb, BoundingBox, Coerce, CoercionTarget, ConvertFrame, CountHoles, ExtractBoundary,
+    ExtractHoles, ExtractedPart, ForceTwoDimension, ForceTwoDimensionError, RemoveAppearance,
+    Reproject, ReprojectionCache, Translate, Triangulate, UnsupportedOperation,
 };
 // `ValidationParams` / `ValidationType` / `ValidationReport` are named by the
 // `enum_dispatch`-generated `Validate` impls on the geometry enums, so they must
@@ -190,7 +190,8 @@ impl GeometryCollection {
         ForceTwoDimension,
         RemoveAppearance,
         CountHoles,
-        ExtractHoles
+        ExtractHoles,
+        ExtractBoundary
     )
 )]
 #[cfg_attr(
@@ -208,6 +209,7 @@ impl GeometryCollection {
         RemoveAppearance,
         CountHoles,
         ExtractHoles,
+        ExtractBoundary,
         Footprint
     )
 )]
@@ -247,7 +249,8 @@ pub enum Euclidean2DGeometry {
         ForceTwoDimension,
         RemoveAppearance,
         CountHoles,
-        ExtractHoles
+        ExtractHoles,
+        ExtractBoundary
     )
 )]
 #[cfg_attr(
@@ -265,6 +268,7 @@ pub enum Euclidean2DGeometry {
         RemoveAppearance,
         CountHoles,
         ExtractHoles,
+        ExtractBoundary,
         Footprint
     )
 )]
@@ -541,6 +545,56 @@ impl ExtractHoles for GeometryCollection {
             }
         }
         Ok(())
+    }
+}
+
+impl ExtractBoundary for Geometry {
+    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+        match self {
+            // An absent geometry has no extent, so there is nothing to bound —
+            // which is not the same as being bounded by nothing.
+            Geometry::None => Err(UnsupportedOperation {
+                geometry: "Geometry::None",
+                operation: "extract_boundary",
+            }),
+            Geometry::Euclidean2D(g) => g.extract_boundary(),
+            Geometry::Euclidean3D(g) => g.extract_boundary(),
+            Geometry::GeometryCollection(c) => c.extract_boundary(),
+        }
+    }
+}
+
+impl ExtractBoundary for GeometryCollection {
+    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+        let mut members = Vec::new();
+        let mut attrs = Vec::new();
+        let mut any = false;
+        for (i, member) in self.members.iter().enumerate() {
+            let Ok(boundary) = member.extract_boundary() else {
+                continue;
+            };
+            any = true;
+            if matches!(boundary, Geometry::None) {
+                continue;
+            }
+            members.push(boundary);
+            if let Some(a) = self.attrs.get(i) {
+                attrs.push(a.clone());
+            }
+        }
+        if !any && !self.members.is_empty() {
+            return Err(ops::boundary::unsupported::<Self>());
+        }
+        if members.is_empty() {
+            return Ok(Geometry::None);
+        }
+        if attrs.len() != members.len() {
+            attrs.clear();
+        }
+        Ok(Geometry::GeometryCollection(GeometryCollection {
+            members,
+            attrs,
+        }))
     }
 }
 

--- a/engine/runtime/geometry/src/line_string/ops.rs
+++ b/engine/runtime/geometry/src/line_string/ops.rs
@@ -269,7 +269,7 @@ impl Footprint for LineString3D {
 }
 
 use crate::collection::{Collection2D, Collection3D};
-use crate::ops::boundary::{endpoints, ExtractBoundary};
+use crate::ops::boundary::{endpoints, Boundary, ExtractBoundary};
 use crate::point::{Point2D, Point3D};
 
 // A chain is bounded by its two ends. One that closes on itself has no ends, so
@@ -278,31 +278,31 @@ use crate::point::{Point2D, Point3D};
 // The ends come back as bare points, which carry no elevation of their own, so a
 // 2.5D chain's elevation is not preserved onto them.
 impl ExtractBoundary for LineString2D {
-    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+    fn extract_boundary(&self) -> Result<Boundary, UnsupportedOperation> {
         let Some((first, last)) = endpoints(self.coords()) else {
-            return Ok(Geometry::None);
+            return Ok(Boundary::EMPTY);
         };
         let frame = self.frame();
-        Ok(Geometry::Euclidean2D(Euclidean2DGeometry::Collection(
-            Collection2D::new([
+        Ok(Boundary::Bounded(Geometry::Euclidean2D(
+            Euclidean2DGeometry::Collection(Collection2D::new([
                 Euclidean2DGeometry::Point(Point2D::new(frame.clone(), first)),
                 Euclidean2DGeometry::Point(Point2D::new(frame.clone(), last)),
-            ]),
+            ])),
         )))
     }
 }
 
 impl ExtractBoundary for LineString3D {
-    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+    fn extract_boundary(&self) -> Result<Boundary, UnsupportedOperation> {
         let Some((first, last)) = endpoints(self.coords()) else {
-            return Ok(Geometry::None);
+            return Ok(Boundary::EMPTY);
         };
         let frame = self.frame();
-        Ok(Geometry::Euclidean3D(Euclidean3DGeometry::Collection(
-            Collection3D::new([
+        Ok(Boundary::Bounded(Geometry::Euclidean3D(
+            Euclidean3DGeometry::Collection(Collection3D::new([
                 Euclidean3DGeometry::Point(Point3D::new(frame.clone(), first)),
                 Euclidean3DGeometry::Point(Point3D::new(frame.clone(), last)),
-            ]),
+            ])),
         )))
     }
 }

--- a/engine/runtime/geometry/src/line_string/ops.rs
+++ b/engine/runtime/geometry/src/line_string/ops.rs
@@ -268,6 +268,45 @@ impl Footprint for LineString3D {
     }
 }
 
+use crate::collection::{Collection2D, Collection3D};
+use crate::ops::boundary::{endpoints, ExtractBoundary};
+use crate::point::{Point2D, Point3D};
+
+// A chain is bounded by its two ends. One that closes on itself has no ends, so
+// its boundary is empty.
+//
+// The ends come back as bare points, which carry no elevation of their own, so a
+// 2.5D chain's elevation is not preserved onto them.
+impl ExtractBoundary for LineString2D {
+    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+        let Some((first, last)) = endpoints(self.coords()) else {
+            return Ok(Geometry::None);
+        };
+        let frame = self.frame();
+        Ok(Geometry::Euclidean2D(Euclidean2DGeometry::Collection(
+            Collection2D::new([
+                Euclidean2DGeometry::Point(Point2D::new(frame.clone(), first)),
+                Euclidean2DGeometry::Point(Point2D::new(frame.clone(), last)),
+            ]),
+        )))
+    }
+}
+
+impl ExtractBoundary for LineString3D {
+    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+        let Some((first, last)) = endpoints(self.coords()) else {
+            return Ok(Geometry::None);
+        };
+        let frame = self.frame();
+        Ok(Geometry::Euclidean3D(Euclidean3DGeometry::Collection(
+            Collection3D::new([
+                Euclidean3DGeometry::Point(Point3D::new(frame.clone(), first)),
+                Euclidean3DGeometry::Point(Point3D::new(frame.clone(), last)),
+            ]),
+        )))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/ops/boundary.rs
+++ b/engine/runtime/geometry/src/ops/boundary.rs
@@ -1,0 +1,761 @@
+//! Boundary extraction.
+//!
+//! What bounds a geometry lies one dimension below it: a volume is bounded by
+//! surfaces, an area by curves, a curve by its two endpoints, and a set of
+//! points by nothing at all.
+
+use std::collections::HashMap;
+
+use crate::coordinate::CoordinateFrame;
+use crate::line_string::{LineString2D, LineString3D};
+use crate::ops::coerce::{wrap_2d, wrap_3d};
+use crate::ops::UnsupportedOperation;
+use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
+
+/// The boundary of a geometry: the shells bounding a volume, the rings bounding
+/// a surface, the endpoints bounding a curve.
+///
+/// * `Ok(geometry)`: the boundary.
+/// * `Ok(`[`Geometry::None`]`)`: the boundary is **empty**. The geometry closes
+///   on itself, or carries no extent to bound. An answer, not a failure.
+/// * `Err(`[`UnsupportedOperation`]`)`: the type has no boundary to report at
+///   all. Today only an unevaluated [`Csg`](crate::csg::Csg) tree and an absent
+///   geometry.
+///
+/// A face's rings come out verbatim, neither re-wound nor re-closed. Appearance
+/// is dropped from the curves a surface or face bounds, whose per-corner UV no
+/// longer applies, and kept on the shells a volume bounds. A 2.5D chain's
+/// endpoints come back as bare points, which have no elevation slot, so its
+/// elevation is lost.
+///
+/// A container takes the boundary of each member and sets the results side by
+/// side in a container of the same kind, keeping the attributes of the members
+/// that contributed; it reports `Err` only when it has members and *every* one
+/// of them did. Endpoints shared
+/// by two members are **not** cancelled against each other: cancellation happens
+/// only at shared vertex indices within one surface, never by matching
+/// coordinates, which float noise makes unreliable.
+#[enum_dispatch::enum_dispatch]
+pub trait ExtractBoundary {
+    /// This geometry's boundary.
+    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+        Err(unsupported::<Self>())
+    }
+}
+
+// The boxed enum variants (`Box<Polygon3D>`, `Box<Solid>`, …) need the trait on
+// the `Box` itself: `enum_dispatch` forwards by UFCS, not auto-deref.
+impl<T: ExtractBoundary + ?Sized> ExtractBoundary for Box<T> {
+    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+        (**self).extract_boundary()
+    }
+}
+
+/// This type has no boundary to report.
+pub(crate) fn unsupported<T: ?Sized>() -> UnsupportedOperation {
+    UnsupportedOperation {
+        geometry: core::any::type_name::<T>(),
+        operation: "extract_boundary",
+    }
+}
+
+/// The two ends of an open chain. A chain whose ends meet closes on itself, and
+/// one with fewer than two coordinates has no span, so neither is bounded.
+pub(crate) fn endpoints<const N: usize>(coords: &[[f64; N]]) -> Option<([f64; N], [f64; N])> {
+    let (first, last) = (coords.first()?, coords.last()?);
+    if coords.len() < 2 || first == last {
+        return None;
+    }
+    Some((*first, *last))
+}
+
+/// Counts how many face corners walk each edge of a surface, so the edges only
+/// one of them walks, the surface's boundary, can be chained into rings.
+///
+/// Edges are keyed by vertex index, so corners the mesh keeps distinct stay
+/// distinct. Meshes built from polygons or from a triangle soup deduplicate
+/// their corners by exact bits, so their faces already share the vertices they
+/// meet at; a caller-supplied pool that repeats a position instead reports both
+/// copies as boundary, which is the truth for faces that pool does not join.
+#[derive(Default)]
+pub(crate) struct BoundaryEdges {
+    /// Undirected edge `[min, max]` to how many corners walked it and the
+    /// direction the first of them took, so a boundary ring inherits the winding
+    /// of the face it came off.
+    seen: HashMap<[u32; 2], (u32, [u32; 2])>,
+}
+
+impl BoundaryEdges {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Walk one face ring, stored open or closed. A face ring always closes, so
+    /// its last vertex is joined back to its first either way.
+    pub(crate) fn add_ring(&mut self, ring: &[u32]) {
+        // A ring stored closed repeats its first vertex last; that repeat is not
+        // a corner of its own.
+        let n = match ring.split_last() {
+            Some((last, rest)) if !rest.is_empty() && *last == ring[0] => rest.len(),
+            _ => ring.len(),
+        };
+        if n < 2 {
+            return;
+        }
+        for i in 0..n {
+            self.add_edge(ring[i], ring[(i + 1) % n]);
+        }
+    }
+
+    /// Walk one triangle, whose corners close implicitly.
+    pub(crate) fn add_triangle(&mut self, [i, j, k]: [u32; 3]) {
+        self.add_edge(i, j);
+        self.add_edge(j, k);
+        self.add_edge(k, i);
+    }
+
+    fn add_edge(&mut self, from: u32, to: u32) {
+        // A corner repeated back to back spans nothing.
+        if from == to {
+            return;
+        }
+        let key = if from < to { [from, to] } else { [to, from] };
+        self.seen.entry(key).or_insert((0, [from, to])).0 += 1;
+    }
+
+    /// The boundary edges chained into paths of vertex indices, a path that
+    /// closes repeating its first index last. Empty when the surface is closed.
+    pub(crate) fn into_paths(self) -> Vec<Vec<u32>> {
+        // Only an edge a single corner walked bounds the surface: two means two
+        // faces meet along it, more means they branch there. Two coincident
+        // copies of one face therefore cancel each other out, and the doubled
+        // surface reports itself closed.
+        let mut edges: Vec<[u32; 2]> = self
+            .seen
+            .into_values()
+            .filter_map(|(walks, edge)| (walks == 1).then_some(edge))
+            .collect();
+        if edges.is_empty() {
+            return Vec::new();
+        }
+        // Hash order is not stable across runs, so the same surface has to be
+        // put back in order to chain the same way twice.
+        edges.sort_unstable();
+
+        // Chaining ignores which way each edge was walked. Neighbouring faces
+        // may be wound against each other, and a ring has to close regardless;
+        // following the walked directions would leave it open.
+        let mut incident: HashMap<u32, Vec<usize>> = HashMap::new();
+        for (i, &[from, to]) in edges.iter().enumerate() {
+            incident.entry(from).or_default().push(i);
+            incident.entry(to).or_default().push(i);
+        }
+
+        let mut walked = vec![false; edges.len()];
+        let mut paths = Vec::new();
+        // Open chains first, from the vertices an odd number of boundary edges
+        // meet at, which can only be ends. Starting mid-chain would cut it in two.
+        let odd = |v: u32| incident.get(&v).is_some_and(|at| at.len() % 2 == 1);
+        for start in 0..edges.len() {
+            if walked[start] {
+                continue;
+            }
+            let [from, to] = edges[start];
+            // `from` first, so a chain leaves the way its face walked it.
+            let end = if odd(from) {
+                from
+            } else if odd(to) {
+                to
+            } else {
+                continue;
+            };
+            paths.push(walk(end, &edges, &incident, &mut walked));
+        }
+        // Every edge not on one of those chains lies on a ring that closes.
+        for start in 0..edges.len() {
+            if !walked[start] {
+                paths.push(walk(edges[start][0], &edges, &incident, &mut walked));
+            }
+        }
+        paths
+    }
+}
+
+/// Follow boundary edges from `start` until the path closes on its own first
+/// vertex or leaves no unwalked edge to take, marking each edge walked.
+fn walk(
+    start: u32,
+    edges: &[[u32; 2]],
+    incident: &HashMap<u32, Vec<usize>>,
+    walked: &mut [bool],
+) -> Vec<u32> {
+    let mut path = vec![start];
+    let mut current = start;
+    while let Some(next) = incident
+        .get(&current)
+        .and_then(|at| at.iter().copied().find(|&i| !walked[i]))
+    {
+        walked[next] = true;
+        let [from, to] = edges[next];
+        current = if from == current { to } else { from };
+        path.push(current);
+        if current == path[0] {
+            break;
+        }
+    }
+    path
+}
+
+/// The boundary a 2D surface's ledger describes, at the surface's elevation.
+/// [`Geometry::None`] when the surface is closed.
+pub(crate) fn surface_boundary_2d(
+    frame: &CoordinateFrame,
+    vertices: &[[f64; 2]],
+    elevation: Option<f64>,
+    edges: BoundaryEdges,
+) -> Geometry {
+    let lines = edges
+        .into_paths()
+        .into_iter()
+        .map(|path| {
+            let coords = path.into_iter().map(|i| vertices[i as usize]);
+            Euclidean2DGeometry::LineString(match elevation {
+                None => LineString2D::from_coords(frame.clone(), coords),
+                Some(elevation) => {
+                    LineString2D::from_coords_at_elevation(frame.clone(), coords, elevation)
+                }
+            })
+        })
+        .collect();
+    wrap_2d(lines).unwrap_or(Geometry::None)
+}
+
+/// The 3D counterpart of [`surface_boundary_2d`].
+pub(crate) fn surface_boundary_3d(
+    frame: &CoordinateFrame,
+    vertices: &[[f64; 3]],
+    edges: BoundaryEdges,
+) -> Geometry {
+    let lines = edges
+        .into_paths()
+        .into_iter()
+        .map(|path| {
+            let coords = path.into_iter().map(|i| vertices[i as usize]);
+            Euclidean3DGeometry::LineString(LineString3D::from_coords(frame.clone(), coords))
+        })
+        .collect();
+    wrap_3d(lines).unwrap_or(Geometry::None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::collection::{Collection2D, Collection3D};
+    use crate::csg::Csg;
+    use crate::point::{Point2D, Point3D};
+    use crate::point_cloud::PointCloud;
+    use crate::polygon::{Polygon2D, Polygon3D};
+    use crate::polygon_mesh::{PolygonMesh2D, PolygonMesh3D, PolygonMesh3DData};
+    use crate::solid::{Shell, Solid};
+    use crate::triangular_mesh::{TriangularMesh2D, TriangularMesh3D};
+    use crate::GeometryCollection;
+    use pretty_assertions::assert_eq;
+    use reearth_flow_common::attribute::{Attribute, AttributeValue, Attributes};
+
+    /// A closed 4x4 square, as an exterior ring.
+    const SQUARE: [[f64; 3]; 5] = [
+        [0.0, 0.0, 0.0],
+        [4.0, 0.0, 0.0],
+        [4.0, 4.0, 0.0],
+        [0.0, 4.0, 0.0],
+        [0.0, 0.0, 0.0],
+    ];
+
+    /// [`SQUARE`] without its z.
+    const SQUARE_2D: [[f64; 2]; 5] = [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]];
+
+    /// A closed square hole ring of side 2, centred in [`SQUARE`].
+    fn hole_ring() -> Vec<[f64; 3]> {
+        vec![
+            [1.0, 1.0, 0.0],
+            [1.0, 3.0, 0.0],
+            [3.0, 3.0, 0.0],
+            [3.0, 1.0, 0.0],
+            [1.0, 1.0, 0.0],
+        ]
+    }
+
+    fn face(holes: usize) -> Polygon3D {
+        Polygon3D::from_rings(
+            CoordinateFrame::Euclidean,
+            SQUARE,
+            (0..holes).map(|_| hole_ring()),
+        )
+    }
+
+    fn g3(g: Euclidean3DGeometry) -> Geometry {
+        Geometry::Euclidean3D(g)
+    }
+
+    fn point() -> Euclidean3DGeometry {
+        Euclidean3DGeometry::Point(Point3D::new(CoordinateFrame::Euclidean, [0.0; 3]))
+    }
+
+    fn csg() -> Euclidean3DGeometry {
+        Euclidean3DGeometry::Csg(Csg::union(
+            Solid::from_exterior(
+                CoordinateFrame::Euclidean,
+                PolygonMesh3DData::from_polygons([&face(0)]),
+            ),
+            Solid::from_exterior(
+                CoordinateFrame::Euclidean,
+                PolygonMesh3DData::from_polygons([&face(0)]),
+            ),
+        ))
+    }
+
+    /// A closed tetrahedron as a triangle mesh: every edge is walked twice.
+    fn tetrahedron() -> TriangularMesh3D {
+        TriangularMesh3D::from_parts(
+            CoordinateFrame::Euclidean,
+            vec![
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            [0u32, 2, 1, 0, 1, 3, 0, 3, 2, 1, 2, 3],
+        )
+        .unwrap()
+    }
+
+    /// The parts of a boundary: the chain of every polyline, or the position of
+    /// every point, in emission order.
+    fn chains_3d(geometry: &Geometry) -> Vec<Vec<[f64; 3]>> {
+        fn parts(g: &Euclidean3DGeometry) -> Vec<Vec<[f64; 3]>> {
+            match g {
+                Euclidean3DGeometry::LineString(l) => vec![l.coords().to_vec()],
+                Euclidean3DGeometry::Point(p) => vec![vec![p.position()]],
+                Euclidean3DGeometry::Collection(c) => c.members().iter().flat_map(parts).collect(),
+                other => panic!("unexpected boundary part {other:?}"),
+            }
+        }
+        match geometry {
+            Geometry::Euclidean3D(g) => parts(g),
+            other => panic!("expected a 3D boundary, got {other:?}"),
+        }
+    }
+
+    /// The undirected edges a set of chains covers, panicking on a repeat: every
+    /// boundary edge must be handed back exactly once.
+    fn edges_of(chains: &[Vec<[f64; 3]>]) -> Vec<([u64; 3], [u64; 3])> {
+        let key = |p: [f64; 3]| p.map(f64::to_bits);
+        let mut seen = Vec::new();
+        for chain in chains {
+            for pair in chain.windows(2) {
+                let (a, b) = (key(pair[0]), key(pair[1]));
+                let edge = if a <= b { (a, b) } else { (b, a) };
+                assert!(!seen.contains(&edge), "edge handed back twice");
+                seen.push(edge);
+            }
+        }
+        seen
+    }
+
+    fn boundary(geometry: &impl ExtractBoundary) -> Geometry {
+        geometry.extract_boundary().expect("bounded")
+    }
+
+    #[test]
+    fn a_face_is_bounded_by_its_rings_exterior_first() {
+        assert_eq!(chains_3d(&boundary(&face(0))), vec![SQUARE.to_vec()]);
+        assert_eq!(
+            chains_3d(&boundary(&face(1))),
+            vec![SQUARE.to_vec(), hole_ring()]
+        );
+    }
+
+    #[test]
+    fn a_face_with_no_exterior_ring_has_no_boundary_to_give() {
+        let empty = Polygon3D::from_rings(
+            CoordinateFrame::Euclidean,
+            Vec::<[f64; 3]>::new(),
+            Vec::<Vec<[f64; 3]>>::new(),
+        );
+        assert!(empty.extract_boundary().is_err());
+    }
+
+    #[test]
+    fn a_2d_face_carries_its_elevation_onto_its_rings() {
+        let face = Polygon2D::from_rings_at_elevation(
+            CoordinateFrame::Euclidean,
+            SQUARE_2D,
+            Vec::<Vec<[f64; 2]>>::new(),
+            7.5,
+        );
+        let Geometry::Euclidean2D(Euclidean2DGeometry::LineString(line)) = boundary(&face) else {
+            panic!("expected one polyline");
+        };
+        assert_eq!(line.elevation(), Some(7.5));
+    }
+
+    #[test]
+    fn an_open_chain_is_bounded_by_its_two_ends() {
+        let chain = LineString3D::from_coords(
+            CoordinateFrame::Euclidean,
+            [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0], [2.0, 0.0, 0.0]],
+        );
+        assert_eq!(
+            chains_3d(&boundary(&chain)),
+            vec![vec![[0.0, 0.0, 0.0]], vec![[2.0, 0.0, 0.0]]]
+        );
+    }
+
+    #[test]
+    fn a_chain_that_closes_or_spans_nothing_is_bounded_by_nothing() {
+        for coords in [
+            SQUARE.to_vec(),
+            vec![[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+            vec![[0.0, 0.0, 0.0]],
+            Vec::new(),
+        ] {
+            let chain = LineString3D::from_coords(CoordinateFrame::Euclidean, coords);
+            assert_eq!(boundary(&chain), Geometry::None);
+        }
+    }
+
+    #[test]
+    fn a_position_is_bounded_by_nothing() {
+        let cloud = PointCloud::from_positions(CoordinateFrame::Euclidean, [[0.0, 0.0, 0.0]]);
+        assert_eq!(boundary(&point()), Geometry::None);
+        assert_eq!(
+            boundary(&Point2D::new(CoordinateFrame::Euclidean, [0.0, 0.0])),
+            Geometry::None
+        );
+        assert_eq!(boundary(&cloud), Geometry::None);
+    }
+
+    #[test]
+    fn an_unevaluated_boolean_tree_and_an_absent_geometry_have_no_boundary_to_give() {
+        assert!(g3(csg()).extract_boundary().is_err());
+        assert!(Geometry::None.extract_boundary().is_err());
+    }
+
+    // Two triangles sharing an edge: that edge is walked twice and drops out, so
+    // the four outer edges chain into the one ring around the pair.
+    #[test]
+    fn a_surface_is_bounded_by_the_edges_only_one_face_walks() {
+        let mesh = TriangularMesh3D::from_parts(
+            CoordinateFrame::Euclidean,
+            vec![
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [1.0, 1.0, 0.0],
+                [0.0, 1.0, 0.0],
+            ],
+            [0u32, 1, 2, 0, 2, 3],
+        )
+        .unwrap();
+        let rings = chains_3d(&boundary(&mesh));
+        assert_eq!(rings.len(), 1);
+        let ring = &rings[0];
+        // A closed ring around all four corners, repeating where it began.
+        assert_eq!(ring.len(), 5);
+        assert_eq!(ring.first(), ring.last());
+        // Every corner once, so the ring goes round the pair rather than
+        // doubling back over one triangle.
+        for corner in [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [0.0, 1.0, 0.0],
+        ] {
+            assert_eq!(ring[..4].iter().filter(|&&c| c == corner).count(), 1);
+        }
+        // The shared diagonal is not part of it.
+        assert!(!ring.windows(2).any(|e| {
+            (e[0] == [0.0, 0.0, 0.0] && e[1] == [1.0, 1.0, 0.0])
+                || (e[0] == [1.0, 1.0, 0.0] && e[1] == [0.0, 0.0, 0.0])
+        }));
+    }
+
+    // Neighbouring faces wound against each other still bound one closed ring:
+    // chaining follows the edges, not the direction they were walked in.
+    #[test]
+    fn a_surface_whose_faces_disagree_on_winding_still_closes() {
+        let mesh = TriangularMesh3D::from_parts(
+            CoordinateFrame::Euclidean,
+            vec![
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [1.0, 1.0, 0.0],
+                [0.0, 1.0, 0.0],
+            ],
+            // The second triangle walks the shared edge 0-2 the same way as the
+            // first, so the pair is wound inconsistently.
+            [0u32, 1, 2, 0, 3, 2],
+        )
+        .unwrap();
+        let rings = chains_3d(&boundary(&mesh));
+        assert_eq!(rings.len(), 1);
+        assert_eq!(rings[0].len(), 5);
+        assert_eq!(rings[0].first(), rings[0].last());
+    }
+
+    #[test]
+    fn a_closed_shell_is_bounded_by_nothing() {
+        assert_eq!(boundary(&tetrahedron()), Geometry::None);
+    }
+
+    // A hole no neighbouring face fills is walked once, like any outer edge, so
+    // the surface is bounded by both rings.
+    #[test]
+    fn a_surface_is_bounded_by_the_hole_rings_nothing_fills() {
+        let mesh = PolygonMesh3D::from_polygons(CoordinateFrame::Euclidean, [&face(1)]).unwrap();
+        let rings = chains_3d(&boundary(&mesh));
+        assert_eq!(rings.len(), 2);
+        for ring in &rings {
+            assert_eq!(ring.len(), 5);
+            assert_eq!(ring.first(), ring.last());
+        }
+    }
+
+    #[test]
+    fn a_2d_surface_carries_its_elevation_onto_its_boundary() {
+        let corners = vec![[0.0, 0.0], [2.0, 0.0], [2.0, 2.0]];
+        let faces = PolygonMesh2D::from_parts_at_elevation(
+            CoordinateFrame::Euclidean,
+            corners.clone(),
+            vec![vec![0u32, 1, 2]],
+            3.0,
+        )
+        .unwrap();
+        let triangles = TriangularMesh2D::from_parts_at_elevation(
+            CoordinateFrame::Euclidean,
+            corners,
+            [0u32, 1, 2],
+            3.0,
+        )
+        .unwrap();
+        for boundary in [boundary(&faces), boundary(&triangles)] {
+            let Geometry::Euclidean2D(Euclidean2DGeometry::LineString(line)) = boundary else {
+                panic!("expected one ring");
+            };
+            assert_eq!(line.elevation(), Some(3.0));
+            assert_eq!(line.coords().len(), 4);
+        }
+    }
+
+    #[test]
+    fn an_empty_surface_is_bounded_by_nothing() {
+        let mesh =
+            PolygonMesh3D::from_parts(CoordinateFrame::Euclidean, vec![], Vec::<Vec<u32>>::new())
+                .unwrap();
+        assert_eq!(boundary(&mesh), Geometry::None);
+    }
+
+    // Vertices the pool keeps distinct are distinct corners, so faces it does not
+    // join are not joined here either.
+    #[test]
+    fn faces_the_vertex_pool_does_not_join_stay_apart() {
+        let mesh = TriangularMesh3D::from_parts(
+            CoordinateFrame::Euclidean,
+            vec![
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [1.0, 1.0, 0.0],
+                // The same three positions again, under their own indices.
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [1.0, 1.0, 0.0],
+            ],
+            [0u32, 1, 2, 3, 4, 5],
+        )
+        .unwrap();
+        assert_eq!(chains_3d(&boundary(&mesh)).len(), 2);
+    }
+
+    // Three faces sharing one edge: that edge is walked three times, so it is no
+    // more a boundary than a shared edge is. How the six that remain split at the
+    // junction is arbitrary, but every one of them must come back exactly once,
+    // and none may come back as a stranded two-vertex fragment.
+    #[test]
+    fn a_branching_boundary_comes_back_whole() {
+        let mesh = PolygonMesh3D::from_parts(
+            CoordinateFrame::Euclidean,
+            vec![
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [0.0, -1.0, 0.0],
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [2.0, 0.0, 0.0],
+            ],
+            vec![vec![4u32, 5, 0], vec![4, 5, 1], vec![4, 5, 2]],
+        )
+        .unwrap();
+        let chains = chains_3d(&boundary(&mesh));
+        assert_eq!(edges_of(&chains).len(), 6);
+        assert!(chains.iter().all(|c| c.len() > 2));
+    }
+
+    #[test]
+    fn a_volume_is_bounded_by_its_shells_exterior_first() {
+        let solid = Solid::new(
+            CoordinateFrame::Euclidean,
+            PolygonMesh3DData::from_polygons([&face(0)]),
+            vec![Shell::from(PolygonMesh3DData::from_polygons([&face(1)]))],
+        );
+        let Geometry::Euclidean3D(Euclidean3DGeometry::Collection(shells)) = boundary(&solid)
+        else {
+            panic!("expected the two shells");
+        };
+        assert_eq!(shells.members().len(), 2);
+        for member in shells.members() {
+            assert!(matches!(member, Euclidean3DGeometry::PolygonMesh(_)));
+        }
+    }
+
+    // Twice over: the shells of a watertight volume are bounded by nothing, which
+    // is what makes them watertight.
+    #[test]
+    fn the_boundary_of_a_closed_volumes_boundary_is_empty() {
+        let solid = Solid::from_exterior(CoordinateFrame::Euclidean, tetrahedron().into_data());
+        let shell = boundary(&solid);
+        assert_eq!(boundary(&shell), Geometry::None);
+    }
+
+    #[test]
+    fn a_container_sets_its_members_boundaries_side_by_side() {
+        let c = Collection3D::new([
+            Euclidean3DGeometry::Polygon(Box::new(face(0))),
+            Euclidean3DGeometry::Polygon(Box::new(face(1))),
+        ]);
+        let rings = chains_3d(&boundary(&g3(Euclidean3DGeometry::Collection(c))));
+        assert_eq!(rings.len(), 3);
+    }
+
+    // One curve among the surfaces must not discard the surfaces, and a member
+    // bounded by nothing contributes nothing rather than an empty slot.
+    #[test]
+    fn a_container_skips_the_members_that_give_nothing() {
+        let c = Collection3D::new([
+            Euclidean3DGeometry::Polygon(Box::new(face(0))),
+            point(),
+            csg(),
+        ]);
+        let rings = chains_3d(&boundary(&g3(Euclidean3DGeometry::Collection(c))));
+        assert_eq!(rings, vec![SQUARE.to_vec()]);
+    }
+
+    #[test]
+    fn a_container_no_member_of_which_has_a_boundary_has_none_to_give() {
+        let c = Collection3D::new([csg()]);
+        assert!(g3(Euclidean3DGeometry::Collection(c))
+            .extract_boundary()
+            .is_err());
+    }
+
+    #[test]
+    fn a_container_whose_members_are_all_bounded_by_nothing_is_bounded_by_nothing() {
+        let c = Collection3D::new([point(), point()]);
+        assert_eq!(
+            boundary(&g3(Euclidean3DGeometry::Collection(c))),
+            Geometry::None
+        );
+        assert_eq!(
+            boundary(&g3(Euclidean3DGeometry::Collection(Collection3D::new(
+                Vec::new()
+            )))),
+            Geometry::None
+        );
+    }
+
+    // A container's boundary is a container of the same kind, whatever its
+    // members bound, so a downstream match does not turn on how many of them
+    // contributed or on whether the source carried child attributes.
+    #[test]
+    fn a_2d_container_stays_a_two_dimensional_container() {
+        let c = Collection2D::new([Euclidean2DGeometry::Polygon(Box::new(
+            Polygon2D::from_rings(
+                CoordinateFrame::Euclidean,
+                SQUARE_2D,
+                Vec::<Vec<[f64; 2]>>::new(),
+            ),
+        ))]);
+        let Geometry::Euclidean2D(Euclidean2DGeometry::Collection(out)) =
+            boundary(&Geometry::Euclidean2D(Euclidean2DGeometry::Collection(c)))
+        else {
+            panic!("expected a 2D collection");
+        };
+        assert!(matches!(
+            out.members(),
+            [Euclidean2DGeometry::LineString(_)]
+        ));
+    }
+
+    #[test]
+    fn boundaries_reach_through_nested_collections() {
+        let inner = Geometry::GeometryCollection(GeometryCollection::new([g3(
+            Euclidean3DGeometry::Polygon(Box::new(face(0))),
+        )]));
+        let outer = Geometry::GeometryCollection(GeometryCollection::new([
+            inner,
+            g3(Euclidean3DGeometry::Polygon(Box::new(face(1)))),
+            Geometry::None,
+        ]));
+        let Geometry::GeometryCollection(out) = boundary(&outer) else {
+            panic!("expected a geometry collection");
+        };
+        // The absent member has no boundary to give and drops out.
+        assert_eq!(out.members().len(), 2);
+    }
+
+    #[test]
+    fn a_container_keeps_the_attributes_lined_up_when_a_member_drops_out() {
+        let attrs = |n: i64| {
+            Attributes::from([(
+                Attribute::new("lod"),
+                AttributeValue::Number(serde_json::Number::from(n)),
+            )])
+        };
+        let members = vec![
+            g3(point()),
+            g3(Euclidean3DGeometry::Polygon(Box::new(face(0)))),
+        ];
+        let g = Geometry::GeometryCollection(
+            GeometryCollection::with_attributes(members, vec![attrs(1), attrs(2)]).unwrap(),
+        );
+        let Geometry::GeometryCollection(out) = boundary(&g) else {
+            panic!("expected a geometry collection");
+        };
+        assert_eq!(out.members().len(), 1);
+        assert_eq!(out.member_attributes(), [attrs(2)]);
+    }
+
+    // Hash iteration order is not stable, so the same surface has to chain the
+    // same way every time or downstream splits would shuffle between runs. The
+    // faces are disjoint, so several rings come back and there is an order to get
+    // wrong.
+    #[test]
+    fn chaining_the_same_surface_twice_gives_the_same_answer() {
+        let offset = |d: f64| {
+            Polygon3D::from_rings(
+                CoordinateFrame::Euclidean,
+                SQUARE.map(|[x, y, z]| [x + d, y, z]),
+                Vec::<Vec<[f64; 3]>>::new(),
+            )
+        };
+        let mesh = PolygonMesh3D::from_polygons(
+            CoordinateFrame::Euclidean,
+            [&face(1), &offset(10.0), &offset(20.0)],
+        )
+        .unwrap();
+        // Two rings from the holed face, one from each disjoint square.
+        assert_eq!(chains_3d(&boundary(&mesh)).len(), 4);
+        let first = boundary(&mesh);
+        for _ in 0..8 {
+            assert_eq!(boundary(&mesh), first);
+        }
+    }
+}

--- a/engine/runtime/geometry/src/ops/boundary.rs
+++ b/engine/runtime/geometry/src/ops/boundary.rs
@@ -1,8 +1,5 @@
-//! Boundary extraction.
-//!
-//! What bounds a geometry lies one dimension below it: a volume is bounded by
-//! surfaces, an area by curves, a curve by its two endpoints, and a set of
-//! points by nothing at all.
+//! Boundary extraction: a volume is bounded by surfaces, an area by curves, a
+//! curve by its two endpoints, and a set of points by nothing at all.
 
 use std::collections::HashMap;
 
@@ -16,25 +13,19 @@ use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
 /// a surface, the endpoints bounding a curve.
 ///
 /// * `Ok(geometry)`: the boundary.
-/// * `Ok(`[`Geometry::None`]`)`: the boundary is **empty**. The geometry closes
-///   on itself, or carries no extent to bound. An answer, not a failure.
+/// * `Ok(`[`Geometry::None`]`)`: the boundary is empty.
 /// * `Err(`[`UnsupportedOperation`]`)`: the type has no boundary to report at
-///   all. Today only an unevaluated [`Csg`](crate::csg::Csg) tree and an absent
-///   geometry.
+///   all.
 ///
 /// A face's rings come out verbatim, neither re-wound nor re-closed. Appearance
-/// is dropped from the curves a surface or face bounds, whose per-corner UV no
-/// longer applies, and kept on the shells a volume bounds. A 2.5D chain's
-/// endpoints come back as bare points, which have no elevation slot, so its
-/// elevation is lost.
+/// is dropped from bounding curves and kept on the shells a volume bounds. A
+/// 2.5D chain's endpoints lose its elevation, having no slot for one.
 ///
-/// A container takes the boundary of each member and sets the results side by
-/// side in a container of the same kind, keeping the attributes of the members
-/// that contributed; it reports `Err` only when it has members and *every* one
-/// of them did. Endpoints shared
-/// by two members are **not** cancelled against each other: cancellation happens
-/// only at shared vertex indices within one surface, never by matching
-/// coordinates, which float noise makes unreliable.
+/// A container bounds each member into a container of the same kind, keeping the
+/// attributes of the members that contributed, and reports `Err` only when every
+/// member did. Endpoints shared by two members are not cancelled against each
+/// other: cancellation happens only at shared vertex indices within one surface,
+/// never by matching coordinates, which float noise makes unreliable.
 #[enum_dispatch::enum_dispatch]
 pub trait ExtractBoundary {
     /// This geometry's boundary.
@@ -51,7 +42,6 @@ impl<T: ExtractBoundary + ?Sized> ExtractBoundary for Box<T> {
     }
 }
 
-/// This type has no boundary to report.
 pub(crate) fn unsupported<T: ?Sized>() -> UnsupportedOperation {
     UnsupportedOperation {
         geometry: core::any::type_name::<T>(),
@@ -59,8 +49,8 @@ pub(crate) fn unsupported<T: ?Sized>() -> UnsupportedOperation {
     }
 }
 
-/// The two ends of an open chain. A chain whose ends meet closes on itself, and
-/// one with fewer than two coordinates has no span, so neither is bounded.
+/// The two ends of an open chain, or `None` if it closes on itself or spans
+/// nothing.
 pub(crate) fn endpoints<const N: usize>(coords: &[[f64; N]]) -> Option<([f64; N], [f64; N])> {
     let (first, last) = (coords.first()?, coords.last()?);
     if coords.len() < 2 || first == last {
@@ -70,18 +60,15 @@ pub(crate) fn endpoints<const N: usize>(coords: &[[f64; N]]) -> Option<([f64; N]
 }
 
 /// Counts how many face corners walk each edge of a surface, so the edges only
-/// one of them walks, the surface's boundary, can be chained into rings.
+/// one of them walks, its boundary, can be chained into rings.
 ///
 /// Edges are keyed by vertex index, so corners the mesh keeps distinct stay
-/// distinct. Meshes built from polygons or from a triangle soup deduplicate
-/// their corners by exact bits, so their faces already share the vertices they
-/// meet at; a caller-supplied pool that repeats a position instead reports both
-/// copies as boundary, which is the truth for faces that pool does not join.
+/// distinct: a pool that repeats a position reports both copies as boundary,
+/// which is the truth for faces it does not join.
 #[derive(Default)]
 pub(crate) struct BoundaryEdges {
     /// Undirected edge `[min, max]` to how many corners walked it and the
-    /// direction the first of them took, so a boundary ring inherits the winding
-    /// of the face it came off.
+    /// direction the first of them took.
     seen: HashMap<[u32; 2], (u32, [u32; 2])>,
 }
 
@@ -90,11 +77,8 @@ impl BoundaryEdges {
         Self::default()
     }
 
-    /// Walk one face ring, stored open or closed. A face ring always closes, so
-    /// its last vertex is joined back to its first either way.
+    /// Walk one face ring, stored open or closed: it closes either way.
     pub(crate) fn add_ring(&mut self, ring: &[u32]) {
-        // A ring stored closed repeats its first vertex last; that repeat is not
-        // a corner of its own.
         let n = match ring.split_last() {
             Some((last, rest)) if !rest.is_empty() && *last == ring[0] => rest.len(),
             _ => ring.len(),
@@ -107,7 +91,6 @@ impl BoundaryEdges {
         }
     }
 
-    /// Walk one triangle, whose corners close implicitly.
     pub(crate) fn add_triangle(&mut self, [i, j, k]: [u32; 3]) {
         self.add_edge(i, j);
         self.add_edge(j, k);
@@ -126,10 +109,6 @@ impl BoundaryEdges {
     /// The boundary edges chained into paths of vertex indices, a path that
     /// closes repeating its first index last. Empty when the surface is closed.
     pub(crate) fn into_paths(self) -> Vec<Vec<u32>> {
-        // Only an edge a single corner walked bounds the surface: two means two
-        // faces meet along it, more means they branch there. Two coincident
-        // copies of one face therefore cancel each other out, and the doubled
-        // surface reports itself closed.
         let mut edges: Vec<[u32; 2]> = self
             .seen
             .into_values()
@@ -138,13 +117,9 @@ impl BoundaryEdges {
         if edges.is_empty() {
             return Vec::new();
         }
-        // Hash order is not stable across runs, so the same surface has to be
-        // put back in order to chain the same way twice.
+
         edges.sort_unstable();
 
-        // Chaining ignores which way each edge was walked. Neighbouring faces
-        // may be wound against each other, and a ring has to close regardless;
-        // following the walked directions would leave it open.
         let mut incident: HashMap<u32, Vec<usize>> = HashMap::new();
         for (i, &[from, to]) in edges.iter().enumerate() {
             incident.entry(from).or_default().push(i);
@@ -153,15 +128,12 @@ impl BoundaryEdges {
 
         let mut walked = vec![false; edges.len()];
         let mut paths = Vec::new();
-        // Open chains first, from the vertices an odd number of boundary edges
-        // meet at, which can only be ends. Starting mid-chain would cut it in two.
         let odd = |v: u32| incident.get(&v).is_some_and(|at| at.len() % 2 == 1);
         for start in 0..edges.len() {
             if walked[start] {
                 continue;
             }
             let [from, to] = edges[start];
-            // `from` first, so a chain leaves the way its face walked it.
             let end = if odd(from) {
                 from
             } else if odd(to) {
@@ -171,7 +143,6 @@ impl BoundaryEdges {
             };
             paths.push(walk(end, &edges, &incident, &mut walked));
         }
-        // Every edge not on one of those chains lies on a ring that closes.
         for start in 0..edges.len() {
             if !walked[start] {
                 paths.push(walk(edges[start][0], &edges, &incident, &mut walked));
@@ -181,8 +152,7 @@ impl BoundaryEdges {
     }
 }
 
-/// Follow boundary edges from `start` until the path closes on its own first
-/// vertex or leaves no unwalked edge to take, marking each edge walked.
+/// Follow boundary edges from `start` until the path closes or runs out.
 fn walk(
     start: u32,
     edges: &[[u32; 2]],
@@ -206,7 +176,7 @@ fn walk(
     path
 }
 
-/// The boundary a 2D surface's ledger describes, at the surface's elevation.
+/// The boundary a 2D surface's ledger describes, at its elevation.
 /// [`Geometry::None`] when the surface is closed.
 pub(crate) fn surface_boundary_2d(
     frame: &CoordinateFrame,
@@ -250,19 +220,16 @@ pub(crate) fn surface_boundary_3d(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::collection::{Collection2D, Collection3D};
-    use crate::csg::Csg;
-    use crate::point::{Point2D, Point3D};
-    use crate::point_cloud::PointCloud;
-    use crate::polygon::{Polygon2D, Polygon3D};
-    use crate::polygon_mesh::{PolygonMesh2D, PolygonMesh3D, PolygonMesh3DData};
-    use crate::solid::{Shell, Solid};
-    use crate::triangular_mesh::{TriangularMesh2D, TriangularMesh3D};
+    use crate::point::Point3D;
+    use crate::polygon::Polygon3D;
+    use crate::polygon_mesh::PolygonMesh3D;
+    use crate::triangular_mesh::TriangularMesh3D;
     use crate::GeometryCollection;
     use pretty_assertions::assert_eq;
     use reearth_flow_common::attribute::{Attribute, AttributeValue, Attributes};
 
-    /// A closed 4x4 square, as an exterior ring.
+    /// Only the chaining is worth a test here: every other leaf hands its
+    /// boundary straight back, which reading the leaf's `ops.rs` shows.
     const SQUARE: [[f64; 3]; 5] = [
         [0.0, 0.0, 0.0],
         [4.0, 0.0, 0.0],
@@ -271,10 +238,6 @@ mod tests {
         [0.0, 0.0, 0.0],
     ];
 
-    /// [`SQUARE`] without its z.
-    const SQUARE_2D: [[f64; 2]; 5] = [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]];
-
-    /// A closed square hole ring of side 2, centred in [`SQUARE`].
     fn hole_ring() -> Vec<[f64; 3]> {
         vec![
             [1.0, 1.0, 0.0],
@@ -293,61 +256,27 @@ mod tests {
         )
     }
 
-    fn g3(g: Euclidean3DGeometry) -> Geometry {
-        Geometry::Euclidean3D(g)
+    fn boundary(geometry: &impl ExtractBoundary) -> Geometry {
+        geometry.extract_boundary().expect("bounded")
     }
 
-    fn point() -> Euclidean3DGeometry {
-        Euclidean3DGeometry::Point(Point3D::new(CoordinateFrame::Euclidean, [0.0; 3]))
-    }
-
-    fn csg() -> Euclidean3DGeometry {
-        Euclidean3DGeometry::Csg(Csg::union(
-            Solid::from_exterior(
-                CoordinateFrame::Euclidean,
-                PolygonMesh3DData::from_polygons([&face(0)]),
-            ),
-            Solid::from_exterior(
-                CoordinateFrame::Euclidean,
-                PolygonMesh3DData::from_polygons([&face(0)]),
-            ),
-        ))
-    }
-
-    /// A closed tetrahedron as a triangle mesh: every edge is walked twice.
-    fn tetrahedron() -> TriangularMesh3D {
-        TriangularMesh3D::from_parts(
-            CoordinateFrame::Euclidean,
-            vec![
-                [0.0, 0.0, 0.0],
-                [1.0, 0.0, 0.0],
-                [0.0, 1.0, 0.0],
-                [0.0, 0.0, 1.0],
-            ],
-            [0u32, 2, 1, 0, 1, 3, 0, 3, 2, 1, 2, 3],
-        )
-        .unwrap()
-    }
-
-    /// The parts of a boundary: the chain of every polyline, or the position of
-    /// every point, in emission order.
-    fn chains_3d(geometry: &Geometry) -> Vec<Vec<[f64; 3]>> {
+    /// The chain of every polyline a boundary is made of, in emission order.
+    fn chains(geometry: &Geometry) -> Vec<Vec<[f64; 3]>> {
         fn parts(g: &Euclidean3DGeometry) -> Vec<Vec<[f64; 3]>> {
             match g {
                 Euclidean3DGeometry::LineString(l) => vec![l.coords().to_vec()],
-                Euclidean3DGeometry::Point(p) => vec![vec![p.position()]],
                 Euclidean3DGeometry::Collection(c) => c.members().iter().flat_map(parts).collect(),
                 other => panic!("unexpected boundary part {other:?}"),
             }
         }
         match geometry {
             Geometry::Euclidean3D(g) => parts(g),
+            Geometry::None => Vec::new(),
             other => panic!("expected a 3D boundary, got {other:?}"),
         }
     }
 
-    /// The undirected edges a set of chains covers, panicking on a repeat: every
-    /// boundary edge must be handed back exactly once.
+    /// The undirected edges a set of chains covers, panicking on a repeat.
     fn edges_of(chains: &[Vec<[f64; 3]>]) -> Vec<([u64; 3], [u64; 3])> {
         let key = |p: [f64; 3]| p.map(f64::to_bits);
         let mut seen = Vec::new();
@@ -362,90 +291,19 @@ mod tests {
         seen
     }
 
-    fn boundary(geometry: &impl ExtractBoundary) -> Geometry {
-        geometry.extract_boundary().expect("bounded")
-    }
-
-    #[test]
-    fn a_face_is_bounded_by_its_rings_exterior_first() {
-        assert_eq!(chains_3d(&boundary(&face(0))), vec![SQUARE.to_vec()]);
-        assert_eq!(
-            chains_3d(&boundary(&face(1))),
-            vec![SQUARE.to_vec(), hole_ring()]
-        );
-    }
-
-    #[test]
-    fn a_face_with_no_exterior_ring_has_no_boundary_to_give() {
-        let empty = Polygon3D::from_rings(
-            CoordinateFrame::Euclidean,
-            Vec::<[f64; 3]>::new(),
-            Vec::<Vec<[f64; 3]>>::new(),
-        );
-        assert!(empty.extract_boundary().is_err());
-    }
-
-    #[test]
-    fn a_2d_face_carries_its_elevation_onto_its_rings() {
-        let face = Polygon2D::from_rings_at_elevation(
-            CoordinateFrame::Euclidean,
-            SQUARE_2D,
-            Vec::<Vec<[f64; 2]>>::new(),
-            7.5,
-        );
-        let Geometry::Euclidean2D(Euclidean2DGeometry::LineString(line)) = boundary(&face) else {
-            panic!("expected one polyline");
-        };
-        assert_eq!(line.elevation(), Some(7.5));
-    }
-
-    #[test]
-    fn an_open_chain_is_bounded_by_its_two_ends() {
-        let chain = LineString3D::from_coords(
-            CoordinateFrame::Euclidean,
-            [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0], [2.0, 0.0, 0.0]],
-        );
-        assert_eq!(
-            chains_3d(&boundary(&chain)),
-            vec![vec![[0.0, 0.0, 0.0]], vec![[2.0, 0.0, 0.0]]]
-        );
-    }
-
-    #[test]
-    fn a_chain_that_closes_or_spans_nothing_is_bounded_by_nothing() {
-        for coords in [
-            SQUARE.to_vec(),
-            vec![[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
-            vec![[0.0, 0.0, 0.0]],
-            Vec::new(),
-        ] {
-            let chain = LineString3D::from_coords(CoordinateFrame::Euclidean, coords);
-            assert_eq!(boundary(&chain), Geometry::None);
+    fn ring_lengths(geometry: &Geometry) -> Vec<usize> {
+        let rings = chains(geometry);
+        for ring in &rings {
+            assert_eq!(ring.first(), ring.last(), "a ring has to close");
         }
+        rings.iter().map(Vec::len).collect()
     }
 
     #[test]
-    fn a_position_is_bounded_by_nothing() {
-        let cloud = PointCloud::from_positions(CoordinateFrame::Euclidean, [[0.0, 0.0, 0.0]]);
-        assert_eq!(boundary(&point()), Geometry::None);
-        assert_eq!(
-            boundary(&Point2D::new(CoordinateFrame::Euclidean, [0.0, 0.0])),
-            Geometry::None
-        );
-        assert_eq!(boundary(&cloud), Geometry::None);
-    }
-
-    #[test]
-    fn an_unevaluated_boolean_tree_and_an_absent_geometry_have_no_boundary_to_give() {
-        assert!(g3(csg()).extract_boundary().is_err());
-        assert!(Geometry::None.extract_boundary().is_err());
-    }
-
-    // Two triangles sharing an edge: that edge is walked twice and drops out, so
-    // the four outer edges chain into the one ring around the pair.
-    #[test]
-    fn a_surface_is_bounded_by_the_edges_only_one_face_walks() {
-        let mesh = TriangularMesh3D::from_parts(
+    fn edges_two_faces_share_cancel_and_the_rest_close_into_rings() {
+        // Two triangles sharing a diagonal: the diagonal drops out and the four
+        // outer edges make one ring.
+        let pair = TriangularMesh3D::from_parts(
             CoordinateFrame::Euclidean,
             vec![
                 [0.0, 0.0, 0.0],
@@ -456,31 +314,30 @@ mod tests {
             [0u32, 1, 2, 0, 2, 3],
         )
         .unwrap();
-        let rings = chains_3d(&boundary(&mesh));
-        assert_eq!(rings.len(), 1);
-        let ring = &rings[0];
-        // A closed ring around all four corners, repeating where it began.
-        assert_eq!(ring.len(), 5);
-        assert_eq!(ring.first(), ring.last());
-        // Every corner once, so the ring goes round the pair rather than
-        // doubling back over one triangle.
-        for corner in [
-            [0.0, 0.0, 0.0],
-            [1.0, 0.0, 0.0],
-            [1.0, 1.0, 0.0],
-            [0.0, 1.0, 0.0],
-        ] {
-            assert_eq!(ring[..4].iter().filter(|&&c| c == corner).count(), 1);
-        }
-        // The shared diagonal is not part of it.
-        assert!(!ring.windows(2).any(|e| {
-            (e[0] == [0.0, 0.0, 0.0] && e[1] == [1.0, 1.0, 0.0])
-                || (e[0] == [1.0, 1.0, 0.0] && e[1] == [0.0, 0.0, 0.0])
-        }));
+        assert_eq!(ring_lengths(&boundary(&pair)), [5]);
+
+        // A closed tetrahedron: every edge is walked twice, so nothing is left.
+        let closed = TriangularMesh3D::from_parts(
+            CoordinateFrame::Euclidean,
+            vec![
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            [0u32, 2, 1, 0, 1, 3, 0, 3, 2, 1, 2, 3],
+        )
+        .unwrap();
+        assert_eq!(boundary(&closed), Geometry::None);
+
+        // A hole no neighbouring face fills is walked once, like any outer edge,
+        // so it bounds the surface too.
+        let holed = PolygonMesh3D::from_polygons(CoordinateFrame::Euclidean, [&face(1)]).unwrap();
+        assert_eq!(ring_lengths(&boundary(&holed)), [5, 5]);
     }
 
-    // Neighbouring faces wound against each other still bound one closed ring:
-    // chaining follows the edges, not the direction they were walked in.
+    // Chaining follows the edges, not the direction they were walked in, so faces
+    // wound against each other still bound one closed ring.
     #[test]
     fn a_surface_whose_faces_disagree_on_winding_still_closes() {
         let mesh = TriangularMesh3D::from_parts(
@@ -496,89 +353,13 @@ mod tests {
             [0u32, 1, 2, 0, 3, 2],
         )
         .unwrap();
-        let rings = chains_3d(&boundary(&mesh));
-        assert_eq!(rings.len(), 1);
-        assert_eq!(rings[0].len(), 5);
-        assert_eq!(rings[0].first(), rings[0].last());
+        assert_eq!(ring_lengths(&boundary(&mesh)), [5]);
     }
 
-    #[test]
-    fn a_closed_shell_is_bounded_by_nothing() {
-        assert_eq!(boundary(&tetrahedron()), Geometry::None);
-    }
-
-    // A hole no neighbouring face fills is walked once, like any outer edge, so
-    // the surface is bounded by both rings.
-    #[test]
-    fn a_surface_is_bounded_by_the_hole_rings_nothing_fills() {
-        let mesh = PolygonMesh3D::from_polygons(CoordinateFrame::Euclidean, [&face(1)]).unwrap();
-        let rings = chains_3d(&boundary(&mesh));
-        assert_eq!(rings.len(), 2);
-        for ring in &rings {
-            assert_eq!(ring.len(), 5);
-            assert_eq!(ring.first(), ring.last());
-        }
-    }
-
-    #[test]
-    fn a_2d_surface_carries_its_elevation_onto_its_boundary() {
-        let corners = vec![[0.0, 0.0], [2.0, 0.0], [2.0, 2.0]];
-        let faces = PolygonMesh2D::from_parts_at_elevation(
-            CoordinateFrame::Euclidean,
-            corners.clone(),
-            vec![vec![0u32, 1, 2]],
-            3.0,
-        )
-        .unwrap();
-        let triangles = TriangularMesh2D::from_parts_at_elevation(
-            CoordinateFrame::Euclidean,
-            corners,
-            [0u32, 1, 2],
-            3.0,
-        )
-        .unwrap();
-        for boundary in [boundary(&faces), boundary(&triangles)] {
-            let Geometry::Euclidean2D(Euclidean2DGeometry::LineString(line)) = boundary else {
-                panic!("expected one ring");
-            };
-            assert_eq!(line.elevation(), Some(3.0));
-            assert_eq!(line.coords().len(), 4);
-        }
-    }
-
-    #[test]
-    fn an_empty_surface_is_bounded_by_nothing() {
-        let mesh =
-            PolygonMesh3D::from_parts(CoordinateFrame::Euclidean, vec![], Vec::<Vec<u32>>::new())
-                .unwrap();
-        assert_eq!(boundary(&mesh), Geometry::None);
-    }
-
-    // Vertices the pool keeps distinct are distinct corners, so faces it does not
-    // join are not joined here either.
-    #[test]
-    fn faces_the_vertex_pool_does_not_join_stay_apart() {
-        let mesh = TriangularMesh3D::from_parts(
-            CoordinateFrame::Euclidean,
-            vec![
-                [0.0, 0.0, 0.0],
-                [1.0, 0.0, 0.0],
-                [1.0, 1.0, 0.0],
-                // The same three positions again, under their own indices.
-                [0.0, 0.0, 0.0],
-                [1.0, 0.0, 0.0],
-                [1.0, 1.0, 0.0],
-            ],
-            [0u32, 1, 2, 3, 4, 5],
-        )
-        .unwrap();
-        assert_eq!(chains_3d(&boundary(&mesh)).len(), 2);
-    }
-
-    // Three faces sharing one edge: that edge is walked three times, so it is no
-    // more a boundary than a shared edge is. How the six that remain split at the
-    // junction is arbitrary, but every one of them must come back exactly once,
-    // and none may come back as a stranded two-vertex fragment.
+    // Three faces on one edge: that edge is walked three times, so it is no more
+    // a boundary than a shared edge is. How the six that remain split at the
+    // junction is arbitrary, but each must come back exactly once and none as a
+    // stranded two-vertex fragment.
     #[test]
     fn a_branching_boundary_comes_back_whole() {
         let mesh = PolygonMesh3D::from_parts(
@@ -594,149 +375,13 @@ mod tests {
             vec![vec![4u32, 5, 0], vec![4, 5, 1], vec![4, 5, 2]],
         )
         .unwrap();
-        let chains = chains_3d(&boundary(&mesh));
+        let chains = chains(&boundary(&mesh));
         assert_eq!(edges_of(&chains).len(), 6);
         assert!(chains.iter().all(|c| c.len() > 2));
     }
 
-    #[test]
-    fn a_volume_is_bounded_by_its_shells_exterior_first() {
-        let solid = Solid::new(
-            CoordinateFrame::Euclidean,
-            PolygonMesh3DData::from_polygons([&face(0)]),
-            vec![Shell::from(PolygonMesh3DData::from_polygons([&face(1)]))],
-        );
-        let Geometry::Euclidean3D(Euclidean3DGeometry::Collection(shells)) = boundary(&solid)
-        else {
-            panic!("expected the two shells");
-        };
-        assert_eq!(shells.members().len(), 2);
-        for member in shells.members() {
-            assert!(matches!(member, Euclidean3DGeometry::PolygonMesh(_)));
-        }
-    }
-
-    // Twice over: the shells of a watertight volume are bounded by nothing, which
-    // is what makes them watertight.
-    #[test]
-    fn the_boundary_of_a_closed_volumes_boundary_is_empty() {
-        let solid = Solid::from_exterior(CoordinateFrame::Euclidean, tetrahedron().into_data());
-        let shell = boundary(&solid);
-        assert_eq!(boundary(&shell), Geometry::None);
-    }
-
-    #[test]
-    fn a_container_sets_its_members_boundaries_side_by_side() {
-        let c = Collection3D::new([
-            Euclidean3DGeometry::Polygon(Box::new(face(0))),
-            Euclidean3DGeometry::Polygon(Box::new(face(1))),
-        ]);
-        let rings = chains_3d(&boundary(&g3(Euclidean3DGeometry::Collection(c))));
-        assert_eq!(rings.len(), 3);
-    }
-
-    // One curve among the surfaces must not discard the surfaces, and a member
-    // bounded by nothing contributes nothing rather than an empty slot.
-    #[test]
-    fn a_container_skips_the_members_that_give_nothing() {
-        let c = Collection3D::new([
-            Euclidean3DGeometry::Polygon(Box::new(face(0))),
-            point(),
-            csg(),
-        ]);
-        let rings = chains_3d(&boundary(&g3(Euclidean3DGeometry::Collection(c))));
-        assert_eq!(rings, vec![SQUARE.to_vec()]);
-    }
-
-    #[test]
-    fn a_container_no_member_of_which_has_a_boundary_has_none_to_give() {
-        let c = Collection3D::new([csg()]);
-        assert!(g3(Euclidean3DGeometry::Collection(c))
-            .extract_boundary()
-            .is_err());
-    }
-
-    #[test]
-    fn a_container_whose_members_are_all_bounded_by_nothing_is_bounded_by_nothing() {
-        let c = Collection3D::new([point(), point()]);
-        assert_eq!(
-            boundary(&g3(Euclidean3DGeometry::Collection(c))),
-            Geometry::None
-        );
-        assert_eq!(
-            boundary(&g3(Euclidean3DGeometry::Collection(Collection3D::new(
-                Vec::new()
-            )))),
-            Geometry::None
-        );
-    }
-
-    // A container's boundary is a container of the same kind, whatever its
-    // members bound, so a downstream match does not turn on how many of them
-    // contributed or on whether the source carried child attributes.
-    #[test]
-    fn a_2d_container_stays_a_two_dimensional_container() {
-        let c = Collection2D::new([Euclidean2DGeometry::Polygon(Box::new(
-            Polygon2D::from_rings(
-                CoordinateFrame::Euclidean,
-                SQUARE_2D,
-                Vec::<Vec<[f64; 2]>>::new(),
-            ),
-        ))]);
-        let Geometry::Euclidean2D(Euclidean2DGeometry::Collection(out)) =
-            boundary(&Geometry::Euclidean2D(Euclidean2DGeometry::Collection(c)))
-        else {
-            panic!("expected a 2D collection");
-        };
-        assert!(matches!(
-            out.members(),
-            [Euclidean2DGeometry::LineString(_)]
-        ));
-    }
-
-    #[test]
-    fn boundaries_reach_through_nested_collections() {
-        let inner = Geometry::GeometryCollection(GeometryCollection::new([g3(
-            Euclidean3DGeometry::Polygon(Box::new(face(0))),
-        )]));
-        let outer = Geometry::GeometryCollection(GeometryCollection::new([
-            inner,
-            g3(Euclidean3DGeometry::Polygon(Box::new(face(1)))),
-            Geometry::None,
-        ]));
-        let Geometry::GeometryCollection(out) = boundary(&outer) else {
-            panic!("expected a geometry collection");
-        };
-        // The absent member has no boundary to give and drops out.
-        assert_eq!(out.members().len(), 2);
-    }
-
-    #[test]
-    fn a_container_keeps_the_attributes_lined_up_when_a_member_drops_out() {
-        let attrs = |n: i64| {
-            Attributes::from([(
-                Attribute::new("lod"),
-                AttributeValue::Number(serde_json::Number::from(n)),
-            )])
-        };
-        let members = vec![
-            g3(point()),
-            g3(Euclidean3DGeometry::Polygon(Box::new(face(0)))),
-        ];
-        let g = Geometry::GeometryCollection(
-            GeometryCollection::with_attributes(members, vec![attrs(1), attrs(2)]).unwrap(),
-        );
-        let Geometry::GeometryCollection(out) = boundary(&g) else {
-            panic!("expected a geometry collection");
-        };
-        assert_eq!(out.members().len(), 1);
-        assert_eq!(out.member_attributes(), [attrs(2)]);
-    }
-
     // Hash iteration order is not stable, so the same surface has to chain the
-    // same way every time or downstream splits would shuffle between runs. The
-    // faces are disjoint, so several rings come back and there is an order to get
-    // wrong.
+    // same way every time or downstream splits would shuffle between runs.
     #[test]
     fn chaining_the_same_surface_twice_gives_the_same_answer() {
         let offset = |d: f64| {
@@ -751,11 +396,38 @@ mod tests {
             [&face(1), &offset(10.0), &offset(20.0)],
         )
         .unwrap();
-        // Two rings from the holed face, one from each disjoint square.
-        assert_eq!(chains_3d(&boundary(&mesh)).len(), 4);
         let first = boundary(&mesh);
+        assert_eq!(chains(&first).len(), 4);
         for _ in 0..8 {
             assert_eq!(boundary(&mesh), first);
         }
+    }
+
+    // A member that drops out must not shift the attributes of the ones that
+    // stay: they are indexed against the source, and the output is compacted.
+    #[test]
+    fn a_container_keeps_the_attributes_lined_up_when_a_member_drops_out() {
+        let attrs = |n: i64| {
+            Attributes::from([(
+                Attribute::new("lod"),
+                AttributeValue::Number(serde_json::Number::from(n)),
+            )])
+        };
+        // The point is bounded by nothing, so only the face contributes.
+        let members = vec![
+            Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
+                CoordinateFrame::Euclidean,
+                [0.0; 3],
+            ))),
+            Geometry::Euclidean3D(Euclidean3DGeometry::Polygon(Box::new(face(0)))),
+        ];
+        let g = Geometry::GeometryCollection(
+            GeometryCollection::with_attributes(members, vec![attrs(1), attrs(2)]).unwrap(),
+        );
+        let Geometry::GeometryCollection(out) = boundary(&g) else {
+            panic!("expected a geometry collection");
+        };
+        assert_eq!(out.members().len(), 1);
+        assert_eq!(out.member_attributes(), [attrs(2)]);
     }
 }

--- a/engine/runtime/geometry/src/ops/boundary.rs
+++ b/engine/runtime/geometry/src/ops/boundary.rs
@@ -3,17 +3,43 @@
 
 use std::collections::HashMap;
 
+use reearth_flow_common::attribute::Attributes;
+
 use crate::coordinate::CoordinateFrame;
 use crate::line_string::{LineString2D, LineString3D};
 use crate::ops::coerce::{wrap_2d, wrap_3d};
 use crate::ops::UnsupportedOperation;
 use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
 
+/// What bounding a geometry produced.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Boundary {
+    /// The boundary.
+    Bounded(Geometry),
+    /// Bounded by nothing. `evaluated` is the source narrowed to the parts that
+    /// were bounded at all, `None` when that is the whole source.
+    Empty { evaluated: Option<Geometry> },
+}
+
+impl Boundary {
+    /// Bounded by nothing, with nothing left unbounded.
+    pub const EMPTY: Self = Boundary::Empty { evaluated: None };
+}
+
+impl From<Geometry> for Boundary {
+    fn from(geometry: Geometry) -> Self {
+        match geometry {
+            Geometry::None => Boundary::EMPTY,
+            geometry => Boundary::Bounded(geometry),
+        }
+    }
+}
+
 /// The boundary of a geometry: the shells bounding a volume, the rings bounding
 /// a surface, the endpoints bounding a curve.
 ///
-/// * `Ok(geometry)`: the boundary.
-/// * `Ok(`[`Geometry::None`]`)`: the boundary is empty.
+/// * `Ok(`[`Boundary::Bounded`]`)`: the boundary.
+/// * `Ok(`[`Boundary::Empty`]`)`: the boundary is empty.
 /// * `Err(`[`UnsupportedOperation`]`)`: the geometry has no boundary to report
 ///   at all.
 ///
@@ -22,14 +48,16 @@ use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
 /// 2.5D chain's endpoints lose its elevation, having no slot for one.
 ///
 /// A container bounds each member into a container of the same kind, keeping the
-/// attributes of the members that contributed, and reports `Err` only when every
-/// member did. Endpoints shared by two members are not cancelled against each
-/// other: cancellation happens only at shared vertex indices within one surface,
-/// never by matching coordinates, which float noise makes unreliable.
+/// attributes of the members that contributed, and reports `Err` only when no
+/// member had a boundary to give. A member that had none drops out of both the
+/// container and the [`Boundary::Empty`] source. Endpoints
+/// shared by two members are not cancelled against each other: cancellation
+/// happens only at shared vertex indices within one surface, never by matching
+/// coordinates, which float noise makes unreliable.
 #[enum_dispatch::enum_dispatch]
 pub trait ExtractBoundary {
     /// This geometry's boundary.
-    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+    fn extract_boundary(&self) -> Result<Boundary, UnsupportedOperation> {
         Err(unsupported::<Self>())
     }
 }
@@ -37,9 +65,82 @@ pub trait ExtractBoundary {
 // The boxed enum variants (`Box<Polygon3D>`, `Box<Solid>`, …) need the trait on
 // the `Box` itself: `enum_dispatch` forwards by UFCS, not auto-deref.
 impl<T: ExtractBoundary + ?Sized> ExtractBoundary for Box<T> {
-    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+    fn extract_boundary(&self) -> Result<Boundary, UnsupportedOperation> {
         (**self).extract_boundary()
     }
+}
+
+/// What one member of a container did with its boundary.
+enum Fate<M> {
+    Bounded(M),
+    /// Bounded by nothing; the source member stands as it is.
+    Empty,
+    /// Bounded by nothing; the source member narrows to this.
+    Narrowed(M),
+    /// No boundary to give; the source member drops out.
+    Unbounded,
+}
+
+/// Bound every member of a container into a container of the same kind, with
+/// `member_of` reading a boundary back as a member and `wrap` collecting them.
+/// `None` when no member had a boundary to give, which is the caller's `Err`.
+pub(crate) fn container_boundary<M: ExtractBoundary + Clone>(
+    members: &[M],
+    attrs: &[Attributes],
+    member_of: impl Fn(Geometry) -> Option<M>,
+    wrap: impl Fn(Vec<M>, Vec<Attributes>) -> Geometry,
+) -> Option<Boundary> {
+    // A boundary in another dimension, which no leaf hands back today, could not
+    // join a same-dimension container, so it leaves like an unbounded member.
+    let as_member = |geometry| member_of(geometry).map_or(Fate::Unbounded, Fate::Bounded);
+    let fates: Vec<Fate<M>> = members
+        .iter()
+        .map(|member| match member.extract_boundary() {
+            Err(_) => Fate::Unbounded,
+            Ok(Boundary::Bounded(geometry)) => as_member(geometry),
+            Ok(Boundary::Empty { evaluated: None }) => Fate::Empty,
+            Ok(Boundary::Empty {
+                evaluated: Some(geometry),
+            }) => match member_of(geometry) {
+                Some(member) => Fate::Narrowed(member),
+                None => Fate::Unbounded,
+            },
+        })
+        .collect();
+
+    if !members.is_empty() && fates.iter().all(|f| matches!(f, Fate::Unbounded)) {
+        return None;
+    }
+    // Nothing left unbounded, so the source stands as it is.
+    if fates.iter().all(|f| matches!(f, Fate::Empty)) {
+        return Some(Boundary::EMPTY);
+    }
+
+    // The container holds the boundary if there is one, and otherwise the source
+    // narrowed to the members that were bounded at all.
+    let any_bounded = fates.iter().any(|f| matches!(f, Fate::Bounded(_)));
+    let mut kept = Vec::new();
+    let mut kept_attrs = Vec::new();
+    for (i, fate) in fates.into_iter().enumerate() {
+        let member = match (any_bounded, fate) {
+            (true, Fate::Bounded(member)) => member,
+            (false, Fate::Narrowed(member)) => member,
+            (false, Fate::Empty) => members[i].clone(),
+            _ => continue,
+        };
+        kept.push(member);
+        if let Some(a) = attrs.get(i) {
+            kept_attrs.push(a.clone());
+        }
+    }
+    let geometry = wrap(kept, kept_attrs);
+    Some(if any_bounded {
+        Boundary::Bounded(geometry)
+    } else {
+        Boundary::Empty {
+            evaluated: Some(geometry),
+        }
+    })
 }
 
 pub(crate) fn unsupported<T: ?Sized>() -> UnsupportedOperation {
@@ -256,8 +357,16 @@ mod tests {
         )
     }
 
-    fn boundary(geometry: &impl ExtractBoundary) -> Geometry {
+    fn boundary(geometry: &impl ExtractBoundary) -> Boundary {
         geometry.extract_boundary().expect("bounded")
+    }
+
+    /// The boundary of a geometry a test expects to have one.
+    fn bounded(geometry: &impl ExtractBoundary) -> Geometry {
+        match boundary(geometry) {
+            Boundary::Bounded(geometry) => geometry,
+            empty => panic!("expected a boundary, got {empty:?}"),
+        }
     }
 
     /// The chain of every polyline a boundary is made of, in emission order.
@@ -314,7 +423,7 @@ mod tests {
             [0u32, 1, 2, 0, 2, 3],
         )
         .unwrap();
-        assert_eq!(ring_lengths(&boundary(&pair)), [5]);
+        assert_eq!(ring_lengths(&bounded(&pair)), [5]);
 
         // A closed tetrahedron: every edge is walked twice, so nothing is left.
         let closed = TriangularMesh3D::from_parts(
@@ -328,12 +437,12 @@ mod tests {
             [0u32, 2, 1, 0, 1, 3, 0, 3, 2, 1, 2, 3],
         )
         .unwrap();
-        assert_eq!(boundary(&closed), Geometry::None);
+        assert_eq!(boundary(&closed), Boundary::EMPTY);
 
         // A hole no neighbouring face fills is walked once, like any outer edge,
         // so it bounds the surface too.
         let holed = PolygonMesh3D::from_polygons(CoordinateFrame::Euclidean, [&face(1)]).unwrap();
-        assert_eq!(ring_lengths(&boundary(&holed)), [5, 5]);
+        assert_eq!(ring_lengths(&bounded(&holed)), [5, 5]);
     }
 
     // Chaining follows the edges, not the direction they were walked in, so faces
@@ -353,7 +462,7 @@ mod tests {
             [0u32, 1, 2, 0, 3, 2],
         )
         .unwrap();
-        assert_eq!(ring_lengths(&boundary(&mesh)), [5]);
+        assert_eq!(ring_lengths(&bounded(&mesh)), [5]);
     }
 
     // Three faces on one edge: that edge is walked three times, so it is no more
@@ -375,7 +484,7 @@ mod tests {
             vec![vec![4u32, 5, 0], vec![4, 5, 1], vec![4, 5, 2]],
         )
         .unwrap();
-        let chains = chains(&boundary(&mesh));
+        let chains = chains(&bounded(&mesh));
         assert_eq!(edges_of(&chains).len(), 6);
         assert!(chains.iter().all(|c| c.len() > 2));
     }
@@ -396,10 +505,10 @@ mod tests {
             [&face(1), &offset(10.0), &offset(20.0)],
         )
         .unwrap();
-        let first = boundary(&mesh);
+        let first = bounded(&mesh);
         assert_eq!(chains(&first).len(), 4);
         for _ in 0..8 {
-            assert_eq!(boundary(&mesh), first);
+            assert_eq!(bounded(&mesh), first);
         }
     }
 
@@ -424,7 +533,7 @@ mod tests {
         let g = Geometry::GeometryCollection(
             GeometryCollection::with_attributes(members, vec![attrs(1), attrs(2)]).unwrap(),
         );
-        let Geometry::GeometryCollection(out) = boundary(&g) else {
+        let Geometry::GeometryCollection(out) = bounded(&g) else {
             panic!("expected a geometry collection");
         };
         assert_eq!(out.members().len(), 1);

--- a/engine/runtime/geometry/src/ops/boundary.rs
+++ b/engine/runtime/geometry/src/ops/boundary.rs
@@ -14,8 +14,8 @@ use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
 ///
 /// * `Ok(geometry)`: the boundary.
 /// * `Ok(`[`Geometry::None`]`)`: the boundary is empty.
-/// * `Err(`[`UnsupportedOperation`]`)`: the type has no boundary to report at
-///   all.
+/// * `Err(`[`UnsupportedOperation`]`)`: the geometry has no boundary to report
+///   at all.
 ///
 /// A face's rings come out verbatim, neither re-wound nor re-closed. Appearance
 /// is dropped from bounding curves and kept on the shells a volume bounds. A

--- a/engine/runtime/geometry/src/ops/mod.rs
+++ b/engine/runtime/geometry/src/ops/mod.rs
@@ -8,6 +8,7 @@
 //! chains through to the concrete leaf. `GeometryCollection` and the per-frame
 //! `Collection`s recurse by hand over their children.
 
+pub mod boundary;
 pub mod coerce;
 #[cfg(feature = "new-geometry")]
 pub mod footprint;
@@ -16,6 +17,8 @@ pub mod reproject;
 pub mod split;
 pub mod triangulation;
 
+pub use boundary::ExtractBoundary;
+pub(crate) use boundary::{surface_boundary_2d, surface_boundary_3d, BoundaryEdges};
 pub use coerce::{Coerce, CoercionTarget};
 #[cfg(feature = "new-geometry")]
 pub use footprint::{Footprint, FootprintError, FootprintPlane, FootprintSink};

--- a/engine/runtime/geometry/src/ops/mod.rs
+++ b/engine/runtime/geometry/src/ops/mod.rs
@@ -17,8 +17,10 @@ pub mod reproject;
 pub mod split;
 pub mod triangulation;
 
-pub use boundary::ExtractBoundary;
-pub(crate) use boundary::{surface_boundary_2d, surface_boundary_3d, BoundaryEdges};
+pub(crate) use boundary::{
+    container_boundary, surface_boundary_2d, surface_boundary_3d, BoundaryEdges,
+};
+pub use boundary::{Boundary, ExtractBoundary};
 pub use coerce::{Coerce, CoercionTarget};
 #[cfg(feature = "new-geometry")]
 pub use footprint::{Footprint, FootprintError, FootprintPlane, FootprintSink};

--- a/engine/runtime/geometry/src/point/mod.rs
+++ b/engine/runtime/geometry/src/point/mod.rs
@@ -87,13 +87,13 @@ crate::unsupported!(Point3D: Coerce);
 // A position has no extent, so it reports the empty boundary rather than
 // refusing the operation.
 impl crate::ops::ExtractBoundary for Point2D {
-    fn extract_boundary(&self) -> Result<crate::Geometry, crate::ops::UnsupportedOperation> {
-        Ok(crate::Geometry::None)
+    fn extract_boundary(&self) -> Result<crate::ops::Boundary, crate::ops::UnsupportedOperation> {
+        Ok(crate::ops::Boundary::EMPTY)
     }
 }
 
 impl crate::ops::ExtractBoundary for Point3D {
-    fn extract_boundary(&self) -> Result<crate::Geometry, crate::ops::UnsupportedOperation> {
-        Ok(crate::Geometry::None)
+    fn extract_boundary(&self) -> Result<crate::ops::Boundary, crate::ops::UnsupportedOperation> {
+        Ok(crate::ops::Boundary::EMPTY)
     }
 }

--- a/engine/runtime/geometry/src/point/mod.rs
+++ b/engine/runtime/geometry/src/point/mod.rs
@@ -83,3 +83,17 @@ crate::unsupported!(Point3D: ExtractHoles);
 // re-arrange into one.
 crate::unsupported!(Point2D: Coerce);
 crate::unsupported!(Point3D: Coerce);
+
+// A position has no extent, so it reports the empty boundary rather than
+// refusing the operation.
+impl crate::ops::ExtractBoundary for Point2D {
+    fn extract_boundary(&self) -> Result<crate::Geometry, crate::ops::UnsupportedOperation> {
+        Ok(crate::Geometry::None)
+    }
+}
+
+impl crate::ops::ExtractBoundary for Point3D {
+    fn extract_boundary(&self) -> Result<crate::Geometry, crate::ops::UnsupportedOperation> {
+        Ok(crate::Geometry::None)
+    }
+}

--- a/engine/runtime/geometry/src/point_cloud/mod.rs
+++ b/engine/runtime/geometry/src/point_cloud/mod.rs
@@ -188,3 +188,10 @@ crate::unsupported!(
     ExtractHoles,
     Coerce
 );
+
+// Positions have no extent, so nothing bounds them.
+impl crate::ops::ExtractBoundary for PointCloud {
+    fn extract_boundary(&self) -> Result<crate::Geometry, crate::ops::UnsupportedOperation> {
+        Ok(crate::Geometry::None)
+    }
+}

--- a/engine/runtime/geometry/src/point_cloud/mod.rs
+++ b/engine/runtime/geometry/src/point_cloud/mod.rs
@@ -191,7 +191,7 @@ crate::unsupported!(
 
 // Positions have no extent, so nothing bounds them.
 impl crate::ops::ExtractBoundary for PointCloud {
-    fn extract_boundary(&self) -> Result<crate::Geometry, crate::ops::UnsupportedOperation> {
-        Ok(crate::Geometry::None)
+    fn extract_boundary(&self) -> Result<crate::ops::Boundary, crate::ops::UnsupportedOperation> {
+        Ok(crate::ops::Boundary::EMPTY)
     }
 }

--- a/engine/runtime/geometry/src/polygon/ops.rs
+++ b/engine/runtime/geometry/src/polygon/ops.rs
@@ -482,6 +482,27 @@ impl Footprint for Polygon3D {
     }
 }
 
+use crate::ops::boundary::{unsupported as unbounded, ExtractBoundary};
+
+// A face is bounded by its own rings, exterior first, each kept verbatim. A face
+// with no exterior ring encloses nothing, so there is nothing to bound. That is
+// the one case where a face itself has no boundary to give.
+impl ExtractBoundary for Polygon2D {
+    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+        let mut lines = Vec::new();
+        push_face_lines_2d(self, &mut lines);
+        wrap_2d(lines).ok_or_else(unbounded::<Self>)
+    }
+}
+
+impl ExtractBoundary for Polygon3D {
+    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+        let mut lines = Vec::new();
+        push_face_lines_3d(self, &mut lines);
+        wrap_3d(lines).ok_or_else(unbounded::<Self>)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/polygon/ops.rs
+++ b/engine/runtime/geometry/src/polygon/ops.rs
@@ -482,24 +482,28 @@ impl Footprint for Polygon3D {
     }
 }
 
-use crate::ops::boundary::{unsupported as unbounded, ExtractBoundary};
+use crate::ops::boundary::{unsupported as unbounded, Boundary, ExtractBoundary};
 
 // A face is bounded by its own rings, exterior first, each kept verbatim. A face
 // with no exterior ring encloses nothing, so there is nothing to bound. That is
 // the one case where a face itself has no boundary to give.
 impl ExtractBoundary for Polygon2D {
-    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+    fn extract_boundary(&self) -> Result<Boundary, UnsupportedOperation> {
         let mut lines = Vec::new();
         push_face_lines_2d(self, &mut lines);
-        wrap_2d(lines).ok_or_else(unbounded::<Self>)
+        wrap_2d(lines)
+            .map(Boundary::Bounded)
+            .ok_or_else(unbounded::<Self>)
     }
 }
 
 impl ExtractBoundary for Polygon3D {
-    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+    fn extract_boundary(&self) -> Result<Boundary, UnsupportedOperation> {
         let mut lines = Vec::new();
         push_face_lines_3d(self, &mut lines);
-        wrap_3d(lines).ok_or_else(unbounded::<Self>)
+        wrap_3d(lines)
+            .map(Boundary::Bounded)
+            .ok_or_else(unbounded::<Self>)
     }
 }
 

--- a/engine/runtime/geometry/src/polygon_mesh/ops.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/ops.rs
@@ -703,6 +703,46 @@ impl PolygonMesh3DData {
     }
 }
 
+use crate::ops::boundary::ExtractBoundary;
+use crate::ops::{surface_boundary_2d, surface_boundary_3d, BoundaryEdges};
+
+fn csr_boundary_edges(
+    face_indices: &IndexBuffer<1>,
+    face_offsets: &IndexBuffer<1>,
+    interior_offsets: &IndexBuffer<1>,
+) -> BoundaryEdges {
+    let mut edges = BoundaryEdges::new();
+    super::faces::for_each_ring(face_indices, face_offsets, interior_offsets, |ring, _| {
+        edges.add_ring(ring)
+    });
+    edges
+}
+
+// A hole ring no neighbouring face fills is walked once, like any outer edge, so
+// it bounds the surface too.
+impl ExtractBoundary for PolygonMesh2D {
+    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+        let (face_indices, face_offsets, interior_offsets) = self.csr_buffers();
+        Ok(surface_boundary_2d(
+            self.frame(),
+            self.vertices(),
+            self.elevation(),
+            csr_boundary_edges(face_indices, face_offsets, interior_offsets),
+        ))
+    }
+}
+
+impl ExtractBoundary for PolygonMesh3D {
+    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+        let (face_indices, face_offsets, interior_offsets) = self.data().csr_buffers();
+        Ok(surface_boundary_3d(
+            self.frame(),
+            self.vertices(),
+            csr_boundary_edges(face_indices, face_offsets, interior_offsets),
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/polygon_mesh/ops.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/ops.rs
@@ -703,7 +703,7 @@ impl PolygonMesh3DData {
     }
 }
 
-use crate::ops::boundary::ExtractBoundary;
+use crate::ops::boundary::{Boundary, ExtractBoundary};
 use crate::ops::{surface_boundary_2d, surface_boundary_3d, BoundaryEdges};
 
 fn csr_boundary_edges(
@@ -721,25 +721,27 @@ fn csr_boundary_edges(
 // A hole ring no neighbouring face fills is walked once, like any outer edge, so
 // it bounds the surface too.
 impl ExtractBoundary for PolygonMesh2D {
-    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+    fn extract_boundary(&self) -> Result<Boundary, UnsupportedOperation> {
         let (face_indices, face_offsets, interior_offsets) = self.csr_buffers();
         Ok(surface_boundary_2d(
             self.frame(),
             self.vertices(),
             self.elevation(),
             csr_boundary_edges(face_indices, face_offsets, interior_offsets),
-        ))
+        )
+        .into())
     }
 }
 
 impl ExtractBoundary for PolygonMesh3D {
-    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+    fn extract_boundary(&self) -> Result<Boundary, UnsupportedOperation> {
         let (face_indices, face_offsets, interior_offsets) = self.data().csr_buffers();
         Ok(surface_boundary_3d(
             self.frame(),
             self.vertices(),
             csr_boundary_edges(face_indices, face_offsets, interior_offsets),
-        ))
+        )
+        .into())
     }
 }
 

--- a/engine/runtime/geometry/src/solid/ops.rs
+++ b/engine/runtime/geometry/src/solid/ops.rs
@@ -269,6 +269,33 @@ impl Footprint for Solid {
     }
 }
 
+use crate::ops::boundary::ExtractBoundary;
+use crate::polygon_mesh::PolygonMesh3D;
+use crate::triangular_mesh::TriangularMesh3D;
+
+// The shells the volume already carries, paired with the frame they are
+// expressed in. Nothing is re-triangulated and appearance stays on them.
+//
+// Whether the shells close is not asserted here: taking the boundary of the
+// result answers that, and is empty exactly when they do.
+impl ExtractBoundary for Solid {
+    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+        let frame = self.frame();
+        let shells = std::iter::once(&self.exterior)
+            .chain(self.interiors.iter())
+            .map(|shell| match shell {
+                Shell::PolygonMesh(data) => Euclidean3DGeometry::PolygonMesh(Box::new(
+                    PolygonMesh3D::new(frame.clone(), data.clone()),
+                )),
+                Shell::TriangularMesh(data) => Euclidean3DGeometry::TriangularMesh(Box::new(
+                    TriangularMesh3D::new(frame.clone(), data.clone()),
+                )),
+            })
+            .collect();
+        Ok(wrap_3d(shells).unwrap_or(Geometry::None))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/solid/ops.rs
+++ b/engine/runtime/geometry/src/solid/ops.rs
@@ -269,7 +269,7 @@ impl Footprint for Solid {
     }
 }
 
-use crate::ops::boundary::ExtractBoundary;
+use crate::ops::boundary::{Boundary, ExtractBoundary};
 use crate::polygon_mesh::PolygonMesh3D;
 use crate::triangular_mesh::TriangularMesh3D;
 
@@ -279,7 +279,7 @@ use crate::triangular_mesh::TriangularMesh3D;
 // Whether the shells close is not asserted here: taking the boundary of the
 // result answers that, and is empty exactly when they do.
 impl ExtractBoundary for Solid {
-    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+    fn extract_boundary(&self) -> Result<Boundary, UnsupportedOperation> {
         let frame = self.frame();
         let shells = std::iter::once(&self.exterior)
             .chain(self.interiors.iter())
@@ -292,7 +292,7 @@ impl ExtractBoundary for Solid {
                 )),
             })
             .collect();
-        Ok(wrap_3d(shells).unwrap_or(Geometry::None))
+        Ok(wrap_3d(shells).unwrap_or(Geometry::None).into())
     }
 }
 

--- a/engine/runtime/geometry/src/triangular_mesh/ops.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/ops.rs
@@ -468,6 +468,38 @@ impl TriangularMesh3DData {
     }
 }
 
+use crate::ops::boundary::ExtractBoundary;
+use crate::ops::{surface_boundary_2d, surface_boundary_3d, BoundaryEdges};
+
+fn triangle_boundary_edges(triangles: impl Iterator<Item = [u32; 3]>) -> BoundaryEdges {
+    let mut edges = BoundaryEdges::new();
+    for triangle in triangles {
+        edges.add_triangle(triangle);
+    }
+    edges
+}
+
+impl ExtractBoundary for TriangularMesh2D {
+    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+        Ok(surface_boundary_2d(
+            self.frame(),
+            self.vertices(),
+            self.elevation(),
+            triangle_boundary_edges(self.triangles()),
+        ))
+    }
+}
+
+impl ExtractBoundary for TriangularMesh3D {
+    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+        Ok(surface_boundary_3d(
+            self.frame(),
+            self.vertices(),
+            triangle_boundary_edges(self.triangles()),
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/triangular_mesh/ops.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/ops.rs
@@ -468,7 +468,7 @@ impl TriangularMesh3DData {
     }
 }
 
-use crate::ops::boundary::ExtractBoundary;
+use crate::ops::boundary::{Boundary, ExtractBoundary};
 use crate::ops::{surface_boundary_2d, surface_boundary_3d, BoundaryEdges};
 
 fn triangle_boundary_edges(triangles: impl Iterator<Item = [u32; 3]>) -> BoundaryEdges {
@@ -480,23 +480,25 @@ fn triangle_boundary_edges(triangles: impl Iterator<Item = [u32; 3]>) -> Boundar
 }
 
 impl ExtractBoundary for TriangularMesh2D {
-    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+    fn extract_boundary(&self) -> Result<Boundary, UnsupportedOperation> {
         Ok(surface_boundary_2d(
             self.frame(),
             self.vertices(),
             self.elevation(),
             triangle_boundary_edges(self.triangles()),
-        ))
+        )
+        .into())
     }
 }
 
 impl ExtractBoundary for TriangularMesh3D {
-    fn extract_boundary(&self) -> Result<Geometry, UnsupportedOperation> {
+    fn extract_boundary(&self) -> Result<Boundary, UnsupportedOperation> {
         Ok(surface_boundary_3d(
             self.frame(),
             self.vertices(),
             triangle_boundary_edges(self.triangles()),
-        ))
+        )
+        .into())
     }
 }
 

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -1068,7 +1068,7 @@
         "features"
       ],
       "outputPorts": [
-        "features",
+        "boundary",
         "no-boundary",
         "rejected"
       ],

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -1061,36 +1061,24 @@
     {
       "name": "Boundary Extractor",
       "type": "processor",
-      "description": "Extracts the boundary of geometries. For solids/meshes returns bounding surfaces, for surfaces returns boundary edges, for closed surfaces returns empty geometry",
-      "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Boundary Extractor Parameters",
-        "description": "Configuration for extracting boundaries from geometries.",
-        "type": "object",
-        "properties": {
-          "keepEmptyBoundaries": {
-            "description": "Whether to keep features with empty boundaries (default: false)",
-            "default": false,
-            "type": "boolean"
-          },
-          "exteriorOnly": {
-            "description": "Whether to extract only exterior boundaries (ignoring holes) for polygons (default: false)",
-            "default": false,
-            "type": "boolean"
-          }
-        }
-      },
+      "description": "Replaces a geometry with its boundary: the endpoints of a curve, the boundary rings of a surface, and the bounding shells of a volume.",
+      "parameter": null,
       "builtin": true,
       "inputPorts": [
         "features"
       ],
       "outputPorts": [
-        "features"
+        "features",
+        "no-boundary",
+        "rejected"
       ],
       "categories": [
         "Geometry"
       ],
-      "tags": []
+      "tags": [
+        "3d",
+        "spatial"
+      ]
     },
     {
       "name": "Bounds Extractor",

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -1061,36 +1061,24 @@
     {
       "name": "Boundary Extractor",
       "type": "processor",
-      "description": "Extrae el límite de geometrías. Para sólidos/mallas devuelve superficies delimitadoras, para superficies devuelve aristas de límite, para superficies cerradas devuelve geometría vacía",
-      "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Boundary Extractor Parameters",
-        "description": "Configuration for extracting boundaries from geometries.",
-        "type": "object",
-        "properties": {
-          "keepEmptyBoundaries": {
-            "description": "Whether to keep features with empty boundaries (default: false)",
-            "default": false,
-            "type": "boolean"
-          },
-          "exteriorOnly": {
-            "description": "Whether to extract only exterior boundaries (ignoring holes) for polygons (default: false)",
-            "default": false,
-            "type": "boolean"
-          }
-        }
-      },
+      "description": "Reemplaza una geometría por su frontera: los extremos de una curva, los anillos de borde de una superficie y los cascarones que delimitan un volumen.",
+      "parameter": null,
       "builtin": true,
       "inputPorts": [
         "features"
       ],
       "outputPorts": [
-        "features"
+        "features",
+        "no-boundary",
+        "rejected"
       ],
       "categories": [
         "Geometry"
       ],
-      "tags": []
+      "tags": [
+        "3d",
+        "spatial"
+      ]
     },
     {
       "name": "Bounds Extractor",

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -1068,7 +1068,7 @@
         "features"
       ],
       "outputPorts": [
-        "features",
+        "boundary",
         "no-boundary",
         "rejected"
       ],

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -1068,7 +1068,7 @@
         "features"
       ],
       "outputPorts": [
-        "features",
+        "boundary",
         "no-boundary",
         "rejected"
       ],

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -1061,36 +1061,24 @@
     {
       "name": "Boundary Extractor",
       "type": "processor",
-      "description": "Extrait la limite des géométries. Pour les solides/maillages, retourne les surfaces limites ; pour les surfaces, retourne les arêtes limites ; pour les surfaces fermées, retourne une géométrie vide",
-      "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Boundary Extractor Parameters",
-        "description": "Configuration for extracting boundaries from geometries.",
-        "type": "object",
-        "properties": {
-          "keepEmptyBoundaries": {
-            "description": "Whether to keep features with empty boundaries (default: false)",
-            "default": false,
-            "type": "boolean"
-          },
-          "exteriorOnly": {
-            "description": "Whether to extract only exterior boundaries (ignoring holes) for polygons (default: false)",
-            "default": false,
-            "type": "boolean"
-          }
-        }
-      },
+      "description": "Remplace une géométrie par sa frontière : les extrémités d'une courbe, les anneaux de bord d'une surface, les coques englobantes d'un volume.",
+      "parameter": null,
       "builtin": true,
       "inputPorts": [
         "features"
       ],
       "outputPorts": [
-        "features"
+        "features",
+        "no-boundary",
+        "rejected"
       ],
       "categories": [
         "Geometry"
       ],
-      "tags": []
+      "tags": [
+        "3d",
+        "spatial"
+      ]
     },
     {
       "name": "Bounds Extractor",

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -1061,36 +1061,24 @@
     {
       "name": "Boundary Extractor",
       "type": "processor",
-      "description": "ジオメトリの境界を抽出する。ソリッド/メッシュは境界サーフェスを、サーフェスは境界エッジを、閉じたサーフェスは空のジオメトリを返す",
-      "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Boundary Extractor パラメータ",
-        "description": "ジオメトリから境界を抽出する設定",
-        "type": "object",
-        "properties": {
-          "keepEmptyBoundaries": {
-            "description": "境界が空のフィーチャーを保持するか（デフォルト: false）",
-            "default": false,
-            "type": "boolean"
-          },
-          "exteriorOnly": {
-            "description": "ポリゴンの外周境界のみ抽出するか（穴を無視）（デフォルト: false）",
-            "default": false,
-            "type": "boolean"
-          }
-        }
-      },
+      "description": "ジオメトリをその境界に置き換える。曲線は両端の点、サーフェスは境界リング、ソリッドは境界シェルとなる。",
+      "parameter": null,
       "builtin": true,
       "inputPorts": [
         "features"
       ],
       "outputPorts": [
-        "features"
+        "features",
+        "no-boundary",
+        "rejected"
       ],
       "categories": [
         "Geometry"
       ],
-      "tags": []
+      "tags": [
+        "3d",
+        "spatial"
+      ]
     },
     {
       "name": "Bounds Extractor",

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -1068,7 +1068,7 @@
         "features"
       ],
       "outputPorts": [
-        "features",
+        "boundary",
         "no-boundary",
         "rejected"
       ],

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -1061,7 +1061,7 @@
     {
       "name": "Boundary Extractor",
       "type": "processor",
-      "description": "ジオメトリをその境界に置き換える。曲線は両端の点、サーフェスは境界リング、ソリッドは境界シェルとなる。",
+      "description": "ジオメトリをその境界に置き換える。曲線は両端の点、曲面は境界の曲線、立体は境界の曲面となる。",
       "parameter": null,
       "builtin": true,
       "inputPorts": [

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -1068,7 +1068,7 @@
         "features"
       ],
       "outputPorts": [
-        "features",
+        "boundary",
         "no-boundary",
         "rejected"
       ],

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -1061,36 +1061,24 @@
     {
       "name": "Boundary Extractor",
       "type": "processor",
-      "description": "提取几何体的边界。对于实体/网格返回边界面，对于面返回边界边，对于封闭面返回空几何体",
-      "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Boundary Extractor Parameters",
-        "description": "Configuration for extracting boundaries from geometries.",
-        "type": "object",
-        "properties": {
-          "keepEmptyBoundaries": {
-            "description": "Whether to keep features with empty boundaries (default: false)",
-            "default": false,
-            "type": "boolean"
-          },
-          "exteriorOnly": {
-            "description": "Whether to extract only exterior boundaries (ignoring holes) for polygons (default: false)",
-            "default": false,
-            "type": "boolean"
-          }
-        }
-      },
+      "description": "将几何替换为其边界：曲线为其两个端点，曲面为其边界环，实体为其边界壳。",
+      "parameter": null,
       "builtin": true,
       "inputPorts": [
         "features"
       ],
       "outputPorts": [
-        "features"
+        "features",
+        "no-boundary",
+        "rejected"
       ],
       "categories": [
         "Geometry"
       ],
-      "tags": []
+      "tags": [
+        "3d",
+        "spatial"
+      ]
     },
     {
       "name": "Bounds Extractor",

--- a/engine/schema/i18n/actions/es.json
+++ b/engine/schema/i18n/actions/es.json
@@ -403,19 +403,7 @@
     },
     {
       "name": "Boundary Extractor",
-      "description": "Extrae el límite de geometrías. Para sólidos/mallas devuelve superficies delimitadoras, para superficies devuelve aristas de límite, para superficies cerradas devuelve geometría vacía",
-      "parameterI18n": {
-        "": {
-          "title": "Boundary Extractor Parameters",
-          "description": "Configuration for extracting boundaries from geometries."
-        },
-        "exteriorOnly": {
-          "description": "Whether to extract only exterior boundaries (ignoring holes) for polygons (default: false)"
-        },
-        "keepEmptyBoundaries": {
-          "description": "Whether to keep features with empty boundaries (default: false)"
-        }
-      }
+      "description": "Reemplaza una geometría por su frontera: los extremos de una curva, los anillos de borde de una superficie y los cascarones que delimitan un volumen."
     },
     {
       "name": "Bounds Extractor",

--- a/engine/schema/i18n/actions/fr.json
+++ b/engine/schema/i18n/actions/fr.json
@@ -403,19 +403,7 @@
     },
     {
       "name": "Boundary Extractor",
-      "description": "Extrait la limite des géométries. Pour les solides/maillages, retourne les surfaces limites ; pour les surfaces, retourne les arêtes limites ; pour les surfaces fermées, retourne une géométrie vide",
-      "parameterI18n": {
-        "": {
-          "title": "Boundary Extractor Parameters",
-          "description": "Configuration for extracting boundaries from geometries."
-        },
-        "exteriorOnly": {
-          "description": "Whether to extract only exterior boundaries (ignoring holes) for polygons (default: false)"
-        },
-        "keepEmptyBoundaries": {
-          "description": "Whether to keep features with empty boundaries (default: false)"
-        }
-      }
+      "description": "Remplace une géométrie par sa frontière : les extrémités d'une courbe, les anneaux de bord d'une surface, les coques englobantes d'un volume."
     },
     {
       "name": "Bounds Extractor",

--- a/engine/schema/i18n/actions/ja.json
+++ b/engine/schema/i18n/actions/ja.json
@@ -403,19 +403,7 @@
     },
     {
       "name": "Boundary Extractor",
-      "description": "ジオメトリの境界を抽出する。ソリッド/メッシュは境界サーフェスを、サーフェスは境界エッジを、閉じたサーフェスは空のジオメトリを返す",
-      "parameterI18n": {
-        "": {
-          "title": "Boundary Extractor パラメータ",
-          "description": "ジオメトリから境界を抽出する設定"
-        },
-        "exteriorOnly": {
-          "description": "ポリゴンの外周境界のみ抽出するか（穴を無視）（デフォルト: false）"
-        },
-        "keepEmptyBoundaries": {
-          "description": "境界が空のフィーチャーを保持するか（デフォルト: false）"
-        }
-      }
+      "description": "ジオメトリをその境界に置き換える。曲線は両端の点、サーフェスは境界リング、ソリッドは境界シェルとなる。"
     },
     {
       "name": "Bounds Extractor",

--- a/engine/schema/i18n/actions/ja.json
+++ b/engine/schema/i18n/actions/ja.json
@@ -403,7 +403,7 @@
     },
     {
       "name": "Boundary Extractor",
-      "description": "ジオメトリをその境界に置き換える。曲線は両端の点、サーフェスは境界リング、ソリッドは境界シェルとなる。"
+      "description": "ジオメトリをその境界に置き換える。曲線は両端の点、曲面は境界の曲線、立体は境界の曲面となる。"
     },
     {
       "name": "Bounds Extractor",

--- a/engine/schema/i18n/actions/zh.json
+++ b/engine/schema/i18n/actions/zh.json
@@ -403,19 +403,7 @@
     },
     {
       "name": "Boundary Extractor",
-      "description": "提取几何体的边界。对于实体/网格返回边界面，对于面返回边界边，对于封闭面返回空几何体",
-      "parameterI18n": {
-        "": {
-          "title": "Boundary Extractor Parameters",
-          "description": "Configuration for extracting boundaries from geometries."
-        },
-        "exteriorOnly": {
-          "description": "Whether to extract only exterior boundaries (ignoring holes) for polygons (default: false)"
-        },
-        "keepEmptyBoundaries": {
-          "description": "Whether to keep features with empty boundaries (default: false)"
-        }
-      }
+      "description": "将几何替换为其边界：曲线为其两个端点，曲面为其边界环，实体为其边界壳。"
     },
     {
       "name": "Bounds Extractor",

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.119"
+version = "0.2.120"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.309"
+version = "0.1.310"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
# Overview
This PR implements Boundary Extractor in new geometry.


## Port routing

| Port name | Description | Output feature |
|---|---|---|
| `boundary` | some non-empty boundary is evaluated | the boundary geometry |
| `no-boundary` | boundary is evaluated and it's empty | the geometry it arrived with |
| `rejected` | boundaries cannot be evaluated | the geometry it arrived with |

`no-boundary` and `rejected` are different in that the former means the boundary is evaluated to be empty (e.g. points, closed rings), while the latter means that the boundary cannot be evaluated (e.g. CSG).

## Mapping
| Input | Boundary | Condition |
|---|---|---|
| `Point2D` / `Point3D` | empty | always |
| `PointCloud` | empty | always |
| `LineString2D` / `LineString3D` | `Collection` of the two endpoint `Point`s | open chain |
| | empty | ends meet, or fewer than 2 distinct coords |
| `Polygon2D` / `Polygon3D` | `LineString` (the exterior ring) | no holes |
| | `Collection` of `LineString` (exterior, then each hole) | has holes |
| | rejected | empty exterior |
| `PolygonMesh2D` / `PolygonMesh3D` | `LineString`, or `Collection` of them, one per boundary ring | surface is open |
| | empty | surface is watertight |
| `TriangularMesh2D` / `TriangularMesh3D` | same rule as `PolygonMesh` | |
| `Solid` | the exterior shell as a `PolygonMesh3D` / `TriangularMesh3D` | one shell |
| | `Collection` of shells, exterior then each void | has voids |
| `Csg` | rejected | unconditional |
| `Collection2D` / `Collection3D` / `GeometryCollection` | `Collection` of the members' boundaries (rejected children dropped) | any member contributed |
| | empty (rejected children dropped) | every member has none or gets rejected and at least one member has none, or the collection is empty |
| | rejected | otherwise |

## Removed parameters

- `keepEmptyBoundaries` is gone. This is always expressed by the three ports now.
- `exteriorOnly` is gone. Though this could have lived for solids and Polygon 2D, but removed for generality.

## What I want you to review particularly
Boundary of a point is defined to be `None`, following the sense of CW complex. However, the boundary of a point can sometimes be defined to be a point (e.g. in the sense of point-set topology). I think this would rarely be a serious problem for users, but please push back if you disagree with the definition.