### PR TITLE
refactor(api): build usecase container once at boot

### DIFF
--- a/server/api/e2e/gql_usecase_singleton_test.go
+++ b/server/api/e2e/gql_usecase_singleton_test.go
@@ -125,13 +125,28 @@ func TestUsecaseContainer_SharedAcrossRequests_LogPollerIsNotDuplicated(t *testi
 	time.Sleep(500 * time.Millisecond)
 	afterSubscribe := redisGateway.getLogsCalls.Load()
 
-	// Wait past one 15s monitoring tick (internal/usecase/interactor/log.go).
-	// A single shared poller issues exactly one more GetLogs call in that
-	// window; two independent pollers -- the bug -- issue two.
-	time.Sleep(16 * time.Second)
-	afterOneTick := redisGateway.getLogsCalls.Load()
+	// Wait for the first monitoring tick (internal/usecase/interactor/log.go,
+	// 15s ticker) rather than sleeping a fixed window: this is both faster in
+	// the common case and avoids CI scheduling jitter around tick alignment.
+	var afterFirstTick int64
+	require.Eventually(t, func() bool {
+		afterFirstTick = redisGateway.getLogsCalls.Load()
+		return afterFirstTick-afterSubscribe >= 1
+	}, 20*time.Second, 100*time.Millisecond, "expected at least one GetLogs call from the poller")
 
-	require.Equal(t, int64(1), afterOneTick-afterSubscribe,
-		"expected exactly one poller ticking for the shared job, observed %d GetLogs call(s)",
-		afterOneTick-afterSubscribe)
+	// A single shared poller issues exactly one GetLogs call for the first
+	// tick; two independent pollers -- the bug -- issue two.
+	require.Equal(t, int64(1), afterFirstTick-afterSubscribe,
+		"expected exactly one poller ticking for the shared job, observed %d GetLogs call(s) by the first tick",
+		afterFirstTick-afterSubscribe)
+
+	// Give a duplicated poller with a slightly offset ticker a chance to fire
+	// its own first tick too; a genuine second poller starts within
+	// milliseconds of the first, so this window need not be long.
+	time.Sleep(1 * time.Second)
+	afterGrace := redisGateway.getLogsCalls.Load()
+
+	require.Equal(t, afterFirstTick, afterGrace,
+		"expected no additional GetLogs call within the grace period, observed %d additional call(s)",
+		afterGrace-afterFirstTick)
 }

--- a/server/api/e2e/gql_usecase_singleton_test.go
+++ b/server/api/e2e/gql_usecase_singleton_test.go
@@ -1,0 +1,137 @@
+package e2e
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	gqlgenclient "github.com/99designs/gqlgen/client"
+	accountsid "github.com/reearth/reearth-accounts/server/pkg/id"
+	"github.com/reearth/reearth-flow/api/internal/app"
+	"github.com/reearth/reearth-flow/api/internal/app/config"
+	"github.com/reearth/reearth-flow/api/internal/infrastructure/fs"
+	infragql "github.com/reearth/reearth-flow/api/internal/infrastructure/gql"
+	"github.com/reearth/reearth-flow/api/internal/infrastructure/memory"
+	"github.com/reearth/reearth-flow/api/internal/usecase/gateway"
+	"github.com/reearth/reearth-flow/api/pkg/graph"
+	"github.com/reearth/reearth-flow/api/pkg/id"
+	"github.com/reearth/reearth-flow/api/pkg/job"
+	"github.com/reearth/reearth-flow/api/pkg/log"
+	"github.com/reearth/reearth-flow/api/pkg/userfacinglog"
+	"github.com/samber/lo"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+// countingRedisGateway counts GetLogs calls so the test can tell a single
+// shared poller ticking on a job apart from two independent ones.
+type countingRedisGateway struct {
+	getLogsCalls atomic.Int64
+}
+
+func (g *countingRedisGateway) GetLogs(_ context.Context, _, _ time.Time, _ id.JobID) ([]*log.Log, error) {
+	g.getLogsCalls.Add(1)
+	return nil, nil
+}
+
+func (g *countingRedisGateway) GetUserFacingLogs(_ context.Context, _, _ time.Time, _ id.JobID) ([]*userfacinglog.UserFacingLog, error) {
+	return nil, nil
+}
+
+func (g *countingRedisGateway) GetNodeExecutions(_ context.Context, _ id.JobID) ([]*graph.NodeExecution, error) {
+	return nil, nil
+}
+
+func (g *countingRedisGateway) GetNodeExecution(_ context.Context, _ id.JobID, _ string) (*graph.NodeExecution, error) {
+	return nil, nil
+}
+
+func (g *countingRedisGateway) GetJobCompleteEvent(_ context.Context, _ id.JobID) (*gateway.JobCompleteEvent, error) {
+	return nil, nil
+}
+
+func (g *countingRedisGateway) DeleteJobCompleteEvent(_ context.Context, _ id.JobID) error {
+	return nil
+}
+
+const logsSubscriptionQuery = `subscription($jobId: ID!) { logs(jobId: $jobId) { jobId message } }`
+
+// TestUsecaseContainer_SharedAcrossRequests_LogPollerIsNotDuplicated boots the
+// real server the same way main.Start does -- one interactor.Container built
+// once, reused by every request -- and proves the fix end-to-end: two
+// independent GraphQL subscriptions on the same running job collapse onto a
+// single background log poller.
+//
+// Before this fix, UsecaseMiddleware called interactor.NewContainer per
+// request, so each subscription got its own LogInteractor with a fresh
+// watchers map and its own 15s poller. No unit test on the interactor alone
+// can see that regression: it never has two requests sharing, or failing to
+// share, one container. Only booting the real server and driving it with two
+// separate connections proves the container the server actually serves is
+// the singleton.
+//
+// Memory-backed on purpose (no live MongoDB needed) so this runs anywhere.
+func TestUsecaseContainer_SharedAcrossRequests_LogPollerIsNotDuplicated(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	ctx := context.Background()
+	repos := memory.New()
+	// memory.New doesn't wire a Job repo (it's not needed by the e2e suites
+	// that already exist); this test needs one to persist a running job.
+	repos.Job = memory.NewJob()
+
+	runningJob, err := job.New().
+		NewID().
+		Deployment(id.NewDeploymentID().Ref()).
+		Workspace(accountsid.NewWorkspaceID()).
+		Status(job.StatusRunning).
+		StartedAt(time.Now()).
+		Build()
+	require.NoError(t, err)
+	require.NoError(t, repos.Job.Save(ctx, runningJob))
+
+	redisGateway := &countingRedisGateway{}
+	gateways := &gateway.Container{
+		File:  lo.Must(fs.NewFile(afero.NewMemMapFs(), "https://example.com", "https://example2.com")),
+		Redis: redisGateway,
+	}
+
+	mockPermissionChecker := gateway.NewMockPermissionChecker()
+	mockPermissionChecker.Allow = true
+
+	srv := app.NewServer(ctx, &app.ServerConfig{
+		Config:            &config.Config{AuthSrv: config.AuthSrvConfig{Disabled: true}},
+		Repos:             repos,
+		Gateways:          gateways,
+		AccountRepos:      repos.AccountRepos(),
+		PermissionChecker: mockPermissionChecker,
+		AccountGQLClient:  infragql.NewMockClient(&infragql.MockClientParam{}),
+		Debug:             true,
+	})
+
+	cli := gqlgenclient.New(srv, gqlgenclient.Path("/api/graphql"))
+
+	sub1 := cli.Websocket(logsSubscriptionQuery, gqlgenclient.Var("jobId", runningJob.ID().String()))
+	defer func() { _ = sub1.Close() }()
+	sub2 := cli.Websocket(logsSubscriptionQuery, gqlgenclient.Var("jobId", runningJob.ID().String()))
+	defer func() { _ = sub2.Close() }()
+
+	// Both subscriptions trigger their own "initial missed logs" fetch on top
+	// of the periodic poller; that is not the behaviour under test, so let it
+	// settle first.
+	time.Sleep(500 * time.Millisecond)
+	afterSubscribe := redisGateway.getLogsCalls.Load()
+
+	// Wait past one 15s monitoring tick (internal/usecase/interactor/log.go).
+	// A single shared poller issues exactly one more GetLogs call in that
+	// window; two independent pollers -- the bug -- issue two.
+	time.Sleep(16 * time.Second)
+	afterOneTick := redisGateway.getLogsCalls.Load()
+
+	require.Equal(t, int64(1), afterOneTick-afterSubscribe,
+		"expected exactly one poller ticking for the shared job, observed %d GetLogs call(s)",
+		afterOneTick-afterSubscribe)
+}

--- a/server/api/internal/app/app.go
+++ b/server/api/internal/app/app.go
@@ -95,7 +95,7 @@ func initEcho(ctx context.Context, cfg *ServerConfig) *echo.Echo {
 	}
 
 	sharedJob := interactor.NewJob(cfg.Repos, cfg.Gateways, cfg.PermissionChecker)
-	e.Use(UsecaseMiddleware(cfg.Repos, cfg.Gateways, cfg.PermissionChecker, cfg.AccountGQLClient, sharedJob, interactor.ContainerConfig{
+	uc := interactor.NewContainer(cfg.Repos, cfg.Gateways, cfg.PermissionChecker, cfg.AccountGQLClient, sharedJob, interactor.ContainerConfig{
 		SignupSecret:             cfg.Config.SignupSecret,
 		AuthSrvUIDomain:          cfg.Config.Host_Web,
 		Host:                     cfg.Config.Host,
@@ -103,7 +103,8 @@ func initEcho(ctx context.Context, cfg *ServerConfig) *echo.Echo {
 		WebsocketThriftServerURL: cfg.Config.WebsocketThriftServerURL,
 		WebsocketAPISecret:       cfg.Config.WebsocketAPISecret,
 		SkipPermissionCheck:      cfg.Config.SkipPermissionCheck,
-	}))
+	})
+	e.Use(UsecaseMiddleware(&uc))
 
 	// apis
 	api := e.Group("/api")

--- a/server/api/internal/app/usecase.go
+++ b/server/api/internal/app/usecase.go
@@ -4,21 +4,13 @@ import (
 	"context"
 
 	"github.com/labstack/echo/v4"
-	"github.com/reearth/reearth-accounts/server/pkg/gqlclient"
 	"github.com/reearth/reearth-flow/api/internal/adapter"
-	"github.com/reearth/reearth-flow/api/internal/usecase/gateway"
-	"github.com/reearth/reearth-flow/api/internal/usecase/interactor"
 	"github.com/reearth/reearth-flow/api/internal/usecase/interfaces"
-	"github.com/reearth/reearth-flow/api/internal/usecase/repo"
 )
 
-func UsecaseMiddleware(r *repo.Container, g *gateway.Container, permissionChecker gateway.PermissionChecker, GQLClient *gqlclient.Client, sharedJob interfaces.Job, config interactor.ContainerConfig) echo.MiddlewareFunc {
+func UsecaseMiddleware(uc *interfaces.Container) echo.MiddlewareFunc {
 	return ContextMiddleware(func(ctx context.Context) context.Context {
-		repos := r
-
-		uc := interactor.NewContainer(repos, g, permissionChecker, GQLClient, sharedJob, config)
-		ctx = adapter.AttachUsecases(ctx, &uc)
-		return ctx
+		return adapter.AttachUsecases(ctx, uc)
 	})
 }
 

--- a/server/api/internal/app/usecase_test.go
+++ b/server/api/internal/app/usecase_test.go
@@ -1,0 +1,43 @@
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/reearth/reearth-flow/api/internal/adapter"
+	"github.com/reearth/reearth-flow/api/internal/usecase/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUsecaseMiddleware_SharesContainerAcrossRequests pins the singleton
+// wiring: the middleware must attach the same *interfaces.Container built at
+// boot rather than allocating one per request.
+func TestUsecaseMiddleware_SharesContainerAcrossRequests(t *testing.T) {
+	t.Parallel()
+
+	uc := &interfaces.Container{}
+
+	e := echo.New()
+	e.Use(UsecaseMiddleware(uc))
+
+	var observed []*interfaces.Container
+	e.GET("/probe", func(c echo.Context) error {
+		observed = append(observed, adapter.Usecases(c.Request().Context()))
+		return c.NoContent(http.StatusOK)
+	})
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+
+	require.Len(t, observed, 2)
+	assert.Same(t, uc, observed[0])
+	assert.Same(t, uc, observed[1])
+	assert.Same(t, observed[0], observed[1])
+}

--- a/server/api/internal/usecase/interactor/log_test.go
+++ b/server/api/internal/usecase/interactor/log_test.go
@@ -325,16 +325,23 @@ func TestLogInteractor_SecondSubscriberDoesNotStartSecondPoller(t *testing.T) {
 	// happens once every request shares the same interactor instance.
 	var wg sync.WaitGroup
 	chans := make([]chan *log.Log, 2)
+	errs := make([]error, 2)
 	for i := range chans {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
 			ch, err := liInterface.Subscribe(ctx, jobID)
-			assert.NoError(t, err)
 			chans[i] = ch
+			errs[i] = err
 		}(i)
 	}
 	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("Subscribe(%d) returned error: %v", i, err)
+		}
+	}
 
 	li.mu.Lock()
 	watcherCount := len(li.watchers)

--- a/server/api/internal/usecase/interactor/log_test.go
+++ b/server/api/internal/usecase/interactor/log_test.go
@@ -3,6 +3,7 @@ package interactor
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -283,6 +284,66 @@ func TestLogInteractor_StopsMonitoringWhenJobCompleted(t *testing.T) {
 			t.Fatal("Log monitoring loop did not stop when job was completed")
 		}
 	})
+}
+
+// TestLogInteractor_SecondSubscriberDoesNotStartSecondPoller pins the fix: with
+// a container built once at boot, the same LogInteractor (and its watchers map)
+// is shared by every request. Two subscribers on the same job must collapse
+// onto one background poller, not each start their own.
+func TestLogInteractor_SecondSubscriberDoesNotStartSecondPoller(t *testing.T) {
+	runningJob, err := job.New().
+		NewID().
+		Deployment(id.NewDeploymentID().Ref()).
+		Workspace(accountsid.NewWorkspaceID()).
+		Status(job.StatusRunning).
+		StartedAt(time.Now()).
+		Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	jobID := runningJob.ID()
+	redisMock := &mockLogGateway{}
+	jobRepoMock := &mockJobRepo{job: runningJob}
+	mockPermissionCheckerTrue := NewMockPermissionChecker(func(ctx context.Context, resource, action string) (bool, error) {
+		return true, nil
+	})
+
+	liInterface := NewLogInteractor(redisMock, jobRepoMock, mockPermissionCheckerTrue)
+	li, ok := liInterface.(*LogInteractor)
+	if !ok {
+		t.Fatal("expected *LogInteractor")
+	}
+
+	mockAuthInfo := &appx.AuthInfo{Token: "token"}
+	mockUser := accountsuser.New().NewID().Name("hoge").Email("abc@bb.cc").MustBuild()
+	ctx := context.Background()
+	ctx = adapter.AttachAuthInfo(ctx, mockAuthInfo)
+	ctx = adapter.AttachUser(ctx, mockUser)
+
+	// Two "requests" subscribing to the same running job concurrently, as
+	// happens once every request shares the same interactor instance.
+	var wg sync.WaitGroup
+	chans := make([]chan *log.Log, 2)
+	for i := range chans {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ch, err := liInterface.Subscribe(ctx, jobID)
+			assert.NoError(t, err)
+			chans[i] = ch
+		}(i)
+	}
+	wg.Wait()
+
+	li.mu.Lock()
+	watcherCount := len(li.watchers)
+	li.mu.Unlock()
+	assert.Equal(t, 1, watcherCount, "expected exactly one poller for the job, got %d", watcherCount)
+
+	li.Unsubscribe(jobID, chans[0])
+	li.Unsubscribe(jobID, chans[1])
+	li.stopWatchingLogs(jobID.String())
 }
 
 func TestLogInteractor_FlushFinalLogs(t *testing.T) {


### PR DESCRIPTION
`UsecaseMiddleware` called `interactor.NewContainer` on every request — including static file serving — allocating ~16 interactor structs, a websocket client and three subscription managers each time.

The functional cost is larger than the allocations. The `watchers` maps inside the Log, UserFacingLog and NodeExecution interactors exist to de-duplicate background pollers, but a fresh container per request meant each map only ever saw one connection. Fifty people watching the same running job started fifty independent pollers, each re-reading that job's entire log history from Redis every 15 seconds.

The container is now built once in `initEcho` and attached by pointer, generalising the treatment `sharedJob` already had. `setSkipPermissionCheck` moves to boot with it; it reads process-wide config anyway.

The three `watchers` maps and `Job`'s `activeWatchers`/`jobLocks` were already mutex-guarded, so sharing them process-wide needed no new locking — the touched packages pass under `-race`.

The e2e test boots the real server, opens two `logs` subscriptions on the same job, and asserts the shared Redis gateway sees exactly one `GetLogs` call across a monitoring tick. Against the old per-request wiring it observes two.