### PR TITLE
fix(engine): bind-mount schema/ in worker and cli Docker builds

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.118"
+version = "0.2.119"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "Inflector",
  "approx",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5012,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "bytes",
  "clap",
@@ -5065,7 +5065,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5108,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-diagnostics"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5121,7 +5121,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5149,7 +5149,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5179,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "approx",
  "bvh",
@@ -5220,7 +5220,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5264,7 +5264,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5333,7 +5333,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5350,7 +5350,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5364,7 +5364,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "bytes",
  "futures",
@@ -5381,7 +5381,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "bytes",
  "futures",
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5414,7 +5414,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "ahash",
  "bytes",
@@ -5488,7 +5488,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.495"
+version = "0.0.496"
 dependencies = [
  "async-trait",
  "axum",
@@ -8256,7 +8256,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.308"
+version = "0.1.309"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.495"
+version = "0.0.496"
 
 [profile.dev]
 opt-level = 0

--- a/engine/containers/cli/Dockerfile
+++ b/engine/containers/cli/Dockerfile
@@ -38,6 +38,7 @@ RUN \
     --mount=type=bind,source=Cargo.lock,target=Cargo.lock \
     --mount=type=bind,source=runtime,target=runtime \
     --mount=type=bind,source=cli,target=cli \
+    --mount=type=bind,source=schema,target=schema \
     --mount=type=bind,source=testing/plateau-tiles-test,target=testing/plateau-tiles-test \
     --mount=type=bind,source=testing/workflow-tests,target=testing/workflow-tests \
     --mount=type=bind,source=worker,target=worker \

--- a/engine/containers/worker/Dockerfile
+++ b/engine/containers/worker/Dockerfile
@@ -38,6 +38,7 @@ RUN \
     --mount=type=bind,source=Cargo.lock,target=Cargo.lock \
     --mount=type=bind,source=runtime,target=runtime \
     --mount=type=bind,source=cli,target=cli \
+    --mount=type=bind,source=schema,target=schema \
     --mount=type=bind,source=testing/plateau-tiles-test,target=testing/plateau-tiles-test \
     --mount=type=bind,source=testing/workflow-tests,target=testing/workflow-tests \
     --mount=type=bind,source=worker,target=worker \

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.118"
+version = "0.2.119"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.308"
+version = "0.1.309"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
## Overview

Docker image builds for `worker` and `cli` have been failing on every push to `main` since #2270 merged:

```
thread 'main' panicked at runtime/diagnostics/build.rs:72:10:
error-code registry dir engine/schema/error-codes must exist: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

## Root cause

`reearth-flow-diagnostics`'s `build.rs` reads the error-code registry from `schema/error-codes` at build time (added in #2270). The `worker` and `cli` Dockerfiles bind-mount only `runtime`, `cli`, `testing/plateau-tiles-test`, `testing/workflow-tests`, and `worker` into the Docker build context — `schema/` was never added, so the build script can't find the registry inside the container.

Confirmed via the failing run: https://github.com/reearth/reearth-flow/actions/runs/32339924870/job/96341859405

## Fix

Add `--mount=type=bind,source=schema,target=schema` to both Dockerfiles, matching the existing bind-mount pattern for the other required directories.

## Verification

Docker isn't available in this sandbox, so I couldn't run `docker build` directly. Confirmed by inspecting `build.rs`'s exact path resolution (`runtime/diagnostics/../../schema/error-codes` → `schema/error-codes` relative to the `engine/` build context) and the workflow's `context: engine" setting — the fix directly restores the missing input the build script already told us it needed.