### PR TITLE
perf(api): add composite indexes for workspace list query sort shapes

### DIFF
--- a/server/api/internal/infrastructure/postgres/list_query_index_test.go
+++ b/server/api/internal/infrastructure/postgres/list_query_index_test.go
@@ -1,0 +1,155 @@
+package postgres_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/reearth/reearth-flow/api/internal/infrastructure/postgres/pgtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedListQueryRows inserts enough rows (one target workspace plus noise from
+// another) that the planner has a real choice between a sequential scan and
+// an index scan for the paginated list queries below.
+func seedListQueryRows(t *testing.T, ctx context.Context, exec func(ctx context.Context, sql string, args ...any) error) {
+	t.Helper()
+
+	stmts := []string{
+		`INSERT INTO projects (id, workspace_id, workflow_id, name, description, is_archived, updated_at)
+		 SELECT 'lqi_proj_' || i, CASE WHEN i % 10 = 0 THEN 'lqi_ws_other' ELSE 'lqi_ws_big' END, 'wf', 'P' || i, '', false, now() - (i || ' minutes')::interval
+		 FROM generate_series(1, 500) i`,
+		`INSERT INTO deployments (id, workspace_id, workflow_url, description, version, updated_at, is_head)
+		 SELECT 'lqi_dep_' || i, CASE WHEN i % 10 = 0 THEN 'lqi_ws_other' ELSE 'lqi_ws_big' END, '', 'D' || i, 'v' || i, now() - (i || ' minutes')::interval, false
+		 FROM generate_series(1, 500) i`,
+		`INSERT INTO jobs (id, workspace_id, started_at, debug, status)
+		 SELECT 'lqi_job_' || i, CASE WHEN i % 10 = 0 THEN 'lqi_ws_other' ELSE 'lqi_ws_big' END, now() - (i || ' minutes')::interval, (i % 50 = 0), 'COMPLETED'
+		 FROM generate_series(1, 500) i`,
+		`INSERT INTO triggers (id, workspace_id, deployment_id, description, event_source, created_at, updated_at)
+		 SELECT 'lqi_trg_' || i, CASE WHEN i % 10 = 0 THEN 'lqi_ws_other' ELSE 'lqi_ws_big' END, 'lqi_dep_' || i, 'T' || i, 'API', now() - (i || ' minutes')::interval, now() - (i || ' minutes')::interval
+		 FROM generate_series(1, 500) i`,
+		`INSERT INTO assets (id, workspace_id, created_at, name, file_name)
+		 SELECT 'lqi_asset_' || i, CASE WHEN i % 10 = 0 THEN 'lqi_ws_other' ELSE 'lqi_ws_big' END, now() - (i || ' minutes')::interval, 'A' || i, 'f' || i
+		 FROM generate_series(1, 500) i`,
+		`ANALYZE projects, deployments, jobs, triggers, assets`,
+	}
+	for _, s := range stmts {
+		require.NoError(t, exec(ctx, s))
+	}
+}
+
+// explainPlan runs EXPLAIN (without ANALYZE) and returns the plan text.
+func explainPlan(t *testing.T, ctx context.Context, query func(ctx context.Context, sql string) (string, error), sql string) string {
+	t.Helper()
+	explain := "EXPLAIN " + sql
+	plan, err := query(ctx, explain)
+	require.NoError(t, err)
+	return plan
+}
+
+func TestListQueries_UseCompositeIndexes(t *testing.T) {
+	pool := pgtest.Connect(t)(t)
+	ctx := context.Background()
+
+	exec := func(ctx context.Context, sql string, args ...any) error {
+		_, err := pool.Exec(ctx, sql, args...)
+		return err
+	}
+	query := func(ctx context.Context, sql string) (string, error) {
+		rows, err := pool.Query(ctx, sql)
+		if err != nil {
+			return "", err
+		}
+		defer rows.Close()
+		var b strings.Builder
+		for rows.Next() {
+			var line string
+			if err := rows.Scan(&line); err != nil {
+				return "", err
+			}
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+		return b.String(), rows.Err()
+	}
+
+	seedListQueryRows(t, ctx, exec)
+
+	cases := []struct {
+		name      string
+		sql       string
+		indexName string
+	}{
+		{
+			name:      "projects default list",
+			sql:       `SELECT * FROM projects WHERE workspace_id = 'lqi_ws_big' AND is_archived = false ORDER BY updated_at DESC LIMIT 20`,
+			indexName: "projects_workspace_id_is_archived_updated_at_idx",
+		},
+		{
+			name:      "deployments default list",
+			sql:       `SELECT * FROM deployments WHERE workspace_id = 'lqi_ws_big' ORDER BY updated_at DESC LIMIT 20`,
+			indexName: "deployments_workspace_id_updated_at_idx",
+		},
+		{
+			name:      "jobs default list",
+			sql:       `SELECT * FROM jobs WHERE workspace_id = 'lqi_ws_big' AND (debug IS NULL OR debug = false) ORDER BY started_at DESC LIMIT 20`,
+			indexName: "jobs_workspace_id_started_at_idx",
+		},
+		{
+			name:      "triggers default list",
+			sql:       `SELECT * FROM triggers WHERE workspace_id = 'lqi_ws_big' ORDER BY updated_at DESC LIMIT 20`,
+			indexName: "triggers_workspace_id_updated_at_idx",
+		},
+		{
+			name:      "assets default list",
+			sql:       `SELECT * FROM assets WHERE workspace_id = 'lqi_ws_big' ORDER BY created_at DESC LIMIT 20`,
+			indexName: "assets_workspace_id_created_at_idx",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := explainPlan(t, ctx, query, tc.sql)
+			assert.Contains(t, plan, fmt.Sprintf("Index Scan using %s", tc.indexName), "plan should use %s:\n%s", tc.indexName, plan)
+			assert.NotContains(t, plan, "Seq Scan", "plan should not fall back to a sequential scan:\n%s", plan)
+			assert.NotContains(t, plan, "Sort ", "index should satisfy ORDER BY without a separate sort step:\n%s", plan)
+		})
+	}
+}
+
+// TestListQueries_CompositeIndexesExist pins the exact column order the
+// migration must create: it fails immediately (rather than via planner
+// heuristics) if an index is missing or its column order doesn't match the
+// query's WHERE + ORDER BY shape.
+func TestListQueries_CompositeIndexesExist(t *testing.T) {
+	pool := pgtest.Connect(t)(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		table   string
+		index   string
+		wantDef string
+	}{
+		{"projects", "projects_workspace_id_is_archived_updated_at_idx",
+			`CREATE INDEX projects_workspace_id_is_archived_updated_at_idx ON public.projects USING btree (workspace_id, is_archived, updated_at DESC)`},
+		{"deployments", "deployments_workspace_id_updated_at_idx",
+			`CREATE INDEX deployments_workspace_id_updated_at_idx ON public.deployments USING btree (workspace_id, updated_at DESC)`},
+		{"jobs", "jobs_workspace_id_started_at_idx",
+			`CREATE INDEX jobs_workspace_id_started_at_idx ON public.jobs USING btree (workspace_id, started_at DESC)`},
+		{"triggers", "triggers_workspace_id_updated_at_idx",
+			`CREATE INDEX triggers_workspace_id_updated_at_idx ON public.triggers USING btree (workspace_id, updated_at DESC)`},
+		{"assets", "assets_workspace_id_created_at_idx",
+			`CREATE INDEX assets_workspace_id_created_at_idx ON public.assets USING btree (workspace_id, created_at DESC)`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.index, func(t *testing.T) {
+			var indexdef string
+			row := pool.QueryRow(ctx, `SELECT indexdef FROM pg_indexes WHERE tablename = $1 AND indexname = $2`, tc.table, tc.index)
+			require.NoError(t, row.Scan(&indexdef), "index %s must exist on table %s", tc.index, tc.table)
+			assert.Equal(t, tc.wantDef, indexdef)
+		})
+	}
+}

--- a/server/api/internal/infrastructure/postgres/list_query_index_test.go
+++ b/server/api/internal/infrastructure/postgres/list_query_index_test.go
@@ -2,7 +2,7 @@ package postgres_test
 
 import (
 	"context"
-	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -47,6 +47,27 @@ func explainPlan(t *testing.T, ctx context.Context, query func(ctx context.Conte
 	plan, err := query(ctx, explain)
 	require.NoError(t, err)
 	return plan
+}
+
+// indexScanRegexp matches any scan-node variant (forward, backward,
+// index-only, or bitmap) that names the given index, since the planner may
+// pick any of them over a plain "Index Scan" while still using the index.
+func indexScanRegexp(indexName string) *regexp.Regexp {
+	name := regexp.QuoteMeta(indexName)
+	return regexp.MustCompile(`(?:Index(?: Only)? Scan(?: Backward)? using|Bitmap Index Scan on) ` + name + `\b`)
+}
+
+// fullSortRegexp matches a plain "Sort" plan node but not "Incremental
+// Sort", which still relies on the index for a presorted prefix.
+var fullSortRegexp = regexp.MustCompile(`(?m)^\s*(?:->\s*)?(Incremental )?Sort\s+\(cost=`)
+
+func hasFullSort(plan string) bool {
+	for _, m := range fullSortRegexp.FindAllStringSubmatch(plan, -1) {
+		if m[1] == "" {
+			return true
+		}
+	}
+	return false
 }
 
 func TestListQueries_UseCompositeIndexes(t *testing.T) {
@@ -112,9 +133,9 @@ func TestListQueries_UseCompositeIndexes(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			plan := explainPlan(t, ctx, query, tc.sql)
-			assert.Contains(t, plan, fmt.Sprintf("Index Scan using %s", tc.indexName), "plan should use %s:\n%s", tc.indexName, plan)
+			assert.Regexp(t, indexScanRegexp(tc.indexName), plan, "plan should use %s:\n%s", tc.indexName, plan)
 			assert.NotContains(t, plan, "Seq Scan", "plan should not fall back to a sequential scan:\n%s", plan)
-			assert.NotContains(t, plan, "Sort ", "index should satisfy ORDER BY without a separate sort step:\n%s", plan)
+			assert.False(t, hasFullSort(plan), "index should satisfy ORDER BY without a full sort step:\n%s", plan)
 		})
 	}
 }

--- a/server/db/migrations/20260820132814_add_list_query_indexes.sql
+++ b/server/db/migrations/20260820132814_add_list_query_indexes.sql
@@ -1,0 +1,10 @@
+-- Create index "assets_workspace_id_created_at_idx" to table: "assets"
+CREATE INDEX "assets_workspace_id_created_at_idx" ON "public"."assets" ("workspace_id", "created_at" DESC);
+-- Create index "deployments_workspace_id_updated_at_idx" to table: "deployments"
+CREATE INDEX "deployments_workspace_id_updated_at_idx" ON "public"."deployments" ("workspace_id", "updated_at" DESC);
+-- Create index "jobs_workspace_id_started_at_idx" to table: "jobs"
+CREATE INDEX "jobs_workspace_id_started_at_idx" ON "public"."jobs" ("workspace_id", "started_at" DESC);
+-- Create index "projects_workspace_id_is_archived_updated_at_idx" to table: "projects"
+CREATE INDEX "projects_workspace_id_is_archived_updated_at_idx" ON "public"."projects" ("workspace_id", "is_archived", "updated_at" DESC);
+-- Create index "triggers_workspace_id_updated_at_idx" to table: "triggers"
+CREATE INDEX "triggers_workspace_id_updated_at_idx" ON "public"."triggers" ("workspace_id", "updated_at" DESC);

--- a/server/db/migrations/atlas.sum
+++ b/server/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:57uQGfGdylDX+ygX16BLQrFcRoaqCphwGUrPypSBT9U=
+h1:yY9/0J9/vqxto6mmrUnDeUu4eD021LpZQlwYzcTnoMM=
 20260608231447_initial_triggers.sql h1:8uc/yJazir2+q1q6VudYXM+KRLu3CzLtm7Nd7zSdW18=
 20260615133004_add_config.sql h1:7Y7TzCo0ohdPlGHTgyAD1230ndvat8Dxny5IMCEeHwg=
 20260615133903_add_parameters.sql h1:riYY4v/ZN9fFLzWnsy0434qkwWZ7zN7UrfwX65eGT7o=
@@ -13,3 +13,4 @@ h1:57uQGfGdylDX+ygX16BLQrFcRoaqCphwGUrPypSBT9U=
 20260617183803_add_auth_request.sql h1:satIwV7EKH651tyGk26eL5lpNMbkoxT3FvENFIvzeU0=
 20260618143419_add_asset.sql h1:73GqqRkt6BBRgozKBx8BWxHJqG04G48qsytVs+dtXzk=
 20260622090146_add_job_mode.sql h1:rOSWsDALjuf05wxKMynei9BzO8oZH55cHVIbZFsxnQU=
+20260820132814_add_list_query_indexes.sql h1:YbCWIvxdo2OEi18/lhsKG2tAx2hl9tKHKY9C0kFmsd0=

--- a/server/db/schema.hcl
+++ b/server/db/schema.hcl
@@ -82,6 +82,15 @@ table "triggers" {
   index "triggers_deployment_id_idx" {
     columns = [column.deployment_id]
   }
+  index "triggers_workspace_id_updated_at_idx" {
+    on {
+      column = column.workspace_id
+    }
+    on {
+      column = column.updated_at
+      desc   = true
+    }
+  }
 }
 
 table "parameters" {
@@ -369,6 +378,15 @@ table "deployments" {
   index "deployments_workspace_id_is_head_idx" {
     columns = [column.workspace_id, column.is_head]
   }
+  index "deployments_workspace_id_updated_at_idx" {
+    on {
+      column = column.workspace_id
+    }
+    on {
+      column = column.updated_at
+      desc   = true
+    }
+  }
 }
 
 table "jobs" {
@@ -464,6 +482,15 @@ table "jobs" {
   index "jobs_workspace_id_debug_idx" {
     columns = [column.workspace_id, column.debug]
   }
+  index "jobs_workspace_id_started_at_idx" {
+    on {
+      column = column.workspace_id
+    }
+    on {
+      column = column.started_at
+      desc   = true
+    }
+  }
 }
 
 table "projects" {
@@ -524,6 +551,18 @@ table "projects" {
   }
   index "projects_workspace_id_is_archived_idx" {
     columns = [column.workspace_id, column.is_archived]
+  }
+  index "projects_workspace_id_is_archived_updated_at_idx" {
+    on {
+      column = column.workspace_id
+    }
+    on {
+      column = column.is_archived
+    }
+    on {
+      column = column.updated_at
+      desc   = true
+    }
   }
 }
 
@@ -598,6 +637,15 @@ table "assets" {
 
   index "assets_workspace_id_idx" {
     columns = [column.workspace_id]
+  }
+  index "assets_workspace_id_created_at_idx" {
+    on {
+      column = column.workspace_id
+    }
+    on {
+      column = column.created_at
+      desc   = true
+    }
   }
 }
 


### PR DESCRIPTION
Every paginated list query in the Postgres implementation (`FindByWorkspace` on projects, deployments, jobs, triggers and assets) filters by `workspace_id` and sorts by a fixed column descending, but no index covered that `WHERE` + `ORDER BY` shape — so each page scanned and sorted the whole workspace's rows.

Five composite indexes matching the actual shapes, as an Atlas migration in the shared `server/db` module. `TestListQueries_UseCompositeIndexes` seeds 500 rows and asserts the plans: index scan, no sequential scan, no sort node. Postgres-gated via `pgtest`, so it skips without `REEARTH_FLOW_DB_PG`.

Mongo is deliberately untouched — it is being replaced by Postgres, so index work targets the Postgres path only.

Two things left for follow-ups rather than folded in here:

- Several existing single-column indexes (`projects_workspace_id_idx`, `deployments_workspace_id_idx`, `triggers_workspace_id_idx`, `assets_workspace_id_idx`, `projects_workspace_id_is_archived_idx`) are now redundant prefixes of the new composites and cost write amplification. Dropping them is a separate, easily-reverted change.
- `Project.FindByWorkspace` with `includeArchived=true` produces `WHERE workspace_id = $1 ORDER BY updated_at DESC`, which `(workspace_id, is_archived, updated_at DESC)` cannot satisfy in sorted order because `is_archived` sits between the filter and the sort column. The common archived-excluded path is covered; that variant still sorts.

The indexes are created non-concurrently, matching every prior migration here. That is fine while Postgres is a fresh ETL target rather than the live primary, but once it carries production traffic index additions should move to `CREATE INDEX CONCURRENTLY` with the migration marked non-transactional.

Not in this PR: collapsing `pgxx.CountAndList`'s `COUNT(*)` + page double query. The indexes are the dominant term; changing count semantics is a separate, measured decision.