### PR TITLE
feat(engine): port Elevation Extractor to new geometry

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.127"
+version = "0.2.128"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "Inflector",
  "approx",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5012,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "bytes",
  "clap",
@@ -5065,7 +5065,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5108,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-diagnostics"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5121,7 +5121,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5149,7 +5149,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5179,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "approx",
  "bvh",
@@ -5220,7 +5220,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5264,7 +5264,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5333,7 +5333,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5350,7 +5350,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5364,7 +5364,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "bytes",
  "futures",
@@ -5381,7 +5381,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "bytes",
  "futures",
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5414,7 +5414,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "ahash",
  "bytes",
@@ -5488,7 +5488,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.504"
+version = "0.0.505"
 dependencies = [
  "async-trait",
  "axum",
@@ -8256,7 +8256,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.317"
+version = "0.1.318"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.504"
+version = "0.0.505"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/action-processor/src/geometry/elevation_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/elevation_extractor.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+#[cfg(feature = "new-geometry")]
+use reearth_flow_geometry::ops::Elevation;
 use reearth_flow_runtime::{
     errors::BoxedError,
     event::EventHub,
@@ -7,7 +9,11 @@ use reearth_flow_runtime::{
     forwarder::ProcessorChannelForwarder,
     node::{Port, Processor, ProcessorFactory, FEATURES_PORT},
 };
-use reearth_flow_types::{Attribute, AttributeValue, GeometryValue};
+#[cfg(feature = "new-geometry")]
+use reearth_flow_types::Feature;
+#[cfg(not(feature = "new-geometry"))]
+use reearth_flow_types::GeometryValue;
+use reearth_flow_types::{Attribute, AttributeValue};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -90,6 +96,23 @@ pub struct ElevationExtractor {
     output_attribute: Attribute,
 }
 
+#[cfg(feature = "new-geometry")]
+impl ElevationExtractor {
+    /// Writes the elevation of the geometry's representative vertex into
+    /// `feature`. A geometry with no elevation to read leaves it untouched.
+    /// Returns the elevation that had no JSON form, if any.
+    fn extract(&self, feature: &mut Feature) -> Option<f64> {
+        let elevation = feature.geometry.elevation()?;
+        match serde_json::Number::from_f64(elevation) {
+            Some(number) => {
+                feature.insert(&self.output_attribute, AttributeValue::Number(number));
+                None
+            }
+            None => Some(elevation),
+        }
+    }
+}
+
 impl Processor for ElevationExtractor {
     fn num_threads(&self) -> usize {
         2
@@ -132,7 +155,27 @@ impl Processor for ElevationExtractor {
         Ok(())
     }
 
-    #[cfg(not(feature = "new-geometry"))]
+    /// Attach the elevation of the geometry's representative vertex to the
+    /// feature. Every feature leaves by `features`, with or without the
+    /// attribute: a geometry with no elevation to read is nothing to do rather
+    /// than a failure.
+    #[cfg(feature = "new-geometry")]
+    fn process(
+        &mut self,
+        ctx: ExecutorContext,
+        fw: &ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        let mut feature = ctx.feature.clone();
+        if let Some(elevation) = self.extract(&mut feature) {
+            ctx.event_hub.debug_log(
+                Some(ctx.error_span()),
+                format!("elevation {elevation} is not a finite number"),
+            );
+        }
+        fw.send(ctx.new_with_feature_and_port(feature, FEATURES_PORT.clone()));
+        Ok(())
+    }
+
     fn finish(
         &mut self,
         _ctx: NodeContext,
@@ -143,5 +186,70 @@ impl Processor for ElevationExtractor {
 
     fn name(&self) -> &str {
         "Elevation Extractor"
+    }
+}
+
+#[cfg(all(test, feature = "new-geometry"))]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use reearth_flow_geometry::coordinate::CoordinateFrame;
+    use reearth_flow_geometry::line_string::{LineString2D, LineString3D};
+    use reearth_flow_geometry::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
+
+    /// The feature `process` would forward for `geometry`, and the non-finite
+    /// elevation it would report, if any.
+    fn run(geometry: Geometry) -> (Feature, Option<f64>) {
+        let extractor = ElevationExtractor {
+            output_attribute: Attribute::new("elevation"),
+        };
+        let mut feature = Feature::from(geometry);
+        let not_finite = extractor.extract(&mut feature);
+        (feature, not_finite)
+    }
+
+    fn attribute(feature: &Feature) -> Option<f64> {
+        match feature.attributes.get(&Attribute::new("elevation"))? {
+            AttributeValue::Number(n) => n.as_f64(),
+            other => panic!("expected a number, got {other:?}"),
+        }
+    }
+
+    fn line_3d(coords: [[f64; 3]; 2]) -> Geometry {
+        Geometry::Euclidean3D(Euclidean3DGeometry::LineString(LineString3D::from_coords(
+            CoordinateFrame::Euclidean,
+            coords,
+        )))
+    }
+
+    #[test]
+    fn an_elevation_is_written_under_the_configured_attribute() {
+        let (feature, not_finite) = run(line_3d([[0.0, 0.0, 12.5], [1.0, 0.0, -3.0]]));
+        assert_eq!(attribute(&feature), Some(12.5));
+        assert_eq!(not_finite, None);
+    }
+
+    #[test]
+    fn a_geometry_without_an_elevation_gets_no_attribute() {
+        let plane = Geometry::Euclidean2D(Euclidean2DGeometry::LineString(
+            LineString2D::from_coords(CoordinateFrame::Euclidean, [[0.0, 0.0], [1.0, 0.0]]),
+        ));
+        for (label, geometry) in [
+            ("no geometry", Geometry::None),
+            ("planar line string", plane),
+        ] {
+            let (feature, not_finite) = run(geometry);
+            assert_eq!(attribute(&feature), None, "{label}");
+            assert_eq!(not_finite, None, "{label}");
+        }
+    }
+
+    #[test]
+    fn a_non_finite_elevation_is_reported_and_gets_no_attribute() {
+        for z in [f64::NAN, f64::INFINITY] {
+            let (feature, not_finite) = run(line_3d([[0.0, 0.0, z], [1.0, 0.0, 0.0]]));
+            assert_eq!(attribute(&feature), None, "z = {z}");
+            assert!(!not_finite.unwrap().is_finite(), "z = {z}");
+        }
     }
 }

--- a/engine/runtime/geometry/src/collection.rs
+++ b/engine/runtime/geometry/src/collection.rs
@@ -20,7 +20,7 @@ use crate::ops::{
     Reproject, ReprojectionCache, UnsupportedOperation,
 };
 #[cfg(feature = "new-geometry")]
-use crate::ops::{Footprint, FootprintError, FootprintSink};
+use crate::ops::{Elevation, Footprint, FootprintError, FootprintSink};
 #[cfg(feature = "new-geometry")]
 use crate::validation_next::Validate;
 use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
@@ -439,6 +439,23 @@ impl Footprint for Collection2D {
 impl Footprint for Collection3D {
     fn footprint(&self, sink: &mut FootprintSink<'_>) -> Result<(), FootprintError> {
         self.members.iter().try_for_each(|m| m.footprint(sink))
+    }
+}
+
+// A collection reports the first member that has an elevation, rather than only
+// its head: a member with none (an absent geometry, a 2D point, an empty leaf) is
+// ordinary and must not hide the ones behind it.
+#[cfg(feature = "new-geometry")]
+impl Elevation for Collection2D {
+    fn elevation(&self) -> Option<f64> {
+        self.members.iter().find_map(Elevation::elevation)
+    }
+}
+
+#[cfg(feature = "new-geometry")]
+impl Elevation for Collection3D {
+    fn elevation(&self) -> Option<f64> {
+        self.members.iter().find_map(Elevation::elevation)
     }
 }
 

--- a/engine/runtime/geometry/src/csg/mod.rs
+++ b/engine/runtime/geometry/src/csg/mod.rs
@@ -42,6 +42,11 @@ crate::unsupported!(Csg: Triangulate, Reproject, ConvertFrame, ForceTwoDimension
 #[cfg(feature = "new-geometry")]
 crate::unsupported!(Csg: Footprint);
 
+// An unevaluated boolean tree has no boundary of its own, so it has no first
+// vertex; its operands' vertices are not the tree's.
+#[cfg(feature = "new-geometry")]
+crate::unsupported!(Csg: Elevation);
+
 // An unevaluated boolean tree has no faces of its own; counting the rings of its
 // operands would describe a surface the tree does not yet have.
 crate::unsupported!(Csg: CountHoles);

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -68,7 +68,7 @@ use ops::{
 // be in scope here.
 use ops::Split;
 #[cfg(feature = "new-geometry")]
-use ops::{Footprint, FootprintError, FootprintPlane, FootprintSink};
+use ops::{Elevation, Footprint, FootprintError, FootprintPlane, FootprintSink};
 #[cfg(feature = "new-geometry")]
 use validation_next::{Validate, ValidationParams, ValidationReport, ValidationType};
 
@@ -210,7 +210,8 @@ impl GeometryCollection {
         CountHoles,
         ExtractHoles,
         ExtractBoundary,
-        Footprint
+        Footprint,
+        Elevation,
     )
 )]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -269,7 +270,8 @@ pub enum Euclidean2DGeometry {
         CountHoles,
         ExtractHoles,
         ExtractBoundary,
-        Footprint
+        Footprint,
+        Elevation,
     )
 )]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -640,6 +642,26 @@ impl Geometry {
         let mut sink = FootprintSink::new(plane);
         self.footprint(&mut sink)?;
         sink.finish()
+    }
+}
+
+#[cfg(feature = "new-geometry")]
+impl Elevation for Geometry {
+    fn elevation(&self) -> Option<f64> {
+        match self {
+            // An absent geometry has no vertex to read.
+            Geometry::None => None,
+            Geometry::Euclidean2D(g) => g.elevation(),
+            Geometry::Euclidean3D(g) => g.elevation(),
+            Geometry::GeometryCollection(c) => c.elevation(),
+        }
+    }
+}
+
+#[cfg(feature = "new-geometry")]
+impl Elevation for GeometryCollection {
+    fn elevation(&self) -> Option<f64> {
+        self.members.iter().find_map(Elevation::elevation)
     }
 }
 

--- a/engine/runtime/geometry/src/line_string/ops.rs
+++ b/engine/runtime/geometry/src/line_string/ops.rs
@@ -307,6 +307,23 @@ impl ExtractBoundary for LineString3D {
     }
 }
 
+#[cfg(feature = "new-geometry")]
+use crate::ops::Elevation;
+
+#[cfg(feature = "new-geometry")]
+impl Elevation for LineString2D {
+    fn elevation(&self) -> Option<f64> {
+        self.z
+    }
+}
+
+#[cfg(feature = "new-geometry")]
+impl Elevation for LineString3D {
+    fn elevation(&self) -> Option<f64> {
+        self.coords.first().map(|c| c[2])
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/ops/elevation.rs
+++ b/engine/runtime/geometry/src/ops/elevation.rs
@@ -1,0 +1,326 @@
+//! Elevation: the z of a geometry's representative vertex.
+//!
+//! [`Elevation`] reads the z of the first vertex reached when the geometry is
+//! walked in its natural nesting order — part, then ring, then vertex. A 2D leaf
+//! has no per-vertex z and reports instead the single elevation the whole leaf
+//! lies at, `None` when it is pure 2D.
+//!
+//! The value only describes the geometry as a whole when the geometry lies at one
+//! elevation; on anything else it is one arbitrary vertex's z. That is inherent
+//! to the definition, not a shortcut in the implementation.
+
+/// The elevation of a geometry's representative vertex.
+#[enum_dispatch::enum_dispatch]
+pub trait Elevation {
+    /// The z of the first vertex in nesting order, or the elevation a 2D leaf
+    /// lies at. `None` when the geometry holds no vertex, carries no elevation,
+    /// or has no vertices of its own to read.
+    fn elevation(&self) -> Option<f64> {
+        None
+    }
+}
+
+impl<T: Elevation + ?Sized> Elevation for Box<T> {
+    fn elevation(&self) -> Option<f64> {
+        (**self).elevation()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::collection::{Collection2D, Collection3D};
+    use crate::coordinate::CoordinateFrame;
+    use crate::csg::{Csg, ThreeDimensional};
+    use crate::line_string::{LineString2D, LineString3D};
+    use crate::ops::Elevation;
+    use crate::point::{Point2D, Point3D};
+    use crate::point_cloud::PointCloud;
+    use crate::polygon::{Polygon2D, Polygon3D};
+    use crate::polygon_mesh::{PolygonMesh2D, PolygonMesh3D};
+    use crate::predicates::test3d::{box_shell, e, g3, solid_geometry};
+    use crate::solid::{Shell, Solid};
+    use crate::triangular_mesh::{
+        TriangularMesh2D, TriangularMesh3D, TriangularMesh3DData as TriData,
+    };
+    use crate::{
+        Euclidean2DGeometry as G2, Euclidean3DGeometry as G3, Geometry, GeometryCollection,
+    };
+    use pretty_assertions::assert_eq;
+
+    fn g2(g: G2) -> Geometry {
+        Geometry::Euclidean2D(g)
+    }
+
+    /// A closed ring at `z`, offset in x by `x0` so callers can build several.
+    fn ring(x0: f64, z: f64) -> Vec<[f64; 3]> {
+        vec![
+            [x0, 0.0, z],
+            [x0 + 1.0, 0.0, z],
+            [x0 + 1.0, 1.0, z],
+            [x0, 0.0, z],
+        ]
+    }
+
+    /// A two-face mesh whose vertex pool is ordered so that the pool's first
+    /// vertex is *not* the first face's first vertex: reading the pool head
+    /// instead of the face would give `9.0`.
+    fn two_face_mesh() -> PolygonMesh3D {
+        PolygonMesh3D::from_parts(
+            e(),
+            vec![
+                [0.0, 0.0, 9.0],
+                [1.0, 0.0, 9.0],
+                [1.0, 1.0, 9.0],
+                [0.0, 0.0, 4.0],
+                [1.0, 0.0, 4.0],
+                [1.0, 1.0, 4.0],
+            ],
+            // The first face is the second triple of vertices.
+            vec![vec![3u32, 4, 5], vec![0u32, 1, 2]],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn a_3d_leaf_reports_its_first_vertex_not_its_extreme() {
+        // Every ring here descends, so the first vertex is the maximum: a `min z`
+        // implementation would return the last coordinate instead.
+        let coords = [[0.0, 0.0, 7.0], [1.0, 0.0, -3.0], [1.0, 1.0, 2.0]];
+        let cases: Vec<(&str, Geometry)> = vec![
+            ("point", g3(G3::Point(Point3D::new(e(), [1.0, 2.0, 7.0])))),
+            (
+                "line string",
+                g3(G3::LineString(LineString3D::from_coords(e(), coords))),
+            ),
+            (
+                "polygon",
+                g3(G3::Polygon(Box::new(Polygon3D::from_rings(
+                    e(),
+                    ring(0.0, 7.0),
+                    // A hole lower than the exterior must not win.
+                    [ring(0.25, -3.0)],
+                )))),
+            ),
+            (
+                "triangular mesh",
+                g3(G3::TriangularMesh(Box::new(TriangularMesh3D::from_soup(
+                    e(),
+                    coords,
+                )))),
+            ),
+            (
+                "point cloud",
+                g3(G3::PointCloud(Box::new(PointCloud::from_positions(
+                    e(),
+                    coords,
+                )))),
+            ),
+        ];
+        for (name, geometry) in cases {
+            assert_eq!(geometry.elevation(), Some(7.0), "{name}");
+        }
+    }
+
+    #[test]
+    fn a_mesh_reports_its_first_face_not_its_vertex_pool_head() {
+        let mesh = two_face_mesh();
+        assert_eq!(mesh.elevation(), Some(4.0));
+        assert_eq!(g3(G3::PolygonMesh(Box::new(mesh))).elevation(), Some(4.0));
+    }
+
+    #[test]
+    fn a_solid_reports_its_exterior_shell_only() {
+        // The void sits below the exterior box, so a solid that folded its
+        // interiors in would report the void's z.
+        let solid = Solid::new(
+            e(),
+            Shell::TriangularMesh(box_shell([0.0, 0.0, 5.0], [4.0, 4.0, 4.0])),
+            vec![Shell::TriangularMesh(box_shell(
+                [1.0, 1.0, -8.0],
+                [1.0, 1.0, 1.0],
+            ))],
+        );
+        assert_eq!(g3(solid_geometry(solid)).elevation(), Some(5.0));
+    }
+
+    #[test]
+    fn a_solid_whose_shell_has_no_face_has_no_elevation() {
+        let empty = Solid::from_exterior(e(), TriData::from_parts(Vec::new(), Vec::new()).unwrap());
+        assert_eq!(g3(solid_geometry(empty)).elevation(), None);
+    }
+
+    #[test]
+    fn a_3d_leaf_without_a_vertex_has_no_elevation() {
+        let cases: Vec<(&str, Geometry)> = vec![
+            (
+                "line string",
+                g3(G3::LineString(LineString3D::from_coords(
+                    e(),
+                    Vec::<[f64; 3]>::new(),
+                ))),
+            ),
+            (
+                "polygon",
+                g3(G3::Polygon(Box::new(Polygon3D::from_rings(
+                    e(),
+                    Vec::<[f64; 3]>::new(),
+                    Vec::<Vec<[f64; 3]>>::new(),
+                )))),
+            ),
+            (
+                "triangular mesh",
+                g3(G3::TriangularMesh(Box::new(TriangularMesh3D::from_soup(
+                    e(),
+                    Vec::<[f64; 3]>::new(),
+                )))),
+            ),
+            (
+                "polygon mesh",
+                g3(G3::PolygonMesh(Box::new(
+                    PolygonMesh3D::from_parts(e(), Vec::new(), Vec::<Vec<u32>>::new()).unwrap(),
+                ))),
+            ),
+            (
+                "point cloud",
+                g3(G3::PointCloud(Box::new(PointCloud::from_positions(
+                    e(),
+                    Vec::<[f64; 3]>::new(),
+                )))),
+            ),
+        ];
+        for (name, geometry) in cases {
+            assert_eq!(geometry.elevation(), None, "{name}");
+        }
+    }
+
+    #[test]
+    fn a_2d_leaf_reports_the_elevation_it_lies_at() {
+        let square = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0]];
+        let cases: Vec<(&str, Geometry, Option<f64>)> = vec![
+            (
+                "line string at an elevation",
+                g2(G2::LineString(LineString2D::from_coords_at_elevation(
+                    e(),
+                    square,
+                    3.5,
+                ))),
+                Some(3.5),
+            ),
+            (
+                "pure 2D line string",
+                g2(G2::LineString(LineString2D::from_coords(e(), square))),
+                None,
+            ),
+            (
+                "polygon at an elevation",
+                g2(G2::Polygon(Box::new(Polygon2D::from_rings_at_elevation(
+                    e(),
+                    square,
+                    Vec::<Vec<[f64; 2]>>::new(),
+                    3.5,
+                )))),
+                Some(3.5),
+            ),
+            (
+                "pure 2D polygon",
+                g2(G2::Polygon(Box::new(Polygon2D::from_rings(
+                    e(),
+                    square,
+                    Vec::<Vec<[f64; 2]>>::new(),
+                )))),
+                None,
+            ),
+            (
+                "polygon mesh at an elevation",
+                g2(G2::PolygonMesh(Box::new(
+                    PolygonMesh2D::from_parts_at_elevation(
+                        e(),
+                        vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]],
+                        vec![vec![0u32, 1, 2]],
+                        3.5,
+                    )
+                    .unwrap(),
+                ))),
+                Some(3.5),
+            ),
+            (
+                "triangular mesh at an elevation",
+                g2(G2::TriangularMesh(Box::new(
+                    TriangularMesh2D::from_parts_at_elevation(
+                        e(),
+                        vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]],
+                        [0u32, 1, 2],
+                        3.5,
+                    )
+                    .unwrap(),
+                ))),
+                Some(3.5),
+            ),
+            (
+                // A position cannot lie at a height, so it never reports one.
+                "point",
+                g2(G2::Point(Point2D::new(e(), [1.0, 2.0]))),
+                None,
+            ),
+        ];
+        for (name, geometry, expected) in cases {
+            assert_eq!(geometry.elevation(), expected, "{name}");
+        }
+    }
+
+    #[test]
+    fn an_absent_geometry_has_no_elevation() {
+        assert_eq!(Geometry::None.elevation(), None);
+    }
+
+    #[test]
+    fn an_unevaluated_boolean_tree_has_no_elevation() {
+        let operand = |z: f64| {
+            ThreeDimensional::Solid(Box::new(Solid::from_exterior(
+                e(),
+                box_shell([0.0, 0.0, z], [1.0; 3]),
+            )))
+        };
+        let csg = Csg::Union(Box::new(operand(5.0)), Box::new(operand(9.0)));
+        assert_eq!(g3(G3::Csg(csg)).elevation(), None);
+    }
+
+    #[test]
+    fn a_collection_reports_the_first_member_that_has_one() {
+        // The leading members carry nothing, so a collection that only looked at
+        // its head would report nothing at all.
+        let members = [
+            G3::LineString(LineString3D::from_coords(e(), Vec::<[f64; 3]>::new())),
+            G3::Point(Point3D::new(e(), [0.0, 0.0, 6.0])),
+            G3::Point(Point3D::new(e(), [0.0, 0.0, 1.0])),
+        ];
+        assert_eq!(
+            g3(G3::Collection(Collection3D::new(members.clone()))).elevation(),
+            Some(6.0)
+        );
+        // Frames may differ across members; the first value still wins.
+        let mixed = GeometryCollection::new([
+            g2(G2::Point(Point2D::new(e(), [0.0, 0.0]))),
+            Geometry::None,
+            g2(G2::LineString(LineString2D::from_coords_at_elevation(
+                CoordinateFrame::Euclidean,
+                [[0.0, 0.0], [1.0, 0.0]],
+                2.5,
+            ))),
+            g3(G3::Collection(Collection3D::new(members))),
+        ]);
+        assert_eq!(Geometry::GeometryCollection(mixed).elevation(), Some(2.5));
+    }
+
+    #[test]
+    fn an_empty_collection_has_no_elevation() {
+        assert_eq!(
+            g2(G2::Collection(Collection2D::new(Vec::new()))).elevation(),
+            None
+        );
+        assert_eq!(
+            Geometry::GeometryCollection(GeometryCollection::new(Vec::new())).elevation(),
+            None
+        );
+    }
+}

--- a/engine/runtime/geometry/src/ops/mod.rs
+++ b/engine/runtime/geometry/src/ops/mod.rs
@@ -11,6 +11,8 @@
 pub mod boundary;
 pub mod coerce;
 #[cfg(feature = "new-geometry")]
+pub mod elevation;
+#[cfg(feature = "new-geometry")]
 pub mod footprint;
 pub mod hole;
 pub mod reproject;
@@ -22,6 +24,8 @@ pub(crate) use boundary::{
 };
 pub use boundary::{Boundary, ExtractBoundary};
 pub use coerce::{Coerce, CoercionTarget};
+#[cfg(feature = "new-geometry")]
+pub use elevation::Elevation;
 #[cfg(feature = "new-geometry")]
 pub use footprint::{Footprint, FootprintError, FootprintPlane, FootprintSink};
 pub(crate) use hole::{area_2d, emit_face_2d, emit_face_3d, emit_triangles_3d};

--- a/engine/runtime/geometry/src/point/ops.rs
+++ b/engine/runtime/geometry/src/point/ops.rs
@@ -189,6 +189,21 @@ impl Footprint for Point3D {
     }
 }
 
+#[cfg(feature = "new-geometry")]
+use crate::ops::Elevation;
+
+// Unlike the other 2D leaves, a point has no elevation field: a position is not
+// a shape that could lie at a height. It reports none.
+#[cfg(feature = "new-geometry")]
+impl Elevation for Point2D {}
+
+#[cfg(feature = "new-geometry")]
+impl Elevation for Point3D {
+    fn elevation(&self) -> Option<f64> {
+        Some(self.position[2])
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/point_cloud/ops.rs
+++ b/engine/runtime/geometry/src/point_cloud/ops.rs
@@ -148,6 +148,20 @@ pub(super) fn segment_positions(seg: &Segment) -> impl Iterator<Item = [f64; 3]>
     })
 }
 
+#[cfg(feature = "new-geometry")]
+use crate::ops::Elevation;
+
+#[cfg(feature = "new-geometry")]
+impl Elevation for PointCloud {
+    fn elevation(&self) -> Option<f64> {
+        self.segments
+            .iter()
+            .flat_map(segment_positions)
+            .next()
+            .map(|p| p[2])
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/polygon/ops.rs
+++ b/engine/runtime/geometry/src/polygon/ops.rs
@@ -507,6 +507,25 @@ impl ExtractBoundary for Polygon3D {
     }
 }
 
+#[cfg(feature = "new-geometry")]
+use crate::ops::Elevation;
+
+#[cfg(feature = "new-geometry")]
+impl Elevation for Polygon2D {
+    fn elevation(&self) -> Option<f64> {
+        self.z
+    }
+}
+
+#[cfg(feature = "new-geometry")]
+impl Elevation for Polygon3D {
+    /// The exterior ring's first vertex; the holes lie inside it and are not
+    /// reached.
+    fn elevation(&self) -> Option<f64> {
+        self.exterior().first().map(|c| c[2])
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/polygon_mesh/ops.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/ops.rs
@@ -745,6 +745,35 @@ impl ExtractBoundary for PolygonMesh3D {
     }
 }
 
+#[cfg(feature = "new-geometry")]
+use crate::ops::Elevation;
+
+#[cfg(feature = "new-geometry")]
+impl Elevation for PolygonMesh2D {
+    fn elevation(&self) -> Option<f64> {
+        self.z
+    }
+}
+
+#[cfg(feature = "new-geometry")]
+impl Elevation for PolygonMesh3D {
+    fn elevation(&self) -> Option<f64> {
+        self.data().first_face_elevation()
+    }
+}
+
+#[cfg(feature = "new-geometry")]
+impl PolygonMesh3DData {
+    /// The z of the first face's first exterior vertex. The CSR index buffer
+    /// begins with that face's exterior ring, so this is where the mesh's
+    /// traversal starts — the vertex pool's own order is unrelated.
+    pub(crate) fn first_face_elevation(&self) -> Option<f64> {
+        let (face_indices, _, _) = self.csr_buffers();
+        let [i] = face_indices.iter_u32().next()?;
+        Some(self.vertices()[i as usize][2])
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/solid/ops.rs
+++ b/engine/runtime/geometry/src/solid/ops.rs
@@ -296,6 +296,21 @@ impl ExtractBoundary for Solid {
     }
 }
 
+#[cfg(feature = "new-geometry")]
+use crate::ops::Elevation;
+
+#[cfg(feature = "new-geometry")]
+impl Elevation for Solid {
+    /// The exterior shell's first face; the voids are inside it and are not
+    /// reached. A shell with no face has no vertex to read.
+    fn elevation(&self) -> Option<f64> {
+        match &self.exterior {
+            Shell::PolygonMesh(data) => data.first_face_elevation(),
+            Shell::TriangularMesh(data) => data.first_triangle_elevation(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/triangular_mesh/ops.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/ops.rs
@@ -502,6 +502,33 @@ impl ExtractBoundary for TriangularMesh3D {
     }
 }
 
+#[cfg(feature = "new-geometry")]
+use crate::ops::Elevation;
+
+#[cfg(feature = "new-geometry")]
+impl Elevation for TriangularMesh2D {
+    fn elevation(&self) -> Option<f64> {
+        self.z
+    }
+}
+
+#[cfg(feature = "new-geometry")]
+impl Elevation for TriangularMesh3D {
+    fn elevation(&self) -> Option<f64> {
+        self.data.first_triangle_elevation()
+    }
+}
+
+#[cfg(feature = "new-geometry")]
+impl TriangularMesh3DData {
+    /// The z of the first triangle's first vertex, which is where the mesh's
+    /// traversal starts — the vertex pool's own order is unrelated.
+    pub(crate) fn first_triangle_elevation(&self) -> Option<f64> {
+        let [i, _, _] = self.triangles().next()?;
+        Some(self.vertices()[i as usize][2])
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.127"
+version = "0.2.128"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.317"
+version = "0.1.318"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
# Overview

Ports `ElevationExtractor` to the `new-geometry` world.

## What I've done

- Add an `Elevation` op to the geometry crate and implement it for every leaf, collection, and solid.
- Wire the action to it behind `#[cfg(feature = "new-geometry")]`, leaving the legacy path untouched.

## What I haven't done

- `Csg` reports no elevation: an unevaluated boolean tree has no boundary of its own.

## How I tested

Unit tests for the op across all geometry variants, plus tests for the action's three outcomes (elevation written, nothing to read, non-finite value).

## Screenshot

## Which point I want you to review particularly

- The definition of "representative vertex": first vertex in nesting order, matching FME's `ElevationExtractor` rather than min/max z. Meaningful only for geometries lying at one elevation.

## Memo

- Behavior on the unhappy paths is pass-through, not drop: a feature with no readable elevation still leaves by `features` without the attribute, because the graphs this action sits in check the geometry downstream and dropping would silently exempt it. A non-finite z is logged instead of failing the node.
- Meshes read the first *face*'s first vertex, not the vertex pool's head — the pool order is unrelated to traversal order. Solids read the exterior shell only, so voids never win.