### PR TITLE
fix(api): delete websocket document only after project delete commits

### DIFF
--- a/server/api/internal/usecase/interactor/common.go
+++ b/server/api/internal/usecase/interactor/common.go
@@ -68,9 +68,8 @@ func NewContainer(r *repo.Container, g *gateway.Container,
 }
 
 type ProjectDeleter struct {
-	File      gateway.File
-	Project   repo.Project
-	Websocket interfaces.WebsocketClient
+	File    gateway.File
+	Project repo.Project
 }
 
 func (d ProjectDeleter) Delete(ctx context.Context, prj *project.Project, force bool) error {
@@ -78,15 +77,6 @@ func (d ProjectDeleter) Delete(ctx context.Context, prj *project.Project, force 
 		return nil
 	}
 
-	// Delete collaborative document data (GCS snapshots + Redis stream)
-	if d.Websocket != nil {
-		if err := d.Websocket.DeleteDocument(ctx, prj.ID().String()); err != nil {
-			log.Printf("WARNING: Failed to delete websocket document for project %s: %v", prj.ID(), err)
-			// Non-fatal: project deletion should proceed even if WS cleanup fails
-		}
-	}
-
-	// Delete project
 	if err := d.Project.Remove(ctx, prj.ID()); err != nil {
 		return err
 	}

--- a/server/api/internal/usecase/interactor/project.go
+++ b/server/api/internal/usecase/interactor/project.go
@@ -15,6 +15,7 @@ import (
 	"github.com/reearth/reearth-flow/api/pkg/job"
 	"github.com/reearth/reearth-flow/api/pkg/parameter"
 	"github.com/reearth/reearth-flow/api/pkg/project"
+	"github.com/reearth/reearthx/log"
 	"github.com/reearth/reearthx/rerror"
 	"github.com/reearth/reearthx/usecasex"
 	"go.opentelemetry.io/otel"
@@ -184,23 +185,34 @@ func (i *Project) Delete(ctx context.Context, projectID id.ProjectID) (err error
 		return err
 	}
 
-	return i.transaction.WithinTransaction(ctx, func(ctx context.Context) error {
+	if err := i.transaction.WithinTransaction(ctx, func(ctx context.Context) error {
 		prj, err := i.projectRepo.FindByID(ctx, projectID)
 		if err != nil {
 			return err
 		}
 
 		deleter := ProjectDeleter{
-			File:      i.file,
-			Project:   i.projectRepo,
-			Websocket: i.websocket,
+			File:    i.file,
+			Project: i.projectRepo,
 		}
 		if err := deleter.Delete(ctx, prj, true); err != nil {
 			return err
 		}
 
 		return i.jobRepo.RemoveByProject(ctx, projectID)
-	})
+	}); err != nil {
+		return err
+	}
+
+	// Only now is the project row durably gone: deleting the document earlier
+	// would destroy it even if the transaction failed or was retried.
+	if i.websocket != nil {
+		if err := i.websocket.DeleteDocument(ctx, projectID.String()); err != nil {
+			log.Errorfc(ctx, "project: could not delete websocket document for %s: %v", projectID, err)
+		}
+	}
+
+	return nil
 }
 
 func (i *Project) Run(ctx context.Context, p interfaces.RunProjectParam) (_ *job.Job, err error) {

--- a/server/api/internal/usecase/interactor/project_deleter_test.go
+++ b/server/api/internal/usecase/interactor/project_deleter_test.go
@@ -121,7 +121,7 @@ func TestProjectDeleter_Delete_NilProject(t *testing.T) {
 // commits). ProjectDeleter no longer touches the websocket document at all;
 // that happens in Project.Delete's post-commit step, asserted below.
 
-func TestProject_Delete_DeletesWebsocketDocumentAfterCommit(t *testing.T) {
+func TestProject_Delete_DeletesWebsocketDocument(t *testing.T) {
 	ctx := context.Background()
 	projectRepo := memory.NewProject()
 	jobRepo := memory.NewJob()
@@ -169,6 +169,33 @@ func TestProject_Delete_SerializationRetryDeletesDocumentOnce(t *testing.T) {
 
 	// ...but the document was only destroyed once.
 	assert.Equal(t, []string{prj.ID().String()}, wsClient.deletedDocIDs)
+}
+
+func TestProject_Delete_ContinuesWhenWebsocketFails(t *testing.T) {
+	ctx := context.Background()
+	projectRepo := memory.NewProject()
+	jobRepo := memory.NewJob()
+	wsClient := &mockWebsocketClient{
+		deleteDocumentFunc: func(context.Context, string) error {
+			return errors.New("ws unavailable")
+		},
+	}
+
+	prj := project.New().NewID().MustBuild()
+	assert.NoError(t, projectRepo.Save(ctx, prj))
+
+	uc := &Project{
+		projectRepo:       projectRepo,
+		jobRepo:           jobRepo,
+		websocket:         wsClient,
+		transaction:       usecasex.NewTransactor(&usecasex.NopTransaction{}, 0),
+		permissionChecker: NewMockPermissionChecker(nil),
+	}
+
+	assert.NoError(t, uc.Delete(ctx, prj.ID()))
+
+	_, err := projectRepo.FindByID(ctx, prj.ID())
+	assert.ErrorIs(t, err, rerror.ErrNotFound)
 }
 
 func TestProject_Delete_DoesNotDeleteDocumentWhenTransactionFails(t *testing.T) {

--- a/server/api/internal/usecase/interactor/project_deleter_test.go
+++ b/server/api/internal/usecase/interactor/project_deleter_test.go
@@ -7,10 +7,38 @@ import (
 
 	"github.com/reearth/reearth-flow/api/internal/infrastructure/memory"
 	"github.com/reearth/reearth-flow/api/internal/usecase/interfaces"
+	"github.com/reearth/reearth-flow/api/internal/usecase/repo"
+	"github.com/reearth/reearth-flow/api/pkg/id"
 	"github.com/reearth/reearth-flow/api/pkg/project"
 	ws "github.com/reearth/reearth-flow/api/pkg/websocket"
+	"github.com/reearth/reearthx/rerror"
+	"github.com/reearth/reearthx/usecasex"
 	"github.com/stretchr/testify/assert"
 )
+
+// failingRemoveByProjectJobRepo fails the last step of the deletion transaction,
+// so Project.Delete's WithinTransaction call returns an error.
+type failingRemoveByProjectJobRepo struct {
+	*memory.Job
+	err error
+}
+
+func (f *failingRemoveByProjectJobRepo) RemoveByProject(context.Context, id.ProjectID) error {
+	return f.err
+}
+
+// retryableProjectRepo counts Remove calls without actually deleting, mirroring
+// a serializable transaction: a retried attempt starts from the same committed
+// row, since the failed attempt never took effect.
+type retryableProjectRepo struct {
+	repo.Project
+	removeCalls int
+}
+
+func (r *retryableProjectRepo) Remove(ctx context.Context, pid id.ProjectID) error {
+	r.removeCalls++
+	return nil
+}
 
 // mockWebsocketClient implements interfaces.WebsocketClient for testing.
 type mockWebsocketClient struct {
@@ -60,54 +88,7 @@ func (m *mockWebsocketClient) Close() error { return nil }
 
 var _ interfaces.WebsocketClient = (*mockWebsocketClient)(nil)
 
-func TestProjectDeleter_Delete_CascadesToWebsocket(t *testing.T) {
-	ctx := context.Background()
-	projectRepo := memory.NewProject()
-
-	prj := project.New().NewID().MustBuild()
-	assert.NoError(t, projectRepo.Save(ctx, prj))
-
-	wsClient := &mockWebsocketClient{}
-
-	deleter := ProjectDeleter{
-		Project:   projectRepo,
-		Websocket: wsClient,
-	}
-
-	err := deleter.Delete(ctx, prj, true)
-	assert.NoError(t, err)
-
-	// Verify websocket DeleteDocument was called with the project ID
-	assert.Equal(t, []string{prj.ID().String()}, wsClient.deletedDocIDs)
-}
-
-func TestProjectDeleter_Delete_ContinuesWhenWebsocketFails(t *testing.T) {
-	ctx := context.Background()
-	projectRepo := memory.NewProject()
-
-	prj := project.New().NewID().MustBuild()
-	assert.NoError(t, projectRepo.Save(ctx, prj))
-
-	wsClient := &mockWebsocketClient{
-		deleteDocumentFunc: func(ctx context.Context, docID string) error {
-			return errors.New("websocket server unreachable")
-		},
-	}
-
-	deleter := ProjectDeleter{
-		Project:   projectRepo,
-		Websocket: wsClient,
-	}
-
-	// Should succeed even though websocket deletion failed
-	err := deleter.Delete(ctx, prj, true)
-	assert.NoError(t, err)
-
-	// Verify the attempt was made
-	assert.Equal(t, []string{prj.ID().String()}, wsClient.deletedDocIDs)
-}
-
-func TestProjectDeleter_Delete_WorksWithNilWebsocket(t *testing.T) {
+func TestProjectDeleter_Delete_RemovesProject(t *testing.T) {
 	ctx := context.Background()
 	projectRepo := memory.NewProject()
 
@@ -115,22 +96,98 @@ func TestProjectDeleter_Delete_WorksWithNilWebsocket(t *testing.T) {
 	assert.NoError(t, projectRepo.Save(ctx, prj))
 
 	deleter := ProjectDeleter{
-		Project:   projectRepo,
-		Websocket: nil,
+		Project: projectRepo,
 	}
 
-	// Should succeed without websocket client
 	err := deleter.Delete(ctx, prj, true)
 	assert.NoError(t, err)
+
+	_, err = projectRepo.FindByID(ctx, prj.ID())
+	assert.ErrorIs(t, err, rerror.ErrNotFound)
 }
 
 func TestProjectDeleter_Delete_NilProject(t *testing.T) {
 	deleter := ProjectDeleter{
-		Project:   memory.NewProject(),
-		Websocket: &mockWebsocketClient{},
+		Project: memory.NewProject(),
 	}
 
 	// Should be a no-op
 	err := deleter.Delete(context.Background(), nil, true)
 	assert.NoError(t, err)
+}
+
+// A retried transaction must not destroy the collaborative document twice
+// (and, more importantly, must not destroy it if the row it justifies never
+// commits). ProjectDeleter no longer touches the websocket document at all;
+// that happens in Project.Delete's post-commit step, asserted below.
+
+func TestProject_Delete_DeletesWebsocketDocumentAfterCommit(t *testing.T) {
+	ctx := context.Background()
+	projectRepo := memory.NewProject()
+	jobRepo := memory.NewJob()
+	wsClient := &mockWebsocketClient{}
+
+	prj := project.New().NewID().MustBuild()
+	assert.NoError(t, projectRepo.Save(ctx, prj))
+
+	uc := &Project{
+		projectRepo:       projectRepo,
+		jobRepo:           jobRepo,
+		websocket:         wsClient,
+		transaction:       usecasex.NewTransactor(&usecasex.NopTransaction{}, 0),
+		permissionChecker: NewMockPermissionChecker(nil),
+	}
+
+	assert.NoError(t, uc.Delete(ctx, prj.ID()))
+	assert.Equal(t, []string{prj.ID().String()}, wsClient.deletedDocIDs)
+}
+
+func TestProject_Delete_SerializationRetryDeletesDocumentOnce(t *testing.T) {
+	ctx := context.Background()
+	memProjectRepo := memory.NewProject()
+	projectRepo := &retryableProjectRepo{Project: memProjectRepo}
+	jobRepo := memory.NewJob()
+	wsClient := &mockWebsocketClient{}
+	tx := &retryingTransactor{}
+
+	prj := project.New().NewID().MustBuild()
+	assert.NoError(t, memProjectRepo.Save(ctx, prj))
+
+	uc := &Project{
+		projectRepo:       projectRepo,
+		jobRepo:           jobRepo,
+		websocket:         wsClient,
+		transaction:       tx,
+		permissionChecker: NewMockPermissionChecker(nil),
+	}
+
+	assert.NoError(t, uc.Delete(ctx, prj.ID()))
+
+	// The closure really did run twice...
+	assert.Equal(t, 2, tx.runs)
+	assert.Equal(t, 2, projectRepo.removeCalls)
+
+	// ...but the document was only destroyed once.
+	assert.Equal(t, []string{prj.ID().String()}, wsClient.deletedDocIDs)
+}
+
+func TestProject_Delete_DoesNotDeleteDocumentWhenTransactionFails(t *testing.T) {
+	ctx := context.Background()
+	projectRepo := memory.NewProject()
+	wsClient := &mockWebsocketClient{}
+
+	prj := project.New().NewID().MustBuild()
+	assert.NoError(t, projectRepo.Save(ctx, prj))
+
+	uc := &Project{
+		projectRepo:       projectRepo,
+		jobRepo:           &failingRemoveByProjectJobRepo{Job: memory.NewJob(), err: errors.New("db unavailable")},
+		websocket:         wsClient,
+		transaction:       usecasex.NewTransactor(&usecasex.NopTransaction{}, 0),
+		permissionChecker: NewMockPermissionChecker(nil),
+	}
+
+	err := uc.Delete(ctx, prj.ID())
+	assert.Error(t, err)
+	assert.Empty(t, wsClient.deletedDocIDs)
 }


### PR DESCRIPTION
`Project.Delete` destroyed the project's collaborative document — GCS snapshots and the Redis stream — inside the transaction, before `Project.Remove`. A rollback or a serialization retry left the project row intact with its workflow document permanently gone: the project still appears in the list and opens as a blank canvas.

The document delete now runs after the transaction commits, best-effort and non-fatal, following the pattern `Deployment.Update` already established. The trade is deliberate: a crash between commit and delete now leaks a document instead of destroying a live one.

Tests use the retrying transactor — `DeleteDocument` is called exactly once when the closure runs twice, and not at all when the transaction ultimately fails.