### PR TITLE
refactor(engine): action audit and base_actions adjustment

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.123"
+version = "0.2.124"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "Inflector",
  "approx",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5012,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "bytes",
  "clap",
@@ -5065,7 +5065,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5108,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-diagnostics"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5121,7 +5121,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5149,7 +5149,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5179,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "approx",
  "bvh",
@@ -5220,7 +5220,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5264,7 +5264,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5333,7 +5333,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5350,7 +5350,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5364,7 +5364,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "bytes",
  "futures",
@@ -5381,7 +5381,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "bytes",
  "futures",
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5414,7 +5414,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "ahash",
  "bytes",
@@ -5488,7 +5488,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.500"
+version = "0.0.501"
 dependencies = [
  "async-trait",
  "axum",
@@ -8256,7 +8256,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.313"
+version = "0.1.314"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.124"
+version = "0.2.125"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "Inflector",
  "approx",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5012,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "bytes",
  "clap",
@@ -5065,7 +5065,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5108,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-diagnostics"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5121,7 +5121,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5149,7 +5149,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5179,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "approx",
  "bvh",
@@ -5220,7 +5220,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5264,7 +5264,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5333,7 +5333,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5350,7 +5350,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5364,7 +5364,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "bytes",
  "futures",
@@ -5381,7 +5381,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "bytes",
  "futures",
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5414,7 +5414,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "ahash",
  "bytes",
@@ -5488,7 +5488,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.501"
+version = "0.0.502"
 dependencies = [
  "async-trait",
  "axum",
@@ -8256,7 +8256,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.314"
+version = "0.1.315"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.125"
+version = "0.2.126"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "Inflector",
  "approx",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5012,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "bytes",
  "clap",
@@ -5065,7 +5065,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5108,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-diagnostics"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5121,7 +5121,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5149,7 +5149,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5179,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "approx",
  "bvh",
@@ -5220,7 +5220,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5264,7 +5264,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5333,7 +5333,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5350,7 +5350,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5364,7 +5364,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "bytes",
  "futures",
@@ -5381,7 +5381,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "bytes",
  "futures",
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5414,7 +5414,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "ahash",
  "bytes",
@@ -5488,7 +5488,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.502"
+version = "0.0.503"
 dependencies = [
  "async-trait",
  "axum",
@@ -8256,7 +8256,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.315"
+version = "0.1.316"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.121"
+version = "0.2.122"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "Inflector",
  "approx",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5012,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "bytes",
  "clap",
@@ -5065,7 +5065,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5108,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-diagnostics"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5121,7 +5121,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5149,7 +5149,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5179,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "approx",
  "bvh",
@@ -5220,7 +5220,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5264,7 +5264,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5333,7 +5333,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5350,7 +5350,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5364,7 +5364,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "bytes",
  "futures",
@@ -5381,7 +5381,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "bytes",
  "futures",
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5414,7 +5414,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "ahash",
  "bytes",
@@ -5488,7 +5488,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.498"
+version = "0.0.499"
 dependencies = [
  "async-trait",
  "axum",
@@ -8256,7 +8256,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.311"
+version = "0.1.312"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.122"
+version = "0.2.123"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "Inflector",
  "approx",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5012,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "bytes",
  "clap",
@@ -5065,7 +5065,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5108,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-diagnostics"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5121,7 +5121,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5149,7 +5149,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5179,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "approx",
  "bvh",
@@ -5220,7 +5220,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5264,7 +5264,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5333,7 +5333,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5350,7 +5350,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5364,7 +5364,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "bytes",
  "futures",
@@ -5381,7 +5381,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "bytes",
  "futures",
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5414,7 +5414,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "ahash",
  "bytes",
@@ -5488,7 +5488,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.499"
+version = "0.0.500"
 dependencies = [
  "async-trait",
  "axum",
@@ -8256,7 +8256,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.312"
+version = "0.1.313"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.498"
+version = "0.0.499"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.500"
+version = "0.0.501"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.501"
+version = "0.0.502"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.499"
+version = "0.0.500"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.502"
+version = "0.0.503"
 
 [profile.dev]
 opt-level = 0

--- a/engine/dev-docs/action-review-findings.md
+++ b/engine/dev-docs/action-review-findings.md
@@ -1,11 +1,16 @@
 # Action Review Findings
 
-Phase 3 quality review of the 73 base actions against [action-standard.md](action-standard.md).
+Quality review of the base actions against [action-standard.md](action-standard.md).
+
+> **Resuming this work? Start at [HANDOVER](#handover--state-of-the-audit-as-of-2026-08-21) at
+> the bottom of this file.** It carries the current palette state, the 22 actions still awaiting
+> an audit with preliminary findings for each, and the cross-cutting issues that should shape
+> whatever order they are tackled in. The sections above it are older per-batch residue.
 
 **How to use:**
 
 - Fill each action with either `ActionName — OK` or the checklist format from §8 of the standard
-- Phase 4 improvement PRs should reference this file and delete completed sections as fixes land
+- Improvement PRs should reference this file and delete completed sections as fixes land
 - File is deleted when all sections are cleared
 
 **Global fix (applies to all base actions):**
@@ -446,88 +451,306 @@ accumulate/emit path of the ~20 actions declaring a non-`features` port.
 
 ---
 
-## Newly exposed actions — audit queue (23 actions, not yet reviewed)
+## HANDOVER — state of the audit as of 2026-08-21
 
-23 previously hidden actions were added to `base_actions.go`, taking the palette from
-82 to 105. Each was gated against §7.1 first — all have a `process`/`start` reachable in
-the shipped build, so none repeats the reprojector situation. **None has had an engine-side
-standard pass**, so their metadata is in whatever state it was authored in. This is the same
-promote-then-audit sequence as #2356, done deliberately this time and with the debt written
-down rather than discovered later.
+Work paused here ahead of FOSS4G. This section is the resumption point: what is done, what is
+not, and every preliminary finding gathered but not acted on. Read this before restarting.
 
-`Attribute Bulk Array Joiner` · `Attribute File Path Info Extractor` ·
-`Attribute Range Mapper` · `Attribute Table Extractor` · `CSG Builder` · `CSG Evaluator` ·
-`Coordinate Frame Reprojector` · `Date Time Converter` · `Excel Writer` ·
-`Feature CityGML 3 Reader` · `Feature Duplicate Filter` · `Feature GeoJSON Writer` ·
-`Feature Reader` · `Feature Writer` · `Geometry Coercer` · `HTTP Caller` · `Hole Counter` ·
-`Hole Extractor` · `JSON Fragmenter` · `Line On Line Overlayer` · `List Concatenator` ·
-`List Indexer` · `Offsetter`
+### Where the palette stands
 
-### Known before the batch starts
+`server/api/internal/app/base_actions.go` exposes **57** actions, down from 105. The gate is now
+strict: an action is listed only if it **runs in the shipped build** (§7.1) **and** has passed an
+engine-side review. Nothing below is a deletion — every hidden action still executes in a
+workflow that names it, so no existing workflow broke.
+
+| Bucket | Count | Trigger to re-expose |
+|---|---|---|
+| Exposed and audited | 57 | — |
+| Does not run in the shipped build | 22 | Its new-geometry port landing (Notion FLOW-DEV-182) |
+| **Pending audit** | **22** | An engine-side §8 pass — the list below |
+| Flagged for removal | 2 | None; they owe an engine-side deletion |
+| Retired on design grounds | 2 | A scope decision, see below |
+
+**The most important consequence:** `Coordinate Frame Reprojector` is in the pending-audit
+bucket, and the two legacy reprojectors are gone, so **the palette currently offers no
+coordinate reprojection at all.** That makes it the strongest candidate to audit first,
+regardless of category order.
+
+### What "audited" now means — read §"How to use" and §8 first
+
+The standard was materially rescoped on 2026-08-21 (see its Changelog). The verify-against-
+implementation duty used to be worded as a precondition for *editing* a title or description,
+which exempted anything that already read well. It now attaches to the action itself, and §8
+gained an `impl:` line — the one checklist line that cannot be answered from `actions.json`.
+
+This matters for planning: **a schema-level scan cannot triage this work.** In Batch 1 the one
+action a mechanical scan marked `OK` (`Attribute Table Extractor`) turned out to have an
+entirely undocumented configuration surface and a parameter name that actively misled. Any
+estimate of "these just need superficial fixes" is unearned until the code is read.
+
+---
+
+### Pending audit — 22 actions, with preliminary findings
+
+Findings below came from a schema scan plus partial code reading. **They are leads, not verdicts** —
+none has had the full `impl:` trace except where stated. Grouped as they were batched; the
+grouping is a suggestion, not a constraint.
+
+#### Group A — Geometry metadata (5)
 
 ```
-Line On Line Overlayer                                  <-- worst of the set
-  params:  `groupBy` and `tolerance` have NO description at all, so they render in the
-             UI as bare camelCase keys with no label. The only non-PLATEAU action in the
-             whole schema in this state. Note the sibling `Area On Area Overlayer` has
-             the same two parameters fully described — copy from there after confirming
-             the semantics match.
-
-15 of 23 actions
-  desc:    Descriptions violate §2. Two distinct kinds, worth separating when fixing:
-             (a) Title Case imperative, needing a rewrite — Hole Counter ("Count Polygon
-                 Holes to Attribute"), Hole Extractor, Feature Duplicate Filter,
-                 Attribute Bulk Array Joiner, Attribute File Path Info Extractor.
-             (b) Otherwise fine, missing only the terminating period — Attribute Range
-                 Mapper, Date Time Converter, HTTP Caller, Geometry Coercer, and others.
-             Fix (b) mechanically; (a) needs the code read first per §"How to use".
-
-Excel Writer
-  cat:     `File`, but it is a genuine sink (`type: sink`, no output ports), so §5 wants
-             `Output`. `File` is for decompression and path utilities. Left as-is
-             pending the batch since it is filterable either way.
+Coordinate Frame Reprojector          <-- AUDIT FIRST (see above)
+  scan:    Clean on every mechanical check. Replaces Horizontal + Vertical Reprojector.
+  unread:  destinationFrame / epsgCode / basePointSource never traced; `base-point`
+             second input port never verified as emitted-from/consumed.
 
 Hole Counter
-  note:    Carries a doc comment naming a commercial product, but on a TEST function
-             inside `mod tests` (`hole_counter.rs:268`), so it does NOT reach
-             actions.json — verified. Not a §2 violation; still worth rewording.
+  desc:    "Count Polygon Holes to Attribute" — Title Case imperative, no period (§2).
+  note:    Carries a doc comment naming a commercial product, but on a TEST function inside
+             `mod tests`, so it does NOT reach actions.json — verified. Not a §2 violation.
+
+Hole Extractor
+  desc:    "Extract Polygon Holes as Separate Features" — Title Case imperative, no period.
+  ports:   `outershell` should be `outer-shell` (§4.1 kebab-case for multi-word). Renaming a
+             port is a data-loss change (§4.3) — size the blast radius first.
+  params:  Zero parameters. Confirm that is genuine minimalism, not a missing control.
+
+Geometry Coercer
+  desc:    No terminating period (§2).
+  unread:  `targetType` enum variants never traced to their branches.
+
+Offsetter
+  scan:    Clean on every mechanical check — titles, descriptions, defaults, tags all present.
+             Best-documented of the group going in. Code never read.
 ```
 
-### Resolved while gating
+#### Group B — List and feature utilities (5)
 
-- `HTTP Caller` was categorised `Web`, which is not in the §5 taxonomy and not in the UI's
-  hardcoded category filter, so it would have landed in a phantom palette group — the same
-  defect fixed for glTF/OBJ Reader in #2365. Recategorised to `Feature`: it is a processor
-  taking features in and out, enriching them with response data. §5 advises against adding
-  a category for a single action, which `Web` would have been.
+```
+Feature Duplicate Filter
+  desc:    "Filter Out Duplicate Features" — Title Case imperative, no period.
+  params:  ZERO parameters, while its sibling Attribute Duplicate Filter takes `filterBy`.
+             What is the dedup key? If it is whole-feature equality that must be documented;
+             if it is implicit, it likely needs a parameter. UNRESOLVED — this is the open
+             design question of the group.
 
-### Open question: the `Feature` versus `Input` split for mid-flow readers
+List Concatenator
+  desc:    No terminating period.
+  params:  all 4 of list/attribute/separateCharacter/outputAttributeName lack a `title`, so
+             they render as bare camelCase labels.
+  note:    Relevant to the retired Attribute Bulk Array Joiner — this is the targeted,
+             separator-aware version of a similar operation. Decide them together.
 
-Not resolved, and it implicates a change already merged.
+List Indexer
+  desc:    No terminating period.
+  params:  all 4 lack a `title`.
 
-`Feature CityGML Reader`, `Feature CityGML 2 Reader`, `Feature CityGML 3 Reader` and
-`Feature Reader` are all **processors** (`features` in, `features` out) that read a path
-taken from the incoming feature. They are not graph sources. §5 assigns "CityGML reading"
-to the `Feature` category, yet the first two are categorised `Input`:
+Feature CityGML 3 Reader
+  desc:    No terminating period; param block has no root description (§3.3).
+  cat:     `Feature`. See the open Feature-vs-Input question below.
+
+Feature GeoJSON Writer
+  scan:    Clean on every mechanical check. Code never read.
+  cat:     `Feature` while every true sink uses `Output` — but it is a processor, not a sink.
+             Same open question as Feature Writer.
+```
+
+#### Group C — CSG pair and Excel Writer (3)
+
+```
+CSG Builder
+  desc:    4 sentences; §2 allows 1–2.
+  ports:   `left` + `right` inputs are properly semantic (§4.2) — good.
+
+CSG Evaluator
+  ports:   **`nullport`** is not in the §4.2 vocabulary, is not a word, and is a label users
+             see on the node. Needs a real name. Defined at csg_evaluator.rs:24.
+
+Excel Writer
+  cat:     `File`, but it is a genuine sink (type: sink, no output ports), so §5 wants
+             `Output`. `File` is for decompression and path utilities.
+  params:  `output` and `sheetName` both lack a `title`.
+```
+
+#### Group D — Overlay family (3)
+
+```
+Line On Line Overlayer                                  <-- worst metadata in the palette
+  params:  `groupBy` and `tolerance` have NO description at all — the only non-PLATEAU action
+             in the schema in that state. They render as bare camelCase keys with no label.
+             `overlaidListsAttrName` lacks a title. Sibling Area On Area Overlayer has both
+             parameters fully described; confirm the semantics match, then copy.
+
+Area On Area Overlayer
+  ports:   `area` was agreed to become `overlaps` (breaking).
+
+Dissolver
+  desc:    "Dissolve Features by Grouping Attributes" — Title Case imperative, no period.
+  ports:   `area` was agreed to become `features` (breaking).
+```
+
+Review these three together — they share `groupBy` / `tolerance` / accumulation semantics, and
+the two port renames were already agreed in principle but never sized against fixtures.
+
+#### Group E — Root-level `oneOf` restructuring (4, plus 1 already-audited)
+
+```
+Feature Reader · Feature Writer · JSON Fragmenter · Geometry Filter
+  params:  The whole parameter block is a root-level `oneOf`, which §3.4 prohibits because
+             apply_parameter_i18n cannot reach the variants — its definitions traversal is
+             scoped inside `definitions`, so a root `oneOf` is never visited. The block's own
+             title/description DO translate via the "" key, so the action looks localised
+             while the mode labels the user picks between stay English permanently.
+             Geometry Filter's Japanese entry is in exactly this state today.
+  fix:     Restructuring, not re-wording (§3.4 names the idiom: a #[serde(tag = "type")] enum
+             as a property VALUE, not as the whole block).
+
+Geometry Filter
+  ports:   20 output ports. Wants per-variant port declaration, which would also retire the
+             action-name-keyed special cases in builder_dag.rs:258-300 and
+             schema_infer.rs::effective_output_ports that the engine authors themselves
+             flagged as needing "an architectural revision of port handling".
+  desc:    "Filter Features by Geometry Type" — Title Case imperative, no period.
+
+XML Fragmenter  — ALREADY AUDITED, still non-compliant
+  params:  Same root-level `oneOf`. It was audited and its oneOf was deliberately extended
+             before §3.4 existed. Owed a re-check per the Changelog rule, not a new finding.
+```
+
+This group is schema-breaking by nature and wants its own PR.
+
+#### Group F — Known-heavy (2)
+
+```
+HTTP Caller
+  params:  13 parameters including `timeouts`, `retry`, `rateLimit`, `httpOptions` and
+             `observability`. §3.5 "No implementation leakage" names `timeout` and
+             `retryCount` as its canonical examples of what must NOT be exposed, and §3.5's
+             volume guideline is 8. Applying the rule as written would delete roughly half
+             this action's surface — that is a product decision, not an audit call.
+  cat:     Was `Web` (off-taxonomy, would have landed in a phantom palette group);
+             recategorised to `Feature` in #2373. Done.
+
+Attribute Duplicate Filter
+  desc:    "Remove Duplicate Features Based on Attribute Values" — Title Case, no period.
+             Param block has no root description.
+  bug:     Known key-collision defect, plus keep-first semantics to settle and a `duplicate`
+             port to consider. Adding that port is a data-loss change (§4.3).
+```
+
+---
+
+### Cross-cutting findings — read these before planning any batch
+
+**1. The §4.3 missing-attribute defect is systemic, not isolated.** The standard's §4.3 was
+corrected on 2026-08-20: a missing attribute is normally a no-op that must pass through, not a
+failure. Confirmed instances so far:
+
+- `Date Time Converter` — **fixed** in this PR.
+- `Attribute File Path Info Extractor` — moot, retired.
+- `JSON Fragmenter` — **not fixed.** Routes a missing attribute to `rejected`, and this is
+  asserted as intended in a test named `test_missing_attribute_rejected`. It sits in Group E.
+
+Three instances across three different batches means the remaining 22 should be assumed to
+contain more. The reliable tell is a `rejected`/`failed` branch guarded by an attribute lookup
+returning `None`. Note that fixing it is a routing change: those ports are unwired in most
+workflows, so features currently vanishing there will start flowing onward.
+
+**2. §6 tag debt in the already-audited set.** §6 was rewritten on 2026-08-21 (tags cut *across*
+categories; zero tags is now explicitly valid). Consequences not yet applied:
+
+- Genuine omissions, proven by a tagged sibling doing the same work: `Two Dimension Forcer`
+  has no tags while `Three Dimension Forcer` has `3d`; `Feature Filter` has none while every
+  other `Filter` action is tagged and `Input Router`/`Output Router` both carry `routing`.
+- Category-restating tags, now findings under the new wording: `Directory Decompressor` and
+  `File Property Extractor` both carry `file` while sitting in category `File`.
+- Correctly zero, needing no change: `Noop Processor`, `Noop Sink`.
+- Undecided, and deliberately not guessed: `Attribute Manager`, `Attribute Flattener`,
+  `Bulk Attribute Renamer`, `Feature Joiner`, `Feature Merger`, `Feature Sorter`,
+  `Geometry Extractor`, `Geometry Remover`, `Geometry Splitter`, `Bounds Extractor`. Each needs
+  the code read to judge whether an orthogonal axis exists.
+
+**3. Open question — `Feature` versus `Input` for mid-flow readers.** Unresolved, and it
+implicates a merged change. `Feature CityGML Reader`, `Feature CityGML 2 Reader`,
+`Feature CityGML 3 Reader` and `Feature Reader` are all **processors** (features in, features
+out) that read a path taken from the incoming feature. They are not graph sources. §5 assigns
+"CityGML reading" to `Feature`, yet the first two are categorised `Input`:
 
 | Action | Category today | Set by |
 |---|---|---|
 | Feature CityGML Reader | `Input` | #2114, which predates the standard |
-| Feature CityGML 2 Reader | `Input` | **#2365 — I moved it `Feature`→`Input`** |
+| Feature CityGML 2 Reader | `Input` | #2365 — changed to match the sibling, not to match §5 |
 | Feature CityGML 3 Reader | `Feature` | original |
 | Feature Reader | `Feature` | original |
 
-**The #2365 change was made for the wrong reason** — matching the sibling rather than
-checking §5, which points the other way. That is the failure mode §3.1 warns about: a
-change can satisfy consistency and still be wrong.
+The #2365 change was made for the wrong reason: matching a sibling rather than checking §5,
+which points the other way. Both directions are defensible — `Feature` follows §5 as written and
+reflects what these actions are; `Input` follows where a user looks for "the thing that reads
+CityGML" and would mean §5's `Feature` row should drop "and CityGML reading". Needs a decision,
+not a unilateral fix. Same class: `Feature Writer` / `Feature GeoJSON Writer` are processors
+categorised `Feature` while every true sink uses `Output`.
 
-Both directions are defensible and it needs a decision, not a unilateral fix:
+**4. Off-taxonomy categories on hidden actions.** `OBJ Writer` has `['File','3D']` and
+`Python Script Processor` has `['Script','Python']`. Neither is in the §5 taxonomy nor the UI's
+category filter, so both would land in a phantom palette group if exposed. Fix before exposing,
+not after.
 
-- **`Feature`** follows §5 as written and reflects what these actions are — mid-flow
-  processors, not sources. Requires moving two actions and reverting part of #2365.
-- **`Input`** follows where a user looks for "the thing that reads CityGML", and would
-  mean §5's `Feature` row is stale and should drop "and CityGML reading". Requires moving
-  two actions the other way.
+**5. Vendor-name leak still shipping.** `neighbor_finder.rs:143` names a commercial product in a
+`///` doc comment, which compiles into `actions.json` (§2). `center_point_replacer.rs:152`
+emits an output attribute named `fme_rejection_code`, referenced by 3 tests — that one is a
+schema-visible rename. Both actions are currently hidden (neither runs), so this is not live
+user-facing text today, but it must be fixed before either is re-exposed.
 
-Also unresolved and in the same class: `Feature Writer` / `Feature GeoJSON Writer` are
-processors categorised `Feature` while every true sink uses `Output`.
+**6. Proposed CI ratchets, neither implemented.** Both are cheap and deterministic:
+- Fail when a `baseActions` key does not exist in `actions.json`, or names a `builtin: false`
+  action. Nothing guards this today; the 105 names were verified by hand.
+- Fail when a parameter in `actions.json` lacks a `description`. Would have caught all four
+  dead GeoPackage Reader parameters in 2025. Start description-only — a `title` rule needs the
+  Group B/C/D cleanup above to land first.
+
+---
+
+### Batch 1 outcome — the only batch completed under the revised standard
+
+Audited and **kept exposed**:
+
+- `Attribute Range Mapper` — well designed; changes were documentation only. Now documents the
+  `to == from` exact-match branch, the string/bool coercion, and that `defaultValue` also
+  applies when the attribute is absent or non-numeric. Gained the `mapping` tag its three
+  siblings carry.
+- `Date Time Converter` — well designed. Gained 4 parameter titles, 12 enum variant titles and a
+  root description; enum values corrected from `unix_s`/`unix_ms` to `unixS`/`unixMs` (§3.4);
+  §4.3 fixed so a feature lacking the attribute passes through on `features`. That fix also
+  required correcting `infer_output_schema`, which promised the output attribute was `always`
+  present on `features` — now `maybe`. Regression test
+  `missing_attribute_passes_through_on_features` added; this behaviour had no coverage.
+- `Attribute Table Extractor` — sound concept, and the only one of the five with real production
+  use (PLATEAU6 01-bldg). `inline` is now typed, so `ExtractRule` finally generates into the
+  schema with titles and `required`. `jsonPath`/`attribute` renamed to
+  `sourcePath`/`destinationPath`: the old name promised JSONPath but the implementation is a
+  space-separated key chain, so `$.a.b` failed silently. Renaming rather than implementing
+  JSONPath was deliberate — the destination path needs *write* semantics, which JSONPath has
+  none of; `$` appears as a literal key in real CityGML tables; multi-match semantics would
+  have to be invented; and feature attributes are an `IndexMap`, so JSONPath would mean
+  serialising every feature per rule. Space separation is correct here because the keys are XML
+  QNames, which cannot contain whitespace but do contain colons. All 106 rules in the PLATEAU6
+  config migrated.
+
+**Retired, not audited:**
+
+- `Attribute File Path Info Extractor` — an exact duplicate of `File Property Extractor`: same
+  five output attributes (`fileType`, `fileSize`, `fileAtime`, `fileMtime`, `fileCtime`), same
+  `"File"`/`"Directory"` values, same single path-attribute parameter. `File Property Extractor`
+  is the better one — documented description covering all five outputs and the recursive
+  directory-size behaviour, plus tags. Zero usage anywhere made retiring free. It also had
+  inverted §4.3 ports (absent attribute → `rejected`; nonexistent path → silent pass-through)
+  and five entirely undocumented output attributes, none of which now need fixing.
+- `Attribute Bulk Array Joiner` — needs a scope decision before it is worth documenting. Joins
+  every array attribute with a hard-coded `,` (no separator parameter, while `List Concatenator`
+  has one); `ignoreAttributes` is opt-out only, so joining one attribute means enumerating every
+  other array attribute on the feature; `_ => {}` silently drops non-scalar elements, so an
+  array of two maps becomes `""`; and a single-element array containing a map is *unwrapped*
+  rather than joined, making it two operations under one name. The `FlattenerFactory` error
+  variant it still uses suggests it was built as an `Attribute Flattener` sibling for collapsing
+  CityGML multi-valued attributes before writing to a flat format. If that is the intent, it
+  should say so and probably be named for it. Zero usage anywhere.

--- a/engine/dev-docs/action-review-findings.md
+++ b/engine/dev-docs/action-review-findings.md
@@ -785,11 +785,24 @@ Dissolver — kept, documentation was materially wrong
              (glue_vertices_closer_than / dissolve_leaves). Ports complete.
   desc:    Was "Dissolve Features by Grouping Attributes" — Title Case imperative, no period,
              and it never said what dissolving does to the geometry. Rewritten.
-  desc:    **The 2D-only constraint was entirely undocumented.** `accepts()` requires
-             Geometry::Euclidean2D, so any 3D or geographic-CRS geometry is silently routed to
-             `rejected`. The sibling overlayers already carry the guidance sentence for this;
-             it is now copied here. This was the substantive finding — a user could wire this
-             up correctly and lose every feature with no indication why.
+  desc:    **The input constraints were entirely undocumented.** `accepts()` requires the
+             Euclidean2D variant, all leaves sharing one coordinate frame, no leaf carrying an
+             elevation, and areal leaves only (Polygon / PolygonMesh / TriangularMesh) — so 3D
+             geometry, mixed frames, elevated 2D and line strings are all silently routed to
+             `rejected`. Note the frame is per-LEAF, so a CRS-framed 2D geometry is fine; it is
+             a MIXTURE of frames that is refused. The substantive finding of the batch: a user
+             could wire this up correctly and lose every feature with no indication why. The
+             sibling overlayers already carry the guidance sentence; it is now here too.
+  prior art: The planar computation is universal — FME's equivalent, and GEOS/JTS via PostGIS
+             ST_Union ("the result is computed using XY only"), all overlay in XY. Refusing 3D
+             input is NOT typical: both accept it and resolve Z by a stated policy (FME exposes
+             a five-option Connect Z Mode; PostGIS copies, averages or interpolates). Rejecting
+             areal-only input matches FME exactly. The mixed-frame check is stricter than either
+             and is the one place we are better — both will silently run planar math across
+             mismatched coordinate systems. A Z-policy parameter is the natural enhancement here,
+             not a defect to fix. The only production user (PLATEAU4 tran) already chains
+             Two Dimension Forcer -> Geometry Filter -> Dissolver, so the constraint is
+             load-bearing and the added guidance matches what that workflow already does.
   params:  `tolerance`'s default was unstated; it is 0.0, set by an `unwrap_or` carrying a TODO
              that calls it a compatibility choice. Now documented, including that zero can
              leave slivers between edges that nearly meet.

--- a/engine/dev-docs/action-review-findings.md
+++ b/engine/dev-docs/action-review-findings.md
@@ -3,7 +3,7 @@
 Quality review of the base actions against [action-standard.md](action-standard.md).
 
 > **Resuming this work? Start at [HANDOVER](#handover--state-of-the-audit-as-of-2026-08-21) at
-> the bottom of this file.** It carries the current palette state, the 22 actions still awaiting
+> the bottom of this file.** It carries the current palette state, the 20 actions still awaiting
 > an audit with preliminary findings for each, and the cross-cutting issues that should shape
 > whatever order they are tackled in. The sections above it are older per-batch residue.
 
@@ -458,23 +458,24 @@ not, and every preliminary finding gathered but not acted on. Read this before r
 
 ### Where the palette stands
 
-`server/api/internal/app/base_actions.go` exposes **57** actions, down from 105. The gate is now
+`server/api/internal/app/base_actions.go` exposes **59** actions, down from 105. The gate is now
 strict: an action is listed only if it **runs in the shipped build** (§7.1) **and** has passed an
 engine-side review. Nothing below is a deletion — every hidden action still executes in a
 workflow that names it, so no existing workflow broke.
 
 | Bucket | Count | Trigger to re-expose |
 |---|---|---|
-| Exposed and audited | 57 | — |
+| Exposed and audited | 59 | — |
 | Does not run in the shipped build | 22 | Its new-geometry port landing (Notion FLOW-DEV-182) |
-| **Pending audit** | **22** | An engine-side §8 pass — the list below |
+| **Pending audit** | **20** | An engine-side §8 pass — the list below |
 | Flagged for removal | 2 | None; they owe an engine-side deletion |
 | Retired on design grounds | 2 | A scope decision, see below |
 
-**The most important consequence:** `Coordinate Frame Reprojector` is in the pending-audit
-bucket, and the two legacy reprojectors are gone, so **the palette currently offers no
-coordinate reprojection at all.** That makes it the strongest candidate to audit first,
-regardless of category order.
+`Coordinate Frame Reprojector` and `Dissolver` were audited after the rest of this section was
+written and are **exposed**; their outcomes are at the bottom. Both were picked because they had
+new-geometry support and were assumed to be near-compliant. That held for the reprojector, which
+postdates the standard, and did not for Dissolver, whose action long predates it — only its
+geometry port is recent. Worth remembering when guessing which of the remaining 20 are cheap.
 
 ### What "audited" now means — read §"How to use" and §8 first
 
@@ -490,20 +491,15 @@ estimate of "these just need superficial fixes" is unearned until the code is re
 
 ---
 
-### Pending audit — 22 actions, with preliminary findings
+### Pending audit — 20 actions, with preliminary findings
 
 Findings below came from a schema scan plus partial code reading. **They are leads, not verdicts** —
 none has had the full `impl:` trace except where stated. Grouped as they were batched; the
 grouping is a suggestion, not a constraint.
 
-#### Group A — Geometry metadata (5)
+#### Group A — Geometry metadata (4)
 
 ```
-Coordinate Frame Reprojector          <-- AUDIT FIRST (see above)
-  scan:    Clean on every mechanical check. Replaces Horizontal + Vertical Reprojector.
-  unread:  destinationFrame / epsgCode / basePointSource never traced; `base-point`
-             second input port never verified as emitted-from/consumed.
-
 Hole Counter
   desc:    "Count Polygon Holes to Attribute" — Title Case imperative, no period (§2).
   note:    Carries a doc comment naming a commercial product, but on a TEST function inside
@@ -572,7 +568,7 @@ Excel Writer
   params:  `output` and `sheetName` both lack a `title`.
 ```
 
-#### Group D — Overlay family (3)
+#### Group D — Overlay family (2, plus Dissolver now done)
 
 ```
 Line On Line Overlayer                                  <-- worst metadata in the palette
@@ -584,13 +580,17 @@ Line On Line Overlayer                                  <-- worst metadata in th
 Area On Area Overlayer
   ports:   `area` was agreed to become `overlaps` (breaking).
 
-Dissolver
-  desc:    "Dissolve Features by Grouping Attributes" — Title Case imperative, no period.
-  ports:   `area` was agreed to become `features` (breaking).
 ```
 
-Review these three together — they share `groupBy` / `tolerance` / accumulation semantics, and
-the two port renames were already agreed in principle but never sized against fixtures.
+`Dissolver` was in this group and is now audited and exposed — see below. Review the remaining
+two together; they share `groupBy` / `tolerance` / accumulation semantics with it and with each
+other, so its wording is the reference to copy.
+
+**The port renames were agreed in principle and are more expensive than assumed.** Sizing them
+for the first time: `Dissolver` alone appears in 10 workflow files, **6 of them committed
+result/truth fixtures** under `engine/testing/data/results/`, with 27 `fromPort: area` edges
+across the tree. Renaming `area` is not a metadata change — it rewrites golden data, and wants
+its own PR with the fixtures regenerated deliberately.
 
 #### Group E — Root-level `oneOf` restructuring (4, plus 1 already-audited)
 
@@ -754,3 +754,56 @@ Audited and **kept exposed**:
   variant it still uses suggests it was built as an `Attribute Flattener` sibling for collapsing
   CityGML multi-valued attributes before writing to a flat format. If that is the intent, it
   should say so and probably be named for it. Zero usage anywhere.
+
+---
+
+### Addendum — Coordinate Frame Reprojector and Dissolver, audited and exposed
+
+Both were picked on the hypothesis that new-geometry support implied recent authorship and
+therefore near-compliance. Half right: `Coordinate Frame Reprojector` was born 2026-07-23, three
+weeks after the standard, and is compliant. `Dissolver` predates the standard by months — only
+its geometry port is recent (#2368) — and its metadata was pre-#2240 style.
+
+```
+Coordinate Frame Reprojector — kept, one structural fix
+  impl:    All three parameters read and applied; no dead surface. Both input ports and both
+             output ports emitted. Base-point features are consumed rather than forwarded,
+             which is the §4.3 merge/join exemption and is consistent for both the valid and
+             invalid cases. Genuinely well-built: PROJ transform cached per worker thread,
+             num_threads pinned to 1 only in the mode that correlates two streams.
+  params:  §3.2/§3.4 — `epsgCode` was a top-level Option validated at build time, so the
+             schema advertised a CRS destination with no code and failed at runtime. Now rides
+             inside the `crs` variant of a #[serde(tag = "type")] enum, which is the idiom the
+             same file already uses for `basePoint`, so the invalid combination cannot be
+             expressed and the runtime check is gone.
+  note:    Internally the EPSG code narrows to u16 (the bound reearth-flow-geometry uses)
+             while Feature Writer and the CityGML writers use u32. Out-of-range codes now get
+             an explicit error rather than a deserialization failure. Worth unifying one day.
+
+Dissolver — kept, documentation was materially wrong
+  impl:    All three parameters read and applied; `tolerance` reaches both geometry worlds
+             (glue_vertices_closer_than / dissolve_leaves). Ports complete.
+  desc:    Was "Dissolve Features by Grouping Attributes" — Title Case imperative, no period,
+             and it never said what dissolving does to the geometry. Rewritten.
+  desc:    **The 2D-only constraint was entirely undocumented.** `accepts()` requires
+             Geometry::Euclidean2D, so any 3D or geographic-CRS geometry is silently routed to
+             `rejected`. The sibling overlayers already carry the guidance sentence for this;
+             it is now copied here. This was the substantive finding — a user could wire this
+             up correctly and lose every feature with no indication why.
+  params:  `tolerance`'s default was unstated; it is 0.0, set by an `unwrap_or` carrying a TODO
+             that calls it a compatibility choice. Now documented, including that zero can
+             leave slivers between edges that nearly meet.
+  params:  Variant description leaked the internal `group_by` spelling into user-facing text.
+  tags:    Was empty. Now `spatial` (matching Bufferer, Clipper, Grid Divider) and `aggregation`
+             (matching the other accumulating processors).
+  ports:   `area` → `features` NOT done. See the Group D note: 10 workflow files, 6 of them
+             committed truth fixtures, 27 edges. Its own PR.
+```
+
+**One methodological trap worth recording.** `cargo check -p reearth-flow-action-processor` and
+`cargo test -p reearth-flow-action-processor` do **not** compile new-geometry code. That crate's
+own `default = []`, and `coordinate_frame_reprojector` is a `#[cfg(feature = "new-geometry")]`
+module, so per-crate commands silently skip it — a per-crate check passed while four of its tests
+were broken by the parameter restructure. `cargo make test-rs` catches it because `--workspace`
+lets cli/worker (both `default = ["new-geometry"]`) unify the feature on. **Verify new-geometry
+actions with the workspace command, never with `-p`.**

--- a/engine/dev-docs/action-standard.md
+++ b/engine/dev-docs/action-standard.md
@@ -19,7 +19,11 @@ cargo make schema-base        # regenerates actions.json and syncs i18n skeleton
 cargo make schema-translated  # regenerates per-language JSON files
 ```
 
-**Verify against the implementation before writing — do this first, every time.** A title or description must describe what the code actually does, not what the parameter name suggests or what a prior description claimed. Polishing text for clarity without reading the code produces confident, wrong documentation. Before adding or editing any title or description, read the factory's `build`, the parameter struct, and the action's execution path (`process`/`start`/`run`), and confirm each of the following:
+**The implementation is the source of truth — verify against it first, every time.** Every user-facing property of an action must be traceable to code that delivers it. A name, title, or description must describe what the code actually does — not what the parameter name suggests, not what a prior description claimed, not what was intended.
+
+Text that reads well is not evidence. A description can be fluent, accurate-sounding, and compliant with every rule below while describing behavior that does not exist, so **a property that looks correct is not exempt from being checked.** This is the most common way the surface starts lying: nobody writes an obviously wrong description, so the wrong ones are the ones that read best.
+
+Whether authoring an action or reviewing one, before the schema is regenerated read the factory's `build`, the parameter struct, and the execution path (`process`/`start`/`run`), and confirm each of the following:
 
 - **Every parameter is actually read and applied.** A parameter accepted but never used (e.g. stored into a field with a `_` prefix and never referenced) is a bug, not something to document — flag it for removal rather than writing a description for behavior that does not exist. Check for *forwarding*: a parameter copied into another struct in `build` and never read from there is still unused. And check **which build it is unused in** — a `cfg`-gated action can read a parameter in one geometry world and ignore it in the other, so establish whether it is dead everywhere, dead only in the shipped build (a migration artifact — leave it, it belongs to the migration's own cleanup), or dead only in the legacy build (live, keep it). `schema/actions.json` is generated from the default build, so anything appearing there is what users see today.
 - **Enum variants behave as their names and descriptions claim** — trace each variant to its branch in the code.
@@ -230,14 +234,21 @@ New categories can be added when a meaningful group of actions does not fit any 
 
 ## 6. Tags
 
+Tags exist to cut **across** categories. The category is where a user browses; a tag is how they find the action from somewhere else. `citygml` earns its place because it spans `Input`, `Output`, `Geometry`, and `Filter` — one tag collects the whole CityGML toolkit. `geometry` on a `Geometry` action tells the user nothing they did not already know from where they found it.
+
 - All lowercase, hyphenated if multi-word: `coordinate-system`, `citygml`
-- Aim for 2–4 tags; 1 is acceptable when no second tag adds genuine discovery value. Never pad to meet a count.
+- **The test:** would this tag help someone find the action from *outside* its category? If not, it is padding.
+- **Zero tags is a valid and complete answer.** When every candidate would restate the category, the action has no cross-cutting axis and takes none. This is normal for general-purpose processors — most `Geometry` and `Debug` actions are in this position. Never invent a tag to avoid an empty list.
+- Two to four tags where the axes genuinely exist — typically format, dimensionality, or domain. Readers and writers almost always qualify (`csv`, `gltf`, `geopackage`, `citygml`); a plain geometry operation usually does not.
+- **Check the siblings.** An action doing the same kind of work as a tagged action should carry the same tag. A gap between siblings — `Three Dimension Forcer` tagged `3d` while `Two Dimension Forcer` has nothing — is an oversight, not a judgement, and it is the reliable way to tell the two apart.
 - Draw from the established vocabulary below; propose additions conservatively
 
 **Established vocabulary:**
 `3d`, `aggregation`, `attribute`, `citygml`, `compression`, `coordinate-system`, `csv`, `database`, `debug`, `file`, `filter`, `geometry`, `geojson`, `geopackage`, `gltf`, `json`, `list`, `logging`, `mapping`, `obj`, `raster`, `routing`, `scripting`, `shapefile`, `spatial`, `statistics`, `tiling`, `validation`, `vector`, `xml`
 
-New tags can be proposed when an established term does not adequately describe an action's domain. Avoid adding tags that duplicate an action's category.
+Some vocabulary entries share a name with a category (`geometry`, `filter`, `file`, `debug`, `attribute`). Those are valid only *outside* the matching category, where they still cut across — `geometry` on `Dimension Filter` and `file` on `Zip File Writer` both earn their place; `file` on a `File` action does not.
+
+New tags can be proposed when an established term does not adequately describe an action's domain.
 
 ---
 
@@ -285,13 +296,18 @@ For each action, flag anything that violates the rules above. Only log issues �
 ActionName
   runs:    [only if it does NOT run in the shipped build, or is listed in
               base_actions.go while broken (§7)]
+  impl:    [parameters declared but never applied; enum variants with no branch;
+              defaults or "when omitted" text the code contradicts; declared
+              ports never emitted]
   name:    [proposed space-case name if different]
   desc:    [issue if any]
   params:  [list issues by param name; flag if count exceeds 8 without justification (§3.5)]
   ports:   [failure-vs-no-op errors (§4.3); missing or unemitted ports]
   cat:     [issue if wrong category]
-  tags:    [missing tags | irrelevant tags]
+  tags:    [missing cross-cutting tag | tag that restates the category (§6)]
 ```
+
+**Every line except `impl:` can be answered from the generated `actions.json`. `impl:` cannot.** It is the only one that requires opening the code, and it is therefore the only one that catches a description which is well-written and false, or a parameter the UI offers and the code ignores. An action marked clean without `impl:` having been worked through has been *read*, not checked.
 
 If an action is clean on all dimensions, write: `ActionName — OK`
 
@@ -302,6 +318,12 @@ If an action is clean on all dimensions, write: `ActionName — OK`
 ## Changelog
 
 Material rule changes, newest first. **A rule added here does not retroactively apply to actions already reviewed** — when a change would alter a past verdict, say so in the entry, and treat previously-reviewed actions as owing a re-check against the new rule.
+
+### 2026-08-21
+
+- **§"How to use" rescoped — this widens what the rule covers.** The verify-against-implementation duty was previously worded as a precondition for *adding or editing* a title or description, which exempted any property that already looked compliant. It now attaches to the action itself: every user-facing property must be traceable to code that delivers it, checked before the schema is regenerated, whether authoring or reviewing. Reviews done under the old wording may have triaged on how the text reads rather than on what the code does.
+- **§8** — added an `impl:` line to the checklist, for parameters never applied, enum variants with no branch, defaults the code contradicts, and ports never emitted. Every other line in the checklist can be answered from the generated schema; this one cannot, which is the point.
+- **§6 corrected — this reverses previous guidance.** The old wording set a floor ("aim for 2–4; 1 is acceptable") while also forbidding tags that duplicate the category, which made the floor unreachable for single-domain actions and invited padding. Tags are now defined by their purpose — cross-category discovery — and **zero tags is explicitly valid** when no orthogonal axis exists. Actions reviewed under the old wording may carry a tag that only restates the category, and a zero-tag action is no longer a finding on its own. Sibling comparison is the test for a genuine omission.
 
 ### 2026-08-20
 

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -2849,7 +2849,7 @@ Reprojects geometry between coordinate reference systems and converts between a 
               "title": "EPSG Code",
               "description": "EPSG code of the destination coordinate reference system.",
               "type": "integer",
-              "format": "uint32",
+              "format": "uint16",
               "minimum": 0.0
             }
           }

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -3309,7 +3309,7 @@ Merges area features that share the same grouping attribute values into one feat
 ### Input Ports
 * features
 ### Output Ports
-* area
+* features
 * rejected
 ### Category
 * Geometry

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -898,12 +898,13 @@ Replaces a feature's attributes with a new set built from mapping rules, each de
 ### Type
 * processor
 ### Description
-Map attribute values to ranges and assign corresponding output values
+Classifies a numeric attribute by looking its value up in a table of ranges and writing the matched range's output value to another attribute.
 ### Parameters
 ```json
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Attribute Range Mapper Parameters",
+  "description": "Defines the attribute to classify, the table of ranges to match it against, and where the matched value is written.",
   "type": "object",
   "required": [
     "inputAttribute",
@@ -913,17 +914,17 @@ Map attribute values to ranges and assign corresponding output values
   "properties": {
     "inputAttribute": {
       "title": "Input Attribute",
-      "description": "The attribute to evaluate for range mapping",
+      "description": "Attribute holding the value to classify. Numbers are used directly, numeric strings are parsed, and booleans count as 1 and 0. Any other type is treated as unclassifiable and takes the default value.",
       "type": "string"
     },
     "outputAttribute": {
       "title": "Output Attribute",
-      "description": "The attribute to store the mapped value",
+      "description": "Attribute the matched value is written to. An existing value is overwritten.",
       "type": "string"
     },
     "rangeTable": {
       "title": "Range Lookup Table",
-      "description": "List of ranges and their corresponding output values",
+      "description": "Ranges to test the input against, in order. The first match wins, so overlapping ranges resolve to whichever is listed first.",
       "type": "array",
       "items": {
         "$ref": "#/definitions/RangeEntry"
@@ -931,7 +932,7 @@ Map attribute values to ranges and assign corresponding output values
     },
     "defaultValue": {
       "title": "Default Value",
-      "description": "Value to use when input doesn't match any range (can be string, number, boolean, etc.)"
+      "description": "Value written when no range matches, and also when the input attribute is absent or is not a number, numeric string, or boolean. When omitted, those features pass through with the output attribute left unset rather than being rejected."
     }
   },
   "definitions": {
@@ -946,19 +947,19 @@ Map attribute values to ranges and assign corresponding output values
       "properties": {
         "from": {
           "title": "From (Minimum)",
-          "description": "The minimum value of the range (inclusive)",
+          "description": "Lower bound of the range, inclusive.",
           "type": "number",
           "format": "double"
         },
         "to": {
           "title": "To (Maximum)",
-          "description": "The maximum value of the range (exclusive)",
+          "description": "Upper bound of the range, exclusive — a value equal to it falls into the next range. Setting it equal to the lower bound makes the entry match that one exact value instead.",
           "type": "number",
           "format": "double"
         },
         "outputValue": {
           "title": "Output Value",
-          "description": "The value to assign when input falls within this range (can be string, number, boolean, etc.)"
+          "description": "Value written to the output attribute when the input falls in this range. Any JSON type is accepted."
         }
       }
     }
@@ -982,12 +983,12 @@ Moves values between nested map/list attribute paths, following a table of sourc
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Attribute Table Extractor Parameters",
-  "description": "Configures the table of source/destination path pairs used to move nested attribute values.",
+  "description": "Configures the table of source/destination path pairs used to move nested attribute values. Supply the table either as a file, via Dataset URI, or directly, via Inline Table — one of the two is required.",
   "type": "object",
   "properties": {
     "dataset": {
       "title": "Dataset URI",
-      "description": "Path or URI of the extraction table file. Provide either this or inline data.",
+      "description": "Path or URI of a JSON file holding the extraction table. Provide either this or Inline Table.",
       "type": [
         "object",
         "null"
@@ -1012,7 +1013,17 @@ Moves values between nested map/list attribute paths, following a table of sourc
     },
     "inline": {
       "title": "Inline Table",
-      "description": "Extraction table content provided directly as JSON. Used when no dataset URI is given."
+      "description": "Extraction table given directly, keyed by feature type. Each key is a feature type name as it appears in the type attribute, and its value is the list of rules applied to features of that type. Provide either this or Dataset URI.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/ExtractRule"
+        }
+      }
     },
     "typeAttribute": {
       "title": "Feature Type Attribute",
@@ -1020,6 +1031,62 @@ Moves values between nested map/list attribute paths, following a table of sourc
       "type": [
         "string",
         "null"
+      ]
+    }
+  },
+  "definitions": {
+    "ExtractRule": {
+      "title": "Extraction Rule",
+      "description": "Moves one value from a source path to a destination path.\n\nBoth paths are chains of attribute keys separated by **spaces**, not dots — the keys themselves are qualified XML names such as `bldg:measuredHeight`, which may contain colons and dots but never whitespace.",
+      "type": "object",
+      "required": [
+        "destinationPath",
+        "sourcePath"
+      ],
+      "properties": {
+        "destinationPath": {
+          "title": "Destination Path",
+          "description": "Where the value is written, as a space-separated chain of keys. A single segment writes a top-level attribute; several segments write into a nested map, creating it and any missing intermediate map as needed.",
+          "type": "string"
+        },
+        "sourcePath": {
+          "title": "Source Path",
+          "description": "Where the value is read from, as a space-separated chain of keys walked from the feature's top level. A segment matches either a key in a map or the first matching element of a list, so it works whether a wrapper element appears once or many times.",
+          "type": "string"
+        },
+        "dataType": {
+          "title": "Value Type",
+          "description": "Converts the extracted value before writing it. Leave unset to write it unchanged.",
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ExtractDataType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "ExtractDataType": {
+      "oneOf": [
+        {
+          "title": "Integer",
+          "description": "Parses a string value as an integer.",
+          "type": "string",
+          "enum": [
+            "int"
+          ]
+        },
+        {
+          "title": "Float",
+          "description": "Parses a string value as a floating point number.",
+          "type": "string",
+          "enum": [
+            "float"
+          ]
+        }
       ]
     }
   }
@@ -2905,23 +2972,26 @@ Reprojects geometry between coordinate reference systems and converts between a 
 ### Type
 * processor
 ### Description
-Convert datetime values between different formats
+Reads a datetime from an attribute and rewrites it in another format, either as a typed datetime value or as a formatted string or Unix timestamp.
 ### Parameters
 ```json
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Date Time Converter Parameters",
+  "description": "Selects the attribute to convert, how to interpret its current value, and the format to write back.",
   "type": "object",
   "required": [
     "attribute"
   ],
   "properties": {
     "attribute": {
-      "description": "Attribute containing the datetime value to convert",
+      "title": "Source Attribute",
+      "description": "Attribute holding the datetime to convert. Features that do not carry it pass through unchanged.",
       "type": "string"
     },
     "inputFormat": {
-      "description": "Format of the input value (default: auto)",
+      "title": "Input Format",
+      "description": "How to interpret the existing value. Leave unset to detect it from the value itself.",
       "default": "auto",
       "allOf": [
         {
@@ -2930,7 +3000,8 @@ Convert datetime values between different formats
       ]
     },
     "outputFormat": {
-      "description": "Desired output format (default: auto). Use `auto` to store as typed DateTime value (parser mode). Use other formats to output as string/number (formatter mode).",
+      "title": "Output Format",
+      "description": "Format to write back. Leave unset to store a typed datetime value; choose any other format to write a string or a number instead.",
       "default": "auto",
       "allOf": [
         {
@@ -2939,7 +3010,8 @@ Convert datetime values between different formats
       ]
     },
     "outputAttribute": {
-      "description": "Write result to a different attribute (leave input untouched) Defaults to the same as `attribute`",
+      "title": "Output Attribute",
+      "description": "Attribute to write the result to, leaving the source untouched. Defaults to overwriting the source attribute.",
       "default": null,
       "type": [
         "string",
@@ -2952,42 +3024,48 @@ Convert datetime values between different formats
       "description": "Input format options for Date Time Converter",
       "oneOf": [
         {
-          "description": "Auto-detect from known formats. Note: Numeric values are always interpreted as Unix seconds. For milliseconds, use the explicit `unix_ms` input format.",
+          "title": "Detect Automatically",
+          "description": "Recognises the value from its own shape. A bare number is always read as Unix seconds — choose Unix Milliseconds explicitly for millisecond timestamps.",
           "type": "string",
           "enum": [
             "auto"
           ]
         },
         {
-          "description": "RFC3339 / ISO 8601 format",
+          "title": "RFC 3339",
+          "description": "Internet date and time format, the profile of ISO 8601 used by most APIs.",
           "type": "string",
           "enum": [
             "rfc3339"
           ]
         },
         {
-          "description": "Unix timestamp in seconds",
+          "title": "Unix Seconds",
+          "description": "Seconds elapsed since 1970-01-01 UTC.",
           "type": "string",
           "enum": [
-            "unix_s"
+            "unixS"
           ]
         },
         {
-          "description": "Unix timestamp in milliseconds",
+          "title": "Unix Milliseconds",
+          "description": "Milliseconds elapsed since 1970-01-01 UTC.",
           "type": "string",
           "enum": [
-            "unix_ms"
+            "unixMs"
           ]
         },
         {
-          "description": "Date only format (YYYY-MM-DD)",
+          "title": "Date Only",
+          "description": "Calendar date with no time part, as YYYY-MM-DD.",
           "type": "string",
           "enum": [
             "date"
           ]
         },
         {
-          "description": "Custom format using chrono format specifiers",
+          "title": "Custom Pattern",
+          "description": "Field-by-field pattern, for values none of the fixed formats match.",
           "type": "object",
           "required": [
             "custom"
@@ -3005,42 +3083,48 @@ Convert datetime values between different formats
       "description": "Output format options for Date Time Converter",
       "oneOf": [
         {
-          "description": "Auto: Store as typed DateTime value (preserves the native variant). Use this when you want the datetime as a proper DateTime type rather than a string.",
+          "title": "Typed Datetime",
+          "description": "Stores a datetime value rather than text, keeping it comparable and sortable downstream.",
           "type": "string",
           "enum": [
             "auto"
           ]
         },
         {
-          "description": "RFC3339 / ISO 8601 format",
+          "title": "RFC 3339",
+          "description": "Writes a string in the internet date and time format, the profile of ISO 8601 used by most APIs.",
           "type": "string",
           "enum": [
             "rfc3339"
           ]
         },
         {
-          "description": "Unix timestamp in seconds",
+          "title": "Unix Seconds",
+          "description": "Writes a number: seconds elapsed since 1970-01-01 UTC.",
           "type": "string",
           "enum": [
-            "unix_s"
+            "unixS"
           ]
         },
         {
-          "description": "Unix timestamp in milliseconds",
+          "title": "Unix Milliseconds",
+          "description": "Writes a number: milliseconds elapsed since 1970-01-01 UTC.",
           "type": "string",
           "enum": [
-            "unix_ms"
+            "unixMs"
           ]
         },
         {
-          "description": "Date only format (YYYY-MM-DD)",
+          "title": "Date Only",
+          "description": "Writes a string holding just the calendar date, as YYYY-MM-DD.",
           "type": "string",
           "enum": [
             "date"
           ]
         },
         {
-          "description": "Custom format using chrono format specifiers",
+          "title": "Custom Pattern",
+          "description": "Writes a string built from a field-by-field pattern.",
           "type": "object",
           "required": [
             "custom"

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -3229,7 +3229,7 @@ Decompresses zip and 7z archives referenced by feature attributes, replacing eac
 ### Type
 * processor
 ### Description
-Merges features that share the same grouping attribute values into one feature per group, combining their geometries and dropping the boundaries between them. Inputs must be flat 2D geometries sharing one coordinate frame; place a Two Dimension Forcer or a Coordinate Frame Reprojector upstream to flatten or unify them.
+Merges area features that share the same grouping attribute values into one feature per group, combining their geometries and dropping the boundaries between them. Inputs must be flat 2D areas sharing one coordinate frame; place a Two Dimension Forcer or a Coordinate Frame Reprojector upstream to flatten or unify them.
 ### Parameters
 ```json
 {

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -2806,23 +2806,12 @@ Reprojects geometry between coordinate reference systems and converts between a 
   "properties": {
     "destinationFrame": {
       "title": "Destination Frame",
-      "description": "Coordinate frame to convert geometry into.",
+      "description": "Coordinate frame to convert geometry into. Choosing a CRS also requires its EPSG code.",
       "allOf": [
         {
           "$ref": "#/definitions/DestinationFrame"
         }
       ]
-    },
-    "epsgCode": {
-      "title": "EPSG Code",
-      "description": "EPSG code of the destination CRS. Required when the destination frame is a CRS.",
-      "default": null,
-      "type": [
-        "integer",
-        "null"
-      ],
-      "format": "uint16",
-      "minimum": 0.0
     },
     "basePointSource": {
       "title": "Base Point",
@@ -2839,23 +2828,47 @@ Reprojects geometry between coordinate reference systems and converts between a 
   },
   "definitions": {
     "DestinationFrame": {
-      "description": "The destination coordinate frame kind.",
+      "description": "The destination coordinate frame, carrying the input each kind needs.",
       "oneOf": [
         {
           "title": "CRS",
           "description": "Reproject to a coordinate reference system identified by an EPSG code.",
-          "type": "string",
-          "enum": [
-            "crs"
-          ]
+          "type": "object",
+          "required": [
+            "epsgCode",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "crs"
+              ]
+            },
+            "epsgCode": {
+              "title": "EPSG Code",
+              "description": "EPSG code of the destination coordinate reference system.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          }
         },
         {
           "title": "Euclidean",
-          "description": "Convert to a non-georeferenced Euclidean frame.",
-          "type": "string",
-          "enum": [
-            "euclidean"
-          ]
+          "description": "Convert to a non-georeferenced Euclidean frame. This is the frame the planar geometry operations work in, so it is the on-ramp for actions that require flat 2D input.",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "euclidean"
+              ]
+            }
+          }
         }
       ]
     },
@@ -3216,18 +3229,18 @@ Decompresses zip and 7z archives referenced by feature attributes, replacing eac
 ### Type
 * processor
 ### Description
-Dissolve Features by Grouping Attributes
+Merges features that share the same grouping attribute values into one feature per group, combining their geometries and dropping the boundaries between them. Inputs must be flat 2D geometries sharing one coordinate frame; place a Two Dimension Forcer or a Coordinate Frame Reprojector upstream to flatten or unify them.
 ### Parameters
 ```json
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Dissolver Parameters",
-  "description": "Configure how to dissolve features by grouping them based on shared attributes",
+  "description": "Sets which features are dissolved together, how closely their vertices must line up, and which of their attributes the merged feature keeps.",
   "type": "object",
   "properties": {
     "groupBy": {
       "title": "Group By Attributes",
-      "description": "List of attribute names to group features by before dissolving. Features with the same values for these attributes will be dissolved together",
+      "description": "Attributes whose values decide which features dissolve together — features matching on all of them are merged into one. When omitted, every feature forms a single group.",
       "type": [
         "array",
         "null"
@@ -3238,7 +3251,7 @@ Dissolve Features by Grouping Attributes
     },
     "tolerance": {
       "title": "Tolerance",
-      "description": "Geometric tolerance. Vertices closer than this distance will be considered identical during the dissolve operation.",
+      "description": "Distance below which two vertices are treated as the same point when merging geometries, in the unit of the input's coordinate frame. Defaults to zero, which merges only exactly coincident vertices and can leave slivers between edges that nearly meet.",
       "type": [
         "number",
         "null"
@@ -3247,7 +3260,7 @@ Dissolve Features by Grouping Attributes
     },
     "attributeAccumulation": {
       "title": "Attribute Accumulation",
-      "description": "Strategy for handling attributes when dissolving features",
+      "description": "Which attributes the merged feature keeps.",
       "default": "useOneFeature",
       "allOf": [
         {
@@ -3262,11 +3275,11 @@ Dissolve Features by Grouping Attributes
     },
     "AttributeAccumulationStrategy": {
       "title": "Attribute Accumulation Strategy",
-      "description": "Defines how attributes should be handled when dissolving multiple features into one",
+      "description": "Which attributes a merged feature keeps.",
       "oneOf": [
         {
           "title": "Drop Incoming Attributes",
-          "description": "No attributes from any incoming features will be preserved in the output (except group_by attributes if specified)",
+          "description": "Keeps only the grouping attributes, discarding everything else.",
           "type": "string",
           "enum": [
             "dropAttributes"
@@ -3274,7 +3287,7 @@ Dissolve Features by Grouping Attributes
         },
         {
           "title": "Merge Incoming Attributes",
-          "description": "The output feature will merge all input attributes. When multiple features have the same attribute with different values, all values are collected into an array",
+          "description": "Keeps every attribute from every feature in the group. Where features disagree on a value, all the differing values are collected into an array.",
           "type": "string",
           "enum": [
             "mergeAttributes"
@@ -3282,7 +3295,7 @@ Dissolve Features by Grouping Attributes
         },
         {
           "title": "Use Attributes From One Feature",
-          "description": "The output inherits the attributes of one representative feature of the group",
+          "description": "Keeps the attributes of a single feature from the group and discards the rest.",
           "type": "string",
           "enum": [
             "useOneFeature"

--- a/engine/runtime/action-processor/src/attribute/datetime_converter.rs
+++ b/engine/runtime/action-processor/src/attribute/datetime_converter.rs
@@ -26,7 +26,7 @@ impl ProcessorFactory for DateTimeConverterFactory {
     }
 
     fn description(&self) -> &str {
-        "Convert datetime values between different formats"
+        "Reads a datetime from an attribute and rewrites it in another format, either as a typed datetime value or as a formatted string or Unix timestamp."
     }
 
     fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
@@ -98,16 +98,18 @@ impl ProcessorFactory for DateTimeConverterFactory {
             DateTimeOutputFormat::UnixS | DateTimeOutputFormat::UnixMs => AttrType::Number,
         };
 
-        // `default` (success) port: the conversion succeeded, so the output
-        // attribute is Always present with the produced type.
+        // `features` port carries two kinds of feature: ones whose value converted, and ones
+        // that never had the source attribute and passed straight through (§4.3). The output
+        // attribute is therefore only *possibly* present, not guaranteed.
         let out_name = params
             .output_attribute
             .clone()
             .unwrap_or_else(|| params.attribute.clone());
         let mut default_schema = input.clone();
-        default_schema.insert(Attribute::new(out_name), AttrField::always(produced_type));
+        default_schema.insert(Attribute::new(out_name), AttrField::maybe(produced_type));
 
-        // `failed` port: the feature passes through untouched.
+        // `failed` port: the value was present but could not be parsed, so the feature is
+        // forwarded untouched.
         Some(HashMap::from([
             (FEATURES_PORT.clone(), default_schema),
             (Port::new(FAILED_PORT), input),
@@ -130,63 +132,80 @@ struct DateTimeConverter {
 }
 
 /// # Date Time Converter Parameters
+/// Selects the attribute to convert, how to interpret its current value, and the format to
+/// write back.
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DateTimeConverterParam {
-    /// Attribute containing the datetime value to convert
+    /// # Source Attribute
+    /// Attribute holding the datetime to convert. Features that do not carry it pass through
+    /// unchanged.
     pub attribute: String,
-    /// Format of the input value (default: auto)
+    /// # Input Format
+    /// How to interpret the existing value. Leave unset to detect it from the value itself.
     #[serde(default)]
     pub input_format: DateTimeInputFormat,
-    /// Desired output format (default: auto).
-    /// Use `auto` to store as typed DateTime value (parser mode).
-    /// Use other formats to output as string/number (formatter mode).
+    /// # Output Format
+    /// Format to write back. Leave unset to store a typed datetime value; choose any other
+    /// format to write a string or a number instead.
     #[serde(default)]
     pub output_format: DateTimeOutputFormat,
-    /// Write result to a different attribute (leave input untouched)
-    /// Defaults to the same as `attribute`
+    /// # Output Attribute
+    /// Attribute to write the result to, leaving the source untouched. Defaults to overwriting
+    /// the source attribute.
     #[serde(default)]
     pub output_attribute: Option<String>,
 }
 
 /// Input format options for Date Time Converter
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, Default)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "camelCase")]
 pub enum DateTimeInputFormat {
-    /// Auto-detect from known formats.
-    /// Note: Numeric values are always interpreted as Unix seconds.
-    /// For milliseconds, use the explicit `unix_ms` input format.
+    /// # Detect Automatically
+    /// Recognises the value from its own shape. A bare number is always read as Unix seconds —
+    /// choose Unix Milliseconds explicitly for millisecond timestamps.
     #[default]
     Auto,
-    /// RFC3339 / ISO 8601 format
+    /// # RFC 3339
+    /// Internet date and time format, the profile of ISO 8601 used by most APIs.
     Rfc3339,
-    /// Unix timestamp in seconds
+    /// # Unix Seconds
+    /// Seconds elapsed since 1970-01-01 UTC.
     UnixS,
-    /// Unix timestamp in milliseconds
+    /// # Unix Milliseconds
+    /// Milliseconds elapsed since 1970-01-01 UTC.
     UnixMs,
-    /// Date only format (YYYY-MM-DD)
+    /// # Date Only
+    /// Calendar date with no time part, as YYYY-MM-DD.
     Date,
-    /// Custom format using chrono format specifiers
+    /// # Custom Pattern
+    /// Field-by-field pattern, for values none of the fixed formats match.
     Custom(String),
 }
 
 /// Output format options for Date Time Converter
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, Default)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "camelCase")]
 pub enum DateTimeOutputFormat {
-    /// Auto: Store as typed DateTime value (preserves the native variant).
-    /// Use this when you want the datetime as a proper DateTime type rather than a string.
+    /// # Typed Datetime
+    /// Stores a datetime value rather than text, keeping it comparable and sortable downstream.
     #[default]
     Auto,
-    /// RFC3339 / ISO 8601 format
+    /// # RFC 3339
+    /// Writes a string in the internet date and time format, the profile of ISO 8601 used by
+    /// most APIs.
     Rfc3339,
-    /// Unix timestamp in seconds
+    /// # Unix Seconds
+    /// Writes a number: seconds elapsed since 1970-01-01 UTC.
     UnixS,
-    /// Unix timestamp in milliseconds
+    /// # Unix Milliseconds
+    /// Writes a number: milliseconds elapsed since 1970-01-01 UTC.
     UnixMs,
-    /// Date only format (YYYY-MM-DD)
+    /// # Date Only
+    /// Writes a string holding just the calendar date, as YYYY-MM-DD.
     Date,
-    /// Custom format using chrono format specifiers
+    /// # Custom Pattern
+    /// Writes a string built from a field-by-field pattern.
     Custom(String),
 }
 
@@ -204,12 +223,13 @@ impl Processor for DateTimeConverter {
             .unwrap_or(&self.params.attribute)
             .clone();
 
-        // Get the input value
+        // A feature that simply does not carry the attribute had nothing to convert. That is a
+        // no-op, not a conversion failure, so it passes through on `features` — `failed` is for
+        // values that were present and could not be parsed. See action-standard.md §4.3.
         let input_value = match feature.get(&self.params.attribute) {
             Some(v) => v,
             None => {
-                // Attribute not found, send to failed port
-                fw.send(ctx.new_with_feature_and_port(feature, Port::new(FAILED_PORT)));
+                fw.send(ctx.new_with_feature_and_port(feature, FEATURES_PORT.clone()));
                 return Ok(());
             }
         };
@@ -418,9 +438,10 @@ mod tests {
         let default = out
             .get(&FEATURES_PORT.clone())
             .expect("default port present");
+        // Maybe, not Always: features lacking `ts` now pass through here untouched (§4.3).
         assert_eq!(
             default.fields.get(&Attribute::new("ts".to_string())),
-            Some(&AttrField::always(AttrType::DateTime))
+            Some(&AttrField::maybe(AttrType::DateTime))
         );
 
         let failed = out.get(&Port::new("failed")).expect("failed port present");
@@ -434,7 +455,7 @@ mod tests {
     fn infer_unix_format_adds_number_to_output_attribute() {
         let with = with_from(json!({
             "attribute": "ts",
-            "outputFormat": "unix_s",
+            "outputFormat": "unixS",
             "outputAttribute": "epoch"
         }));
 
@@ -457,7 +478,7 @@ mod tests {
         );
         assert_eq!(
             default.fields.get(&Attribute::new("epoch".to_string())),
-            Some(&AttrField::always(AttrType::Number))
+            Some(&AttrField::maybe(AttrType::Number))
         );
 
         let failed = out.get(&Port::new("failed")).expect("failed port present");
@@ -485,7 +506,7 @@ mod tests {
             .expect("default port present");
         assert_eq!(
             default.fields.get(&Attribute::new("ts".to_string())),
-            Some(&AttrField::always(AttrType::String))
+            Some(&AttrField::maybe(AttrType::String))
         );
     }
 
@@ -840,6 +861,51 @@ mod tests {
             output_feature.get("createdAtTimestamp"),
             Some(&AttributeValue::Number(1609459200i64.into()))
         );
+    }
+
+    /// A feature that does not carry the source attribute had nothing to convert, which is a
+    /// no-op rather than a conversion failure. It must leave on `features` untouched, not on
+    /// `failed` — see action-standard.md §4.3. `failed` stays reserved for values that were
+    /// present and could not be parsed, covered by `test_invalid_datetime_goes_to_failed_port`.
+    #[test]
+    fn missing_attribute_passes_through_on_features() {
+        use crate::tests::utils::create_default_execute_context;
+        use reearth_flow_runtime::forwarder::NoopChannelForwarder;
+
+        let mut feature = Feature::new_with_attributes(Attributes::new());
+        feature.insert(
+            "unrelated".to_string(),
+            AttributeValue::String("keep me".to_string()),
+        );
+
+        let mut processor = DateTimeConverter {
+            params: DateTimeConverterParam {
+                attribute: "createdAt".to_string(),
+                input_format: DateTimeInputFormat::Auto,
+                output_format: DateTimeOutputFormat::UnixS,
+                output_attribute: None,
+            },
+        };
+
+        let noop = NoopChannelForwarder::default();
+        let fw = ProcessorChannelForwarder::Noop(noop.clone());
+        processor
+            .process(create_default_execute_context(&feature), &fw)
+            .unwrap();
+
+        assert_eq!(
+            noop.send_ports.lock().unwrap().as_slice(),
+            std::slice::from_ref(&*FEATURES_PORT),
+            "a feature with nothing to convert must not be routed to `failed`"
+        );
+        let features = noop.send_features.lock().unwrap();
+        assert_eq!(features.len(), 1);
+        assert_eq!(
+            features[0].get("unrelated"),
+            Some(&AttributeValue::String("keep me".to_string())),
+            "the feature must pass through unmodified"
+        );
+        assert_eq!(features[0].get("createdAt"), None);
     }
 
     #[test]

--- a/engine/runtime/action-processor/src/attribute/range_mapper.rs
+++ b/engine/runtime/action-processor/src/attribute/range_mapper.rs
@@ -25,7 +25,7 @@ impl ProcessorFactory for AttributeRangeMapperFactory {
     }
 
     fn description(&self) -> &str {
-        "Map attribute values to ranges and assign corresponding output values"
+        "Classifies a numeric attribute by looking its value up in a table of ranges and writing the matched range's output value to another attribute."
     }
 
     fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
@@ -34,6 +34,10 @@ impl ProcessorFactory for AttributeRangeMapperFactory {
 
     fn categories(&self) -> &[&'static str] {
         &["Attribute"]
+    }
+
+    fn tags(&self) -> &[&'static str] {
+        &["mapping"]
     }
 
     fn get_input_ports(&self) -> Vec<Port> {
@@ -80,23 +84,30 @@ struct AttributeRangeMapper {
 }
 
 /// # Attribute Range Mapper Parameters
+/// Defines the attribute to classify, the table of ranges to match it against, and where the
+/// matched value is written.
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AttributeRangeMapperParam {
     /// # Input Attribute
-    /// The attribute to evaluate for range mapping
+    /// Attribute holding the value to classify. Numbers are used directly, numeric strings are
+    /// parsed, and booleans count as 1 and 0. Any other type is treated as unclassifiable and
+    /// takes the default value.
     pub input_attribute: String,
 
     /// # Output Attribute
-    /// The attribute to store the mapped value
+    /// Attribute the matched value is written to. An existing value is overwritten.
     pub output_attribute: String,
 
     /// # Range Lookup Table
-    /// List of ranges and their corresponding output values
+    /// Ranges to test the input against, in order. The first match wins, so overlapping ranges
+    /// resolve to whichever is listed first.
     pub range_table: Vec<RangeEntry>,
 
     /// # Default Value
-    /// Value to use when input doesn't match any range (can be string, number, boolean, etc.)
+    /// Value written when no range matches, and also when the input attribute is absent or is
+    /// not a number, numeric string, or boolean. When omitted, those features pass through with
+    /// the output attribute left unset rather than being rejected.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_value: Option<Value>,
 }
@@ -106,15 +117,17 @@ pub struct AttributeRangeMapperParam {
 #[serde(rename_all = "camelCase")]
 pub struct RangeEntry {
     /// # From (Minimum)
-    /// The minimum value of the range (inclusive)
+    /// Lower bound of the range, inclusive.
     pub from: f64,
 
     /// # To (Maximum)
-    /// The maximum value of the range (exclusive)
+    /// Upper bound of the range, exclusive — a value equal to it falls into the next range.
+    /// Setting it equal to the lower bound makes the entry match that one exact value instead.
     pub to: f64,
 
     /// # Output Value
-    /// The value to assign when input falls within this range (can be string, number, boolean, etc.)
+    /// Value written to the output attribute when the input falls in this range. Any JSON type
+    /// is accepted.
     pub output_value: Value,
 }
 

--- a/engine/runtime/action-processor/src/attribute/table_extractor.rs
+++ b/engine/runtime/action-processor/src/attribute/table_extractor.rs
@@ -102,11 +102,7 @@ impl ProcessorFactory for AttributeTableExtractorFactory {
                 ))
             })?
         } else if let Some(inline) = params.inline.clone() {
-            serde_json::from_value(inline).map_err(|e| {
-                AttributeProcessorError::TableExtractorFactory(format!(
-                    "Failed to parse extraction table: {e}"
-                ))
-            })?
+            inline
         } else {
             return Err(AttributeProcessorError::TableExtractorFactory(
                 "Missing required parameter `dataset` or `inline`".to_string(),
@@ -126,31 +122,46 @@ impl ProcessorFactory for AttributeTableExtractorFactory {
 
 /// # Attribute Table Extractor Parameters
 /// Configures the table of source/destination path pairs used to move nested attribute values.
+/// Supply the table either as a file, via Dataset URI, or directly, via Inline Table — one of
+/// the two is required.
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 struct AttributeTableExtractorParam {
     /// # Dataset URI
-    /// Path or URI of the extraction table file. Provide either this or inline data.
+    /// Path or URI of a JSON file holding the extraction table. Provide either this or Inline
+    /// Table.
     dataset: Option<Code>,
     /// # Inline Table
-    /// Extraction table content provided directly as JSON. Used when no dataset URI is given.
-    inline: Option<Value>,
+    /// Extraction table given directly, keyed by feature type. Each key is a feature type name
+    /// as it appears in the type attribute, and its value is the list of rules applied to
+    /// features of that type. Provide either this or Dataset URI.
+    inline: Option<HashMap<String, Vec<ExtractRule>>>,
     /// # Feature Type Attribute
     /// Attribute whose value selects which rule set in the table applies to the feature. Defaults to `__citygml_feature_type`.
     type_attribute: Option<String>,
 }
 
-/// One extraction rule for a single feature type in the extraction table.
+/// # Extraction Rule
+/// Moves one value from a source path to a destination path.
+///
+/// Both paths are chains of attribute keys separated by **spaces**, not dots — the keys
+/// themselves are qualified XML names such as `bldg:measuredHeight`, which may contain colons
+/// and dots but never whitespace.
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 struct ExtractRule {
-    /// Space-separated chain of keys naming where the extracted value is written. A single
-    /// segment writes a top-level attribute; multiple segments write into a nested map,
-    /// creating it (or any missing intermediate map) as needed.
-    attribute: String,
-    /// Space-separated chain of nested keys to walk from the feature's top level down to the value.
-    json_path: String,
-    /// Optional coercion applied to the extracted value before it is written.
+    /// # Destination Path
+    /// Where the value is written, as a space-separated chain of keys. A single segment writes a
+    /// top-level attribute; several segments write into a nested map, creating it and any
+    /// missing intermediate map as needed.
+    destination_path: String,
+    /// # Source Path
+    /// Where the value is read from, as a space-separated chain of keys walked from the
+    /// feature's top level. A segment matches either a key in a map or the first matching
+    /// element of a list, so it works whether a wrapper element appears once or many times.
+    source_path: String,
+    /// # Value Type
+    /// Converts the extracted value before writing it. Leave unset to write it unchanged.
     #[serde(default)]
     data_type: Option<ExtractDataType>,
 }
@@ -186,10 +197,11 @@ impl Processor for AttributeTableExtractor {
         if let Some(feature_type) = feature_type {
             if let Some(rules) = self.table.get(&feature_type) {
                 for rule in rules {
-                    let src_segments: Vec<&str> = rule.json_path.split_whitespace().collect();
+                    let src_segments: Vec<&str> = rule.source_path.split_whitespace().collect();
                     if let Some(value) = resolve_path(&feature, &src_segments) {
                         let value = coerce(value, rule.data_type);
-                        let dst_segments: Vec<&str> = rule.attribute.split_whitespace().collect();
+                        let dst_segments: Vec<&str> =
+                            rule.destination_path.split_whitespace().collect();
                         if !dst_segments.is_empty() {
                             write_path(&mut feature, &dst_segments, value);
                         }

--- a/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
+++ b/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
@@ -42,7 +42,9 @@ enum DestinationFrame {
     Crs {
         /// # EPSG Code
         /// EPSG code of the destination coordinate reference system.
-        epsg_code: u32,
+        // u16 is the width `EpsgCode` itself holds, so the generated schema states the real
+        // bound rather than a looser one that `build` would then have to re-check.
+        epsg_code: u16,
     },
     /// # Euclidean
     /// Convert to a non-georeferenced Euclidean frame. This is the frame the
@@ -162,14 +164,7 @@ impl ProcessorFactory for CoordinateFrameReprojectorFactory {
         // `epsgCode` rides inside the `crs` variant, so the schema cannot express a
         // CRS destination without one — no runtime check needed (§3.2).
         let target = match params.destination_frame {
-            DestinationFrame::Crs { epsg_code } => {
-                let epsg = u16::try_from(epsg_code).map_err(|_| {
-                    GeometryProcessorError::CoordinateFrameReprojectorFactory(format!(
-                        "`epsgCode` {epsg_code} is out of range"
-                    ))
-                })?;
-                CoordinateFrame::Crs(EpsgCode::new(epsg))
-            }
+            DestinationFrame::Crs { epsg_code } => CoordinateFrame::Crs(EpsgCode::new(epsg_code)),
             DestinationFrame::Euclidean => CoordinateFrame::Euclidean,
         };
 

--- a/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
+++ b/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
@@ -32,15 +32,22 @@ thread_local! {
     static REPROJECTION_CACHE: RefCell<ReprojectionCache> = RefCell::new(ReprojectionCache::new());
 }
 
-/// The destination coordinate frame kind.
+/// The destination coordinate frame, carrying the input each kind needs.
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[serde(tag = "type", rename_all = "camelCase")]
 enum DestinationFrame {
     /// # CRS
     /// Reproject to a coordinate reference system identified by an EPSG code.
-    Crs,
+    #[serde(rename_all = "camelCase")]
+    Crs {
+        /// # EPSG Code
+        /// EPSG code of the destination coordinate reference system.
+        epsg_code: u32,
+    },
     /// # Euclidean
-    /// Convert to a non-georeferenced Euclidean frame.
+    /// Convert to a non-georeferenced Euclidean frame. This is the frame the
+    /// planar geometry operations work in, so it is the on-ramp for actions that
+    /// require flat 2D input.
     Euclidean,
 }
 
@@ -86,13 +93,9 @@ enum BasePoint {
 #[serde(rename_all = "camelCase")]
 pub struct CoordinateFrameReprojectorParam {
     /// # Destination Frame
-    /// Coordinate frame to convert geometry into.
+    /// Coordinate frame to convert geometry into. Choosing a CRS also requires
+    /// its EPSG code.
     destination_frame: DestinationFrame,
-    /// # EPSG Code
-    /// EPSG code of the destination CRS. Required when the destination frame is
-    /// a CRS.
-    #[serde(default)]
-    epsg_code: Option<u16>,
     /// # Base Point
     /// How coordinates bridge the Euclidean/CRS boundary.
     #[serde(default)]
@@ -156,12 +159,14 @@ impl ProcessorFactory for CoordinateFrameReprojectorFactory {
             })?
         };
 
+        // `epsgCode` rides inside the `crs` variant, so the schema cannot express a
+        // CRS destination without one — no runtime check needed (§3.2).
         let target = match params.destination_frame {
-            DestinationFrame::Crs => {
-                let epsg = params.epsg_code.ok_or_else(|| {
-                    GeometryProcessorError::CoordinateFrameReprojectorFactory(
-                        "`epsgCode` is required when the destination frame is a CRS".to_string(),
-                    )
+            DestinationFrame::Crs { epsg_code } => {
+                let epsg = u16::try_from(epsg_code).map_err(|_| {
+                    GeometryProcessorError::CoordinateFrameReprojectorFactory(format!(
+                        "`epsgCode` {epsg_code} is out of range"
+                    ))
                 })?;
                 CoordinateFrame::Crs(EpsgCode::new(epsg))
             }
@@ -437,8 +442,7 @@ mod tests {
     #[test]
     fn value_mode_carries_its_base_point() {
         let params = parse(json!({
-            "destinationFrame": "crs",
-            "epsgCode": 6677,
+            "destinationFrame": { "type": "crs", "epsgCode": 6677 },
             "basePointSource": {
                 "type": "value",
                 "basePoint": { "type": "flowExpr", "value": "[1, 2, 3]" },
@@ -450,7 +454,7 @@ mod tests {
     #[test]
     fn from_port_mode_carries_its_match_key() {
         let params = parse(json!({
-            "destinationFrame": "euclidean",
+            "destinationFrame": { "type": "euclidean" },
             "basePointSource": {
                 "type": "fromPort",
                 "matchKey": { "type": "flowExpr", "value": "id" },
@@ -465,7 +469,7 @@ mod tests {
     #[test]
     fn explicit_as_is_mode() {
         let params = parse(json!({
-            "destinationFrame": "euclidean",
+            "destinationFrame": { "type": "euclidean" },
             "basePointSource": { "type": "asIs" },
         }));
         assert!(matches!(params.base_point_source, BasePoint::AsIs));
@@ -473,15 +477,43 @@ mod tests {
 
     #[test]
     fn absent_base_point_source_defaults_to_as_is() {
-        let params = parse(json!({ "destinationFrame": "euclidean" }));
+        let params = parse(json!({ "destinationFrame": { "type": "euclidean" } }));
         assert!(matches!(params.base_point_source, BasePoint::AsIs));
+    }
+
+    /// `epsgCode` rides inside the `crs` variant, so a CRS destination cannot be
+    /// expressed without one. This is what makes the runtime check unnecessary (§3.2).
+    #[test]
+    fn crs_destination_carries_its_epsg_code() {
+        let params = parse(json!({
+            "destinationFrame": { "type": "crs", "epsgCode": 6677 },
+        }));
+        assert!(matches!(
+            params.destination_frame,
+            DestinationFrame::Crs { epsg_code: 6677 }
+        ));
+    }
+
+    #[test]
+    fn crs_destination_without_an_epsg_code_is_rejected() {
+        let result: Result<CoordinateFrameReprojectorParam, _> =
+            serde_json::from_value(json!({ "destinationFrame": { "type": "crs" } }));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn euclidean_destination_needs_no_epsg_code() {
+        let params = parse(json!({ "destinationFrame": { "type": "euclidean" } }));
+        assert!(matches!(
+            params.destination_frame,
+            DestinationFrame::Euclidean
+        ));
     }
 
     #[test]
     fn value_mode_without_its_base_point_is_rejected() {
         let result: Result<CoordinateFrameReprojectorParam, _> = serde_json::from_value(json!({
-            "destinationFrame": "crs",
-            "epsgCode": 6677,
+            "destinationFrame": { "type": "crs", "epsgCode": 6677 },
             "basePointSource": { "type": "value" },
         }));
         assert!(result.is_err());

--- a/engine/runtime/action-processor/src/geometry/dissolver.rs
+++ b/engine/runtime/action-processor/src/geometry/dissolver.rs
@@ -75,7 +75,7 @@ impl ProcessorFactory for DissolverFactory {
     }
 
     fn description(&self) -> &str {
-        "Merges features that share the same grouping attribute values into one feature per group, combining their geometries and dropping the boundaries between them. Inputs must be flat 2D geometries sharing one coordinate frame; place a Two Dimension Forcer or a Coordinate Frame Reprojector upstream to flatten or unify them."
+        "Merges area features that share the same grouping attribute values into one feature per group, combining their geometries and dropping the boundaries between them. Inputs must be flat 2D areas sharing one coordinate frame; place a Two Dimension Forcer or a Coordinate Frame Reprojector upstream to flatten or unify them."
     }
 
     fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {

--- a/engine/runtime/action-processor/src/geometry/dissolver.rs
+++ b/engine/runtime/action-processor/src/geometry/dissolver.rs
@@ -46,8 +46,6 @@ fn engine_cache_dir(executor_id: uuid::Uuid) -> PathBuf {
     executor_cache_subdir(executor_id, "processors")
 }
 
-pub static AREA_PORT: Lazy<Port> = Lazy::new(|| Port::new("area"));
-
 /// # Attribute Accumulation Strategy
 /// Which attributes a merged feature keeps.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Default)]
@@ -95,7 +93,7 @@ impl ProcessorFactory for DissolverFactory {
     }
 
     fn get_output_ports(&self) -> Vec<Port> {
-        vec![AREA_PORT.clone(), REJECTED_PORT.clone()]
+        vec![FEATURES_PORT.clone(), REJECTED_PORT.clone()]
     }
 
     fn build(
@@ -491,7 +489,7 @@ impl Processor for Dissolver {
             fw.send(ExecutorContext::new_with_node_context_feature_and_port(
                 &ctx,
                 dissolved,
-                AREA_PORT.clone(),
+                FEATURES_PORT.clone(),
             ));
         }
         Ok(())
@@ -752,7 +750,7 @@ mod tests {
         let mut area = Vec::new();
         let mut rejected = Vec::new();
         for (port, feature) in ports.iter().zip(sent) {
-            if *port == *AREA_PORT {
+            if *port == *FEATURES_PORT {
                 area.push(feature);
             } else if *port == *REJECTED_PORT {
                 rejected.push(feature);

--- a/engine/runtime/action-processor/src/geometry/dissolver.rs
+++ b/engine/runtime/action-processor/src/geometry/dissolver.rs
@@ -49,18 +49,19 @@ fn engine_cache_dir(executor_id: uuid::Uuid) -> PathBuf {
 pub static AREA_PORT: Lazy<Port> = Lazy::new(|| Port::new("area"));
 
 /// # Attribute Accumulation Strategy
-/// Defines how attributes should be handled when dissolving multiple features into one
+/// Which attributes a merged feature keeps.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub enum AttributeAccumulationStrategy {
     /// # Drop Incoming Attributes
-    /// No attributes from any incoming features will be preserved in the output (except group_by attributes if specified)
+    /// Keeps only the grouping attributes, discarding everything else.
     DropAttributes,
     /// # Merge Incoming Attributes
-    /// The output feature will merge all input attributes. When multiple features have the same attribute with different values, all values are collected into an array
+    /// Keeps every attribute from every feature in the group. Where features disagree on a
+    /// value, all the differing values are collected into an array.
     MergeAttributes,
     /// # Use Attributes From One Feature
-    /// The output inherits the attributes of one representative feature of the group
+    /// Keeps the attributes of a single feature from the group and discards the rest.
     #[default]
     UseOneFeature,
 }
@@ -74,7 +75,7 @@ impl ProcessorFactory for DissolverFactory {
     }
 
     fn description(&self) -> &str {
-        "Dissolve Features by Grouping Attributes"
+        "Merges features that share the same grouping attribute values into one feature per group, combining their geometries and dropping the boundaries between them. Inputs must be flat 2D geometries sharing one coordinate frame; place a Two Dimension Forcer or a Coordinate Frame Reprojector upstream to flatten or unify them."
     }
 
     fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
@@ -83,6 +84,10 @@ impl ProcessorFactory for DissolverFactory {
 
     fn categories(&self) -> &[&'static str] {
         &["Geometry"]
+    }
+
+    fn tags(&self) -> &[&'static str] {
+        &["spatial", "aggregation"]
     }
 
     fn get_input_ports(&self) -> Vec<Port> {
@@ -140,18 +145,22 @@ impl ProcessorFactory for DissolverFactory {
 }
 
 /// # Dissolver Parameters
-/// Configure how to dissolve features by grouping them based on shared attributes
+/// Sets which features are dissolved together, how closely their vertices must line up, and
+/// which of their attributes the merged feature keeps.
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DissolverParam {
     /// # Group By Attributes
-    /// List of attribute names to group features by before dissolving. Features with the same values for these attributes will be dissolved together
+    /// Attributes whose values decide which features dissolve together — features matching on
+    /// all of them are merged into one. When omitted, every feature forms a single group.
     group_by: Option<Vec<Attribute>>,
     /// # Tolerance
-    /// Geometric tolerance. Vertices closer than this distance will be considered identical during the dissolve operation.
+    /// Distance below which two vertices are treated as the same point when merging geometries,
+    /// in the unit of the input's coordinate frame. Defaults to zero, which merges only exactly
+    /// coincident vertices and can leave slivers between edges that nearly meet.
     tolerance: Option<f64>,
     /// # Attribute Accumulation
-    /// Strategy for handling attributes when dissolving features
+    /// Which attributes the merged feature keeps.
     #[serde(default)]
     attribute_accumulation: AttributeAccumulationStrategy,
 }

--- a/engine/runtime/examples/fixture/config/plateau6_bldg_flatten_attributes.json
+++ b/engine/runtime/examples/fixture/config/plateau6_bldg_flatten_attributes.json
@@ -1,474 +1,474 @@
 {
   "bldg:Building": [
     {
-      "attribute": "attributes gml:name",
-      "jsonPath": "cityGmlAttributes gml:name"
+      "destinationPath": "attributes gml:name",
+      "sourcePath": "cityGmlAttributes gml:name"
     },
     {
-      "attribute": "attributes core:creationDate",
-      "jsonPath": "cityGmlAttributes core:creationDate"
+      "destinationPath": "attributes core:creationDate",
+      "sourcePath": "cityGmlAttributes core:creationDate"
     },
     {
-      "attribute": "attributes bldg:class",
-      "jsonPath": "cityGmlAttributes bldg:class"
+      "destinationPath": "attributes bldg:class",
+      "sourcePath": "cityGmlAttributes bldg:class"
     },
     {
-      "attribute": "attributes bldg:usage",
-      "jsonPath": "cityGmlAttributes bldg:usage"
+      "destinationPath": "attributes bldg:usage",
+      "sourcePath": "cityGmlAttributes bldg:usage"
     },
     {
-      "attribute": "attributes bldg:yearOfConstruction",
-      "jsonPath": "cityGmlAttributes con:dateOfConstruction"
+      "destinationPath": "attributes bldg:yearOfConstruction",
+      "sourcePath": "cityGmlAttributes con:dateOfConstruction"
     },
     {
-      "attribute": "attributes bldg:measuredHeight",
-      "jsonPath": "cityGmlAttributes con:height con:Height con:value"
+      "destinationPath": "attributes bldg:measuredHeight",
+      "sourcePath": "cityGmlAttributes con:height con:Height con:value"
     },
     {
-      "attribute": "attributes bldg:measuredHeight_uom",
-      "jsonPath": "cityGmlAttributes con:height con:Height con:value_uom"
+      "destinationPath": "attributes bldg:measuredHeight_uom",
+      "sourcePath": "cityGmlAttributes con:height con:Height con:value_uom"
     },
     {
-      "attribute": "attributes bldg:storeysAboveGround",
-      "jsonPath": "cityGmlAttributes bldg:storeysAboveGround",
+      "destinationPath": "attributes bldg:storeysAboveGround",
+      "sourcePath": "cityGmlAttributes bldg:storeysAboveGround",
       "dataType": "int"
     },
     {
-      "attribute": "attributes bldg:storeysBelowGround",
-      "jsonPath": "cityGmlAttributes bldg:storeysBelowGround",
+      "destinationPath": "attributes bldg:storeysBelowGround",
+      "sourcePath": "cityGmlAttributes bldg:storeysBelowGround",
       "dataType": "int"
     },
     {
-      "attribute": "attributes bldg:address",
-      "jsonPath": "cityGmlAttributes bldg:address core:Address core:xalAddress xAL:Address xAL:Locality xAL:NameElement $"
+      "destinationPath": "attributes bldg:address",
+      "sourcePath": "cityGmlAttributes bldg:address core:Address core:xalAddress xAL:Address xAL:Locality xAL:NameElement $"
     },
     {
-      "attribute": "attributes uro:BuildingIDAttribute_uro:buildingID",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:buildingID"
+      "destinationPath": "attributes uro:BuildingIDAttribute_uro:buildingID",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:buildingID"
     },
     {
-      "attribute": "attributes uro:BuildingIDAttribute_uro:branchID",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:branchID",
+      "destinationPath": "attributes uro:BuildingIDAttribute_uro:branchID",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:branchID",
       "dataType": "int"
     },
     {
-      "attribute": "attributes uro:BuildingIDAttribute_uro:partID",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:partID",
+      "destinationPath": "attributes uro:BuildingIDAttribute_uro:partID",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:partID",
       "dataType": "int"
     },
     {
-      "attribute": "attributes uro:BuildingIDAttribute_uro:prefecture",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:prefecture"
+      "destinationPath": "attributes uro:BuildingIDAttribute_uro:prefecture",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:prefecture"
     },
     {
-      "attribute": "attributes uro:BuildingIDAttribute_uro:city",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:city"
+      "destinationPath": "attributes uro:BuildingIDAttribute_uro:city",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:city"
     },
     {
-      "attribute": "attributes uro:BuildingIDAttribute_uro:city_code",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:city_code"
+      "destinationPath": "attributes uro:BuildingIDAttribute_uro:city_code",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:city_code"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:serialNumberOfBuildingCertification",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:serialNumberOfBuildingCertification"
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:serialNumberOfBuildingCertification",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:serialNumberOfBuildingCertification"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:siteArea",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:siteArea",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:siteArea",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:siteArea",
       "dataType": "float"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:totalFloorArea",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:totalFloorArea",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:totalFloorArea",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:totalFloorArea",
       "dataType": "float"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:buildingFootprintArea",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:buildingFootprintArea",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:buildingFootprintArea",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:buildingFootprintArea",
       "dataType": "float"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:buildingRoofEdgeArea",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:buildingRoofEdgeArea",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:buildingRoofEdgeArea",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:buildingRoofEdgeArea",
       "dataType": "float"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:buildingStructureType",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:buildingStructureType"
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:buildingStructureType",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:buildingStructureType"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:fireproofStructureType",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:fireproofStructureType"
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:fireproofStructureType",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:fireproofStructureType"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:urbanPlanType",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:urbanPlanType"
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:urbanPlanType",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:urbanPlanType"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:areaClassificationType",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:areaClassificationType"
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:areaClassificationType",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:areaClassificationType"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:districtsAndZonesType",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:districtsAndZonesType"
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:districtsAndZonesType",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:districtsAndZonesType"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:landUseType",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:landUseType"
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:landUseType",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:landUseType"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:vacancy",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:vacancy"
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:vacancy",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:vacancy"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:buildingCoverageRate",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:buildingCoverageRate",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:buildingCoverageRate",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:buildingCoverageRate",
       "dataType": "float"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:floorAreaRate",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:floorAreaRate",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:floorAreaRate",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:floorAreaRate",
       "dataType": "float"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:specifiedBuildingCoverageRate",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:specifiedBuildingCoverageRate",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:specifiedBuildingCoverageRate",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:specifiedBuildingCoverageRate",
       "dataType": "float"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:specifiedFloorAreaRate",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:specifiedFloorAreaRate",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:specifiedFloorAreaRate",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:specifiedFloorAreaRate",
       "dataType": "float"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:standardFloorAreaRate",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:standardFloorAreaRate",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:standardFloorAreaRate",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:standardFloorAreaRate",
       "dataType": "float"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:buildingHeight",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:buildingHeight",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:buildingHeight",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:buildingHeight",
       "dataType": "float"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:eaveHeight",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:eaveHeight",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:eaveHeight",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:eaveHeight",
       "dataType": "int"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:surveyYear",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:surveyYear",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:surveyYear",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:surveyYear",
       "dataType": "int"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:class",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:class"
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:class",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:class"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:name",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:name"
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:name",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:name"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:capacity",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:capacity",
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:capacity",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:capacity",
       "dataType": "int"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:totalFloorArea",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:totalFloorArea",
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:totalFloorArea",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:totalFloorArea",
       "dataType": "float"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:inauguralDate",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:inauguralDate"
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:inauguralDate",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:inauguralDate"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:yearOpened",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:yearOpened",
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:yearOpened",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:yearOpened",
       "dataType": "int"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:yearClosed",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:yearClosed",
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:yearClosed",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:yearClosed",
       "dataType": "int"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:urbanPlanType",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:urbanPlanType"
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:urbanPlanType",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:urbanPlanType"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:areaClassificationType",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:areaClassificationType"
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:areaClassificationType",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:areaClassificationType"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:districtsAndZonesType",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:districtsAndZonesType"
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:districtsAndZonesType",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:districtsAndZonesType"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:landUseType",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:landUseType"
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:landUseType",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:landUseType"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:surveyYear",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:surveyYear",
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:surveyYear",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:surveyYear",
       "dataType": "int"
     },
     {
-      "attribute": "attributes uro:RealEstateIDAttribute_uro:realEstateIDOfBuilding",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:RealEstateIDAttribute uro:realEstateIDOfBuilding"
+      "destinationPath": "attributes uro:RealEstateIDAttribute_uro:realEstateIDOfBuilding",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:RealEstateIDAttribute uro:realEstateIDOfBuilding"
     },
     {
-      "attribute": "attributes uro:RealEstateIDAttribute_uro:matchingScore",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:RealEstateIDAttribute uro:matchingScore",
+      "destinationPath": "attributes uro:RealEstateIDAttribute_uro:matchingScore",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:RealEstateIDAttribute uro:matchingScore",
       "dataType": "int"
     },
     {
-      "attribute": "attributes urc:DataQualityAttribute_urc:geometrySrcDescLod1",
-      "jsonPath": "cityGmlAttributes core:adeOfAbstractCityObject urc:DataQualityAttribute urc:geometrySrcDescLod1"
+      "destinationPath": "attributes urc:DataQualityAttribute_urc:geometrySrcDescLod1",
+      "sourcePath": "cityGmlAttributes core:adeOfAbstractCityObject urc:DataQualityAttribute urc:geometrySrcDescLod1"
     },
     {
-      "attribute": "attributes urc:DataQualityAttribute_urc:lodType",
-      "jsonPath": "cityGmlAttributes core:adeOfAbstractCityObject urc:DataQualityAttribute urc:lodType"
+      "destinationPath": "attributes urc:DataQualityAttribute_urc:lodType",
+      "sourcePath": "cityGmlAttributes core:adeOfAbstractCityObject urc:DataQualityAttribute urc:lodType"
     },
     {
-      "attribute": "attributes urc:DataQualityAttribute_urc:lod1HeightType",
-      "jsonPath": "cityGmlAttributes core:adeOfAbstractCityObject urc:DataQualityAttribute urc:lod1HeightType"
+      "destinationPath": "attributes urc:DataQualityAttribute_urc:lod1HeightType",
+      "sourcePath": "cityGmlAttributes core:adeOfAbstractCityObject urc:DataQualityAttribute urc:lod1HeightType"
     }
   ],
   "bldg:BuildingPart": [
     {
-      "attribute": "attributes gml:name",
-      "jsonPath": "cityGmlAttributes gml:name"
+      "destinationPath": "attributes gml:name",
+      "sourcePath": "cityGmlAttributes gml:name"
     },
     {
-      "attribute": "attributes core:creationDate",
-      "jsonPath": "cityGmlAttributes core:creationDate"
+      "destinationPath": "attributes core:creationDate",
+      "sourcePath": "cityGmlAttributes core:creationDate"
     },
     {
-      "attribute": "attributes bldg:class",
-      "jsonPath": "cityGmlAttributes bldg:class"
+      "destinationPath": "attributes bldg:class",
+      "sourcePath": "cityGmlAttributes bldg:class"
     },
     {
-      "attribute": "attributes bldg:usage",
-      "jsonPath": "cityGmlAttributes bldg:usage"
+      "destinationPath": "attributes bldg:usage",
+      "sourcePath": "cityGmlAttributes bldg:usage"
     },
     {
-      "attribute": "attributes bldg:yearOfConstruction",
-      "jsonPath": "cityGmlAttributes con:dateOfConstruction"
+      "destinationPath": "attributes bldg:yearOfConstruction",
+      "sourcePath": "cityGmlAttributes con:dateOfConstruction"
     },
     {
-      "attribute": "attributes bldg:measuredHeight",
-      "jsonPath": "cityGmlAttributes con:height con:Height con:value"
+      "destinationPath": "attributes bldg:measuredHeight",
+      "sourcePath": "cityGmlAttributes con:height con:Height con:value"
     },
     {
-      "attribute": "attributes bldg:measuredHeight_uom",
-      "jsonPath": "cityGmlAttributes con:height con:Height con:value_uom"
+      "destinationPath": "attributes bldg:measuredHeight_uom",
+      "sourcePath": "cityGmlAttributes con:height con:Height con:value_uom"
     },
     {
-      "attribute": "attributes bldg:storeysAboveGround",
-      "jsonPath": "cityGmlAttributes bldg:storeysAboveGround",
+      "destinationPath": "attributes bldg:storeysAboveGround",
+      "sourcePath": "cityGmlAttributes bldg:storeysAboveGround",
       "dataType": "int"
     },
     {
-      "attribute": "attributes bldg:storeysBelowGround",
-      "jsonPath": "cityGmlAttributes bldg:storeysBelowGround",
+      "destinationPath": "attributes bldg:storeysBelowGround",
+      "sourcePath": "cityGmlAttributes bldg:storeysBelowGround",
       "dataType": "int"
     },
     {
-      "attribute": "attributes bldg:address",
-      "jsonPath": "cityGmlAttributes bldg:address core:Address core:xalAddress xAL:Address xAL:Locality xAL:NameElement $"
+      "destinationPath": "attributes bldg:address",
+      "sourcePath": "cityGmlAttributes bldg:address core:Address core:xalAddress xAL:Address xAL:Locality xAL:NameElement $"
     },
     {
-      "attribute": "attributes uro:BuildingIDAttribute_uro:buildingID",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:buildingID"
+      "destinationPath": "attributes uro:BuildingIDAttribute_uro:buildingID",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:buildingID"
     },
     {
-      "attribute": "attributes uro:BuildingIDAttribute_uro:branchID",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:branchID",
+      "destinationPath": "attributes uro:BuildingIDAttribute_uro:branchID",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:branchID",
       "dataType": "int"
     },
     {
-      "attribute": "attributes uro:BuildingIDAttribute_uro:partID",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:partID",
+      "destinationPath": "attributes uro:BuildingIDAttribute_uro:partID",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:partID",
       "dataType": "int"
     },
     {
-      "attribute": "attributes uro:BuildingIDAttribute_uro:prefecture",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:prefecture"
+      "destinationPath": "attributes uro:BuildingIDAttribute_uro:prefecture",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:prefecture"
     },
     {
-      "attribute": "attributes uro:BuildingIDAttribute_uro:city",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:city"
+      "destinationPath": "attributes uro:BuildingIDAttribute_uro:city",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:city"
     },
     {
-      "attribute": "attributes uro:BuildingIDAttribute_uro:city_code",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:city_code"
+      "destinationPath": "attributes uro:BuildingIDAttribute_uro:city_code",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingIDAttribute uro:city_code"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:serialNumberOfBuildingCertification",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:serialNumberOfBuildingCertification"
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:serialNumberOfBuildingCertification",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:serialNumberOfBuildingCertification"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:siteArea",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:siteArea",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:siteArea",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:siteArea",
       "dataType": "float"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:totalFloorArea",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:totalFloorArea",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:totalFloorArea",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:totalFloorArea",
       "dataType": "float"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:buildingFootprintArea",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:buildingFootprintArea",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:buildingFootprintArea",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:buildingFootprintArea",
       "dataType": "float"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:buildingRoofEdgeArea",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:buildingRoofEdgeArea",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:buildingRoofEdgeArea",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:buildingRoofEdgeArea",
       "dataType": "float"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:buildingStructureType",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:buildingStructureType"
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:buildingStructureType",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:buildingStructureType"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:fireproofStructureType",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:fireproofStructureType"
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:fireproofStructureType",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:fireproofStructureType"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:urbanPlanType",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:urbanPlanType"
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:urbanPlanType",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:urbanPlanType"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:areaClassificationType",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:areaClassificationType"
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:areaClassificationType",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:areaClassificationType"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:districtsAndZonesType",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:districtsAndZonesType"
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:districtsAndZonesType",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:districtsAndZonesType"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:landUseType",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:landUseType"
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:landUseType",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:landUseType"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:vacancy",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:vacancy"
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:vacancy",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:vacancy"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:buildingCoverageRate",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:buildingCoverageRate",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:buildingCoverageRate",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:buildingCoverageRate",
       "dataType": "float"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:floorAreaRate",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:floorAreaRate",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:floorAreaRate",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:floorAreaRate",
       "dataType": "float"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:specifiedBuildingCoverageRate",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:specifiedBuildingCoverageRate",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:specifiedBuildingCoverageRate",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:specifiedBuildingCoverageRate",
       "dataType": "float"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:specifiedFloorAreaRate",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:specifiedFloorAreaRate",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:specifiedFloorAreaRate",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:specifiedFloorAreaRate",
       "dataType": "float"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:standardFloorAreaRate",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:standardFloorAreaRate",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:standardFloorAreaRate",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:standardFloorAreaRate",
       "dataType": "float"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:buildingHeight",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:buildingHeight",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:buildingHeight",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:buildingHeight",
       "dataType": "float"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:eaveHeight",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:eaveHeight",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:eaveHeight",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:eaveHeight",
       "dataType": "int"
     },
     {
-      "attribute": "attributes uro:BuildingDetailAttribute_uro:surveyYear",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:surveyYear",
+      "destinationPath": "attributes uro:BuildingDetailAttribute_uro:surveyYear",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:BuildingDetailAttribute uro:surveyYear",
       "dataType": "int"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:class",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:class"
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:class",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:class"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:name",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:name"
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:name",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:name"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:capacity",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:capacity",
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:capacity",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:capacity",
       "dataType": "int"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:totalFloorArea",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:totalFloorArea",
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:totalFloorArea",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:totalFloorArea",
       "dataType": "float"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:inauguralDate",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:inauguralDate"
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:inauguralDate",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:inauguralDate"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:yearOpened",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:yearOpened",
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:yearOpened",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:yearOpened",
       "dataType": "int"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:yearClosed",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:yearClosed",
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:yearClosed",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:yearClosed",
       "dataType": "int"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:urbanPlanType",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:urbanPlanType"
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:urbanPlanType",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:urbanPlanType"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:areaClassificationType",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:areaClassificationType"
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:areaClassificationType",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:areaClassificationType"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:districtsAndZonesType",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:districtsAndZonesType"
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:districtsAndZonesType",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:districtsAndZonesType"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:landUseType",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:landUseType"
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:landUseType",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:landUseType"
     },
     {
-      "attribute": "attributes uro:LargeCustomerFacilityAttribute_uro:surveyYear",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:surveyYear",
+      "destinationPath": "attributes uro:LargeCustomerFacilityAttribute_uro:surveyYear",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:LargeCustomerFacilityAttribute uro:surveyYear",
       "dataType": "int"
     },
     {
-      "attribute": "attributes uro:RealEstateIDAttribute_uro:realEstateIDOfBuilding",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:RealEstateIDAttribute uro:realEstateIDOfBuilding"
+      "destinationPath": "attributes uro:RealEstateIDAttribute_uro:realEstateIDOfBuilding",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:RealEstateIDAttribute uro:realEstateIDOfBuilding"
     },
     {
-      "attribute": "attributes uro:RealEstateIDAttribute_uro:matchingScore",
-      "jsonPath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:RealEstateIDAttribute uro:matchingScore",
+      "destinationPath": "attributes uro:RealEstateIDAttribute_uro:matchingScore",
+      "sourcePath": "cityGmlAttributes bldg:adeOfAbstractBuilding uro:RealEstateIDAttribute uro:matchingScore",
       "dataType": "int"
     },
     {
-      "attribute": "attributes urc:DataQualityAttribute_urc:geometrySrcDescLod1",
-      "jsonPath": "cityGmlAttributes core:adeOfAbstractCityObject urc:DataQualityAttribute urc:geometrySrcDescLod1"
+      "destinationPath": "attributes urc:DataQualityAttribute_urc:geometrySrcDescLod1",
+      "sourcePath": "cityGmlAttributes core:adeOfAbstractCityObject urc:DataQualityAttribute urc:geometrySrcDescLod1"
     },
     {
-      "attribute": "attributes urc:DataQualityAttribute_urc:lodType",
-      "jsonPath": "cityGmlAttributes core:adeOfAbstractCityObject urc:DataQualityAttribute urc:lodType"
+      "destinationPath": "attributes urc:DataQualityAttribute_urc:lodType",
+      "sourcePath": "cityGmlAttributes core:adeOfAbstractCityObject urc:DataQualityAttribute urc:lodType"
     },
     {
-      "attribute": "attributes urc:DataQualityAttribute_urc:lod1HeightType",
-      "jsonPath": "cityGmlAttributes core:adeOfAbstractCityObject urc:DataQualityAttribute urc:lod1HeightType"
+      "destinationPath": "attributes urc:DataQualityAttribute_urc:lod1HeightType",
+      "sourcePath": "cityGmlAttributes core:adeOfAbstractCityObject urc:DataQualityAttribute urc:lod1HeightType"
     }
   ]
 }

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/02-tran-rwy-trk-squr-wwy.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/02-tran-rwy-trk-squr-wwy.yml
@@ -756,7 +756,7 @@ graphs:
   - id: 4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a
     from: 9f8e7d6c-5b4a-3c2d-1e0f-8a9b7c6d5e4f
     to: b4c8d9e0-f1a2-3b4c-5d6e-7f8a9b0c1d2e
-    fromPort: area
+    fromPort: features
     toPort: features
   - id: 9e0f1a2b-3c4d-5e6f-7a8b-9c0d1e2f3a4b
     from: 6f7a8b9c-0d1e-2f3a-4b5c-6d7e8f9a0b1c

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/02-tran-rwy-trk-squr-wwy/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/02-tran-rwy-trk-squr-wwy/workflow.yml
@@ -522,7 +522,7 @@ graphs:
       - id: 4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a
         from: 9f8e7d6c-5b4a-3c2d-1e0f-8a9b7c6d5e4f
         to: b4c8d9e0-f1a2-3b4c-5d6e-7f8a9b0c1d2e
-        fromPort: area
+        fromPort: features
         toPort: features
       # GeometryFilter (linestrings) -> FeatureSorterPreMVT
       - id: 9e0f1a2b-3c4d-5e6f-7a8b-9c0d1e2f3a4b

--- a/engine/runtime/examples/fixture/workflow/datetime_converter/basic_conversions.yml
+++ b/engine/runtime/examples/fixture/workflow/datetime_converter/basic_conversions.yml
@@ -26,7 +26,7 @@ graphs:
         with:
           attribute: timestamp
           inputFormat: auto
-          outputFormat: unix_s
+          outputFormat: unixS
 
       - id: 550e8400-e29b-41d4-a716-446655440104
         name: "Output"

--- a/engine/runtime/examples/fixture/workflow/datetime_converter/error_handling.yml
+++ b/engine/runtime/examples/fixture/workflow/datetime_converter/error_handling.yml
@@ -26,7 +26,7 @@ graphs:
         with:
           attribute: timestamp
           inputFormat: rfc3339
-          outputFormat: unix_s
+          outputFormat: unixS
 
       - id: 550e8400-e29b-41d4-a716-446655440204
         name: "Output"

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
@@ -3210,7 +3210,7 @@ graphs:
   - id: c472919a-4b86-462f-8570-34a149f69382
     from: c93837eb-e050-46f3-9c97-66d7273fe1e5
     to: 0c979585-82b2-41aa-909c-00d9b8d017d0
-    fromPort: area
+    fromPort: features
     toPort: features
   - id: c472919a-4b86-462f-8570-34a149f69382
     from: 0c979585-82b2-41aa-909c-00d9b8d017d0

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
@@ -996,7 +996,7 @@ graphs:
       - id: c472919a-4b86-462f-8570-34a149f69382
         from: c93837eb-e050-46f3-9c97-66d7273fe1e5
         to: 0c979585-82b2-41aa-909c-00d9b8d017d0
-        fromPort: area
+        fromPort: features
         toPort: features
 
       # FeatureSorter to GeometryExtractor

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -2868,23 +2868,12 @@
         "properties": {
           "destinationFrame": {
             "title": "Destination Frame",
-            "description": "Coordinate frame to convert geometry into.",
+            "description": "Coordinate frame to convert geometry into. Choosing a CRS also requires its EPSG code.",
             "allOf": [
               {
                 "$ref": "#/definitions/DestinationFrame"
               }
             ]
-          },
-          "epsgCode": {
-            "title": "EPSG Code",
-            "description": "EPSG code of the destination CRS. Required when the destination frame is a CRS.",
-            "default": null,
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint16",
-            "minimum": 0.0
           },
           "basePointSource": {
             "title": "Base Point",
@@ -2901,23 +2890,47 @@
         },
         "definitions": {
           "DestinationFrame": {
-            "description": "The destination coordinate frame kind.",
+            "description": "The destination coordinate frame, carrying the input each kind needs.",
             "oneOf": [
               {
                 "title": "CRS",
                 "description": "Reproject to a coordinate reference system identified by an EPSG code.",
-                "type": "string",
-                "enum": [
-                  "crs"
-                ]
+                "type": "object",
+                "required": [
+                  "epsgCode",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "crs"
+                    ]
+                  },
+                  "epsgCode": {
+                    "title": "EPSG Code",
+                    "description": "EPSG code of the destination coordinate reference system.",
+                    "type": "integer",
+                    "format": "uint32",
+                    "minimum": 0.0
+                  }
+                }
               },
               {
                 "title": "Euclidean",
-                "description": "Convert to a non-georeferenced Euclidean frame.",
-                "type": "string",
-                "enum": [
-                  "euclidean"
-                ]
+                "description": "Convert to a non-georeferenced Euclidean frame. This is the frame the planar geometry operations work in, so it is the on-ramp for actions that require flat 2D input.",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "euclidean"
+                    ]
+                  }
+                }
               }
             ]
           },
@@ -3295,16 +3308,16 @@
     {
       "name": "Dissolver",
       "type": "processor",
-      "description": "Dissolve Features by Grouping Attributes",
+      "description": "Merges features that share the same grouping attribute values into one feature per group, combining their geometries and dropping the boundaries between them. Inputs must be flat 2D geometries sharing one coordinate frame; place a Two Dimension Forcer or a Coordinate Frame Reprojector upstream to flatten or unify them.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Dissolver Parameters",
-        "description": "Configure how to dissolve features by grouping them based on shared attributes",
+        "description": "Sets which features are dissolved together, how closely their vertices must line up, and which of their attributes the merged feature keeps.",
         "type": "object",
         "properties": {
           "groupBy": {
             "title": "Group By Attributes",
-            "description": "List of attribute names to group features by before dissolving. Features with the same values for these attributes will be dissolved together",
+            "description": "Attributes whose values decide which features dissolve together — features matching on all of them are merged into one. When omitted, every feature forms a single group.",
             "type": [
               "array",
               "null"
@@ -3315,7 +3328,7 @@
           },
           "tolerance": {
             "title": "Tolerance",
-            "description": "Geometric tolerance. Vertices closer than this distance will be considered identical during the dissolve operation.",
+            "description": "Distance below which two vertices are treated as the same point when merging geometries, in the unit of the input's coordinate frame. Defaults to zero, which merges only exactly coincident vertices and can leave slivers between edges that nearly meet.",
             "type": [
               "number",
               "null"
@@ -3324,7 +3337,7 @@
           },
           "attributeAccumulation": {
             "title": "Attribute Accumulation",
-            "description": "Strategy for handling attributes when dissolving features",
+            "description": "Which attributes the merged feature keeps.",
             "default": "useOneFeature",
             "allOf": [
               {
@@ -3339,11 +3352,11 @@
           },
           "AttributeAccumulationStrategy": {
             "title": "Attribute Accumulation Strategy",
-            "description": "Defines how attributes should be handled when dissolving multiple features into one",
+            "description": "Which attributes a merged feature keeps.",
             "oneOf": [
               {
                 "title": "Drop Incoming Attributes",
-                "description": "No attributes from any incoming features will be preserved in the output (except group_by attributes if specified)",
+                "description": "Keeps only the grouping attributes, discarding everything else.",
                 "type": "string",
                 "enum": [
                   "dropAttributes"
@@ -3351,7 +3364,7 @@
               },
               {
                 "title": "Merge Incoming Attributes",
-                "description": "The output feature will merge all input attributes. When multiple features have the same attribute with different values, all values are collected into an array",
+                "description": "Keeps every attribute from every feature in the group. Where features disagree on a value, all the differing values are collected into an array.",
                 "type": "string",
                 "enum": [
                   "mergeAttributes"
@@ -3359,7 +3372,7 @@
               },
               {
                 "title": "Use Attributes From One Feature",
-                "description": "The output inherits the attributes of one representative feature of the group",
+                "description": "Keeps the attributes of a single feature from the group and discards the rest.",
                 "type": "string",
                 "enum": [
                   "useOneFeature"
@@ -3380,7 +3393,10 @@
       "categories": [
         "Geometry"
       ],
-      "tags": []
+      "tags": [
+        "spatial",
+        "aggregation"
+      ]
     },
     {
       "name": "Echo Processor",

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -2911,7 +2911,7 @@
                     "title": "EPSG Code",
                     "description": "EPSG code of the destination coordinate reference system.",
                     "type": "integer",
-                    "format": "uint32",
+                    "format": "uint16",
                     "minimum": 0.0
                   }
                 }

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -3387,7 +3387,7 @@
         "features"
       ],
       "outputPorts": [
-        "area",
+        "features",
         "rejected"
       ],
       "categories": [

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -919,10 +919,11 @@
     {
       "name": "Attribute Range Mapper",
       "type": "processor",
-      "description": "Map attribute values to ranges and assign corresponding output values",
+      "description": "Classifies a numeric attribute by looking its value up in a table of ranges and writing the matched range's output value to another attribute.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Attribute Range Mapper Parameters",
+        "description": "Defines the attribute to classify, the table of ranges to match it against, and where the matched value is written.",
         "type": "object",
         "required": [
           "inputAttribute",
@@ -932,17 +933,17 @@
         "properties": {
           "inputAttribute": {
             "title": "Input Attribute",
-            "description": "The attribute to evaluate for range mapping",
+            "description": "Attribute holding the value to classify. Numbers are used directly, numeric strings are parsed, and booleans count as 1 and 0. Any other type is treated as unclassifiable and takes the default value.",
             "type": "string"
           },
           "outputAttribute": {
             "title": "Output Attribute",
-            "description": "The attribute to store the mapped value",
+            "description": "Attribute the matched value is written to. An existing value is overwritten.",
             "type": "string"
           },
           "rangeTable": {
             "title": "Range Lookup Table",
-            "description": "List of ranges and their corresponding output values",
+            "description": "Ranges to test the input against, in order. The first match wins, so overlapping ranges resolve to whichever is listed first.",
             "type": "array",
             "items": {
               "$ref": "#/definitions/RangeEntry"
@@ -950,7 +951,7 @@
           },
           "defaultValue": {
             "title": "Default Value",
-            "description": "Value to use when input doesn't match any range (can be string, number, boolean, etc.)"
+            "description": "Value written when no range matches, and also when the input attribute is absent or is not a number, numeric string, or boolean. When omitted, those features pass through with the output attribute left unset rather than being rejected."
           }
         },
         "definitions": {
@@ -965,19 +966,19 @@
             "properties": {
               "from": {
                 "title": "From (Minimum)",
-                "description": "The minimum value of the range (inclusive)",
+                "description": "Lower bound of the range, inclusive.",
                 "type": "number",
                 "format": "double"
               },
               "to": {
                 "title": "To (Maximum)",
-                "description": "The maximum value of the range (exclusive)",
+                "description": "Upper bound of the range, exclusive — a value equal to it falls into the next range. Setting it equal to the lower bound makes the entry match that one exact value instead.",
                 "type": "number",
                 "format": "double"
               },
               "outputValue": {
                 "title": "Output Value",
-                "description": "The value to assign when input falls within this range (can be string, number, boolean, etc.)"
+                "description": "Value written to the output attribute when the input falls in this range. Any JSON type is accepted."
               }
             }
           }
@@ -993,7 +994,9 @@
       "categories": [
         "Attribute"
       ],
-      "tags": []
+      "tags": [
+        "mapping"
+      ]
     },
     {
       "name": "Attribute Table Extractor",
@@ -1002,12 +1005,12 @@
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Attribute Table Extractor Parameters",
-        "description": "Configures the table of source/destination path pairs used to move nested attribute values.",
+        "description": "Configures the table of source/destination path pairs used to move nested attribute values. Supply the table either as a file, via Dataset URI, or directly, via Inline Table — one of the two is required.",
         "type": "object",
         "properties": {
           "dataset": {
             "title": "Dataset URI",
-            "description": "Path or URI of the extraction table file. Provide either this or inline data.",
+            "description": "Path or URI of a JSON file holding the extraction table. Provide either this or Inline Table.",
             "type": [
               "object",
               "null"
@@ -1032,7 +1035,17 @@
           },
           "inline": {
             "title": "Inline Table",
-            "description": "Extraction table content provided directly as JSON. Used when no dataset URI is given."
+            "description": "Extraction table given directly, keyed by feature type. Each key is a feature type name as it appears in the type attribute, and its value is the list of rules applied to features of that type. Provide either this or Dataset URI.",
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ExtractRule"
+              }
+            }
           },
           "typeAttribute": {
             "title": "Feature Type Attribute",
@@ -1040,6 +1053,62 @@
             "type": [
               "string",
               "null"
+            ]
+          }
+        },
+        "definitions": {
+          "ExtractRule": {
+            "title": "Extraction Rule",
+            "description": "Moves one value from a source path to a destination path.\n\nBoth paths are chains of attribute keys separated by **spaces**, not dots — the keys themselves are qualified XML names such as `bldg:measuredHeight`, which may contain colons and dots but never whitespace.",
+            "type": "object",
+            "required": [
+              "destinationPath",
+              "sourcePath"
+            ],
+            "properties": {
+              "destinationPath": {
+                "title": "Destination Path",
+                "description": "Where the value is written, as a space-separated chain of keys. A single segment writes a top-level attribute; several segments write into a nested map, creating it and any missing intermediate map as needed.",
+                "type": "string"
+              },
+              "sourcePath": {
+                "title": "Source Path",
+                "description": "Where the value is read from, as a space-separated chain of keys walked from the feature's top level. A segment matches either a key in a map or the first matching element of a list, so it works whether a wrapper element appears once or many times.",
+                "type": "string"
+              },
+              "dataType": {
+                "title": "Value Type",
+                "description": "Converts the extracted value before writing it. Leave unset to write it unchanged.",
+                "default": null,
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/ExtractDataType"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          },
+          "ExtractDataType": {
+            "oneOf": [
+              {
+                "title": "Integer",
+                "description": "Parses a string value as an integer.",
+                "type": "string",
+                "enum": [
+                  "int"
+                ]
+              },
+              {
+                "title": "Float",
+                "description": "Parses a string value as a floating point number.",
+                "type": "string",
+                "enum": [
+                  "float"
+                ]
+              }
             ]
           }
         }
@@ -2971,21 +3040,24 @@
     {
       "name": "Date Time Converter",
       "type": "processor",
-      "description": "Convert datetime values between different formats",
+      "description": "Reads a datetime from an attribute and rewrites it in another format, either as a typed datetime value or as a formatted string or Unix timestamp.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Date Time Converter Parameters",
+        "description": "Selects the attribute to convert, how to interpret its current value, and the format to write back.",
         "type": "object",
         "required": [
           "attribute"
         ],
         "properties": {
           "attribute": {
-            "description": "Attribute containing the datetime value to convert",
+            "title": "Source Attribute",
+            "description": "Attribute holding the datetime to convert. Features that do not carry it pass through unchanged.",
             "type": "string"
           },
           "inputFormat": {
-            "description": "Format of the input value (default: auto)",
+            "title": "Input Format",
+            "description": "How to interpret the existing value. Leave unset to detect it from the value itself.",
             "default": "auto",
             "allOf": [
               {
@@ -2994,7 +3066,8 @@
             ]
           },
           "outputFormat": {
-            "description": "Desired output format (default: auto). Use `auto` to store as typed DateTime value (parser mode). Use other formats to output as string/number (formatter mode).",
+            "title": "Output Format",
+            "description": "Format to write back. Leave unset to store a typed datetime value; choose any other format to write a string or a number instead.",
             "default": "auto",
             "allOf": [
               {
@@ -3003,7 +3076,8 @@
             ]
           },
           "outputAttribute": {
-            "description": "Write result to a different attribute (leave input untouched) Defaults to the same as `attribute`",
+            "title": "Output Attribute",
+            "description": "Attribute to write the result to, leaving the source untouched. Defaults to overwriting the source attribute.",
             "default": null,
             "type": [
               "string",
@@ -3016,42 +3090,48 @@
             "description": "Input format options for Date Time Converter",
             "oneOf": [
               {
-                "description": "Auto-detect from known formats. Note: Numeric values are always interpreted as Unix seconds. For milliseconds, use the explicit `unix_ms` input format.",
+                "title": "Detect Automatically",
+                "description": "Recognises the value from its own shape. A bare number is always read as Unix seconds — choose Unix Milliseconds explicitly for millisecond timestamps.",
                 "type": "string",
                 "enum": [
                   "auto"
                 ]
               },
               {
-                "description": "RFC3339 / ISO 8601 format",
+                "title": "RFC 3339",
+                "description": "Internet date and time format, the profile of ISO 8601 used by most APIs.",
                 "type": "string",
                 "enum": [
                   "rfc3339"
                 ]
               },
               {
-                "description": "Unix timestamp in seconds",
+                "title": "Unix Seconds",
+                "description": "Seconds elapsed since 1970-01-01 UTC.",
                 "type": "string",
                 "enum": [
-                  "unix_s"
+                  "unixS"
                 ]
               },
               {
-                "description": "Unix timestamp in milliseconds",
+                "title": "Unix Milliseconds",
+                "description": "Milliseconds elapsed since 1970-01-01 UTC.",
                 "type": "string",
                 "enum": [
-                  "unix_ms"
+                  "unixMs"
                 ]
               },
               {
-                "description": "Date only format (YYYY-MM-DD)",
+                "title": "Date Only",
+                "description": "Calendar date with no time part, as YYYY-MM-DD.",
                 "type": "string",
                 "enum": [
                   "date"
                 ]
               },
               {
-                "description": "Custom format using chrono format specifiers",
+                "title": "Custom Pattern",
+                "description": "Field-by-field pattern, for values none of the fixed formats match.",
                 "type": "object",
                 "required": [
                   "custom"
@@ -3069,42 +3149,48 @@
             "description": "Output format options for Date Time Converter",
             "oneOf": [
               {
-                "description": "Auto: Store as typed DateTime value (preserves the native variant). Use this when you want the datetime as a proper DateTime type rather than a string.",
+                "title": "Typed Datetime",
+                "description": "Stores a datetime value rather than text, keeping it comparable and sortable downstream.",
                 "type": "string",
                 "enum": [
                   "auto"
                 ]
               },
               {
-                "description": "RFC3339 / ISO 8601 format",
+                "title": "RFC 3339",
+                "description": "Writes a string in the internet date and time format, the profile of ISO 8601 used by most APIs.",
                 "type": "string",
                 "enum": [
                   "rfc3339"
                 ]
               },
               {
-                "description": "Unix timestamp in seconds",
+                "title": "Unix Seconds",
+                "description": "Writes a number: seconds elapsed since 1970-01-01 UTC.",
                 "type": "string",
                 "enum": [
-                  "unix_s"
+                  "unixS"
                 ]
               },
               {
-                "description": "Unix timestamp in milliseconds",
+                "title": "Unix Milliseconds",
+                "description": "Writes a number: milliseconds elapsed since 1970-01-01 UTC.",
                 "type": "string",
                 "enum": [
-                  "unix_ms"
+                  "unixMs"
                 ]
               },
               {
-                "description": "Date only format (YYYY-MM-DD)",
+                "title": "Date Only",
+                "description": "Writes a string holding just the calendar date, as YYYY-MM-DD.",
                 "type": "string",
                 "enum": [
                   "date"
                 ]
               },
               {
-                "description": "Custom format using chrono format specifiers",
+                "title": "Custom Pattern",
+                "description": "Writes a string built from a field-by-field pattern.",
                 "type": "object",
                 "required": [
                   "custom"

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -3308,7 +3308,7 @@
     {
       "name": "Dissolver",
       "type": "processor",
-      "description": "Merges features that share the same grouping attribute values into one feature per group, combining their geometries and dropping the boundaries between them. Inputs must be flat 2D geometries sharing one coordinate frame; place a Two Dimension Forcer or a Coordinate Frame Reprojector upstream to flatten or unify them.",
+      "description": "Merges area features that share the same grouping attribute values into one feature per group, combining their geometries and dropping the boundaries between them. Inputs must be flat 2D areas sharing one coordinate frame; place a Two Dimension Forcer or a Coordinate Frame Reprojector upstream to flatten or unify them.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Dissolver Parameters",

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -923,6 +923,7 @@
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Attribute Range Mapper Parameters",
+        "description": "Defines the attribute to classify, the table of ranges to match it against, and where the matched value is written.",
         "type": "object",
         "required": [
           "inputAttribute",
@@ -993,7 +994,9 @@
       "categories": [
         "Attribute"
       ],
-      "tags": []
+      "tags": [
+        "mapping"
+      ]
     },
     {
       "name": "Attribute Table Extractor",
@@ -1032,7 +1035,17 @@
           },
           "inline": {
             "title": "Tabla en Línea",
-            "description": "Contenido de la tabla de extracción proporcionado directamente como JSON. Se usa cuando no se proporciona una URI de conjunto de datos"
+            "description": "Contenido de la tabla de extracción proporcionado directamente como JSON. Se usa cuando no se proporciona una URI de conjunto de datos",
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ExtractRule"
+              }
+            }
           },
           "typeAttribute": {
             "title": "Atributo de Tipo de Entidad",
@@ -1040,6 +1053,62 @@
             "type": [
               "string",
               "null"
+            ]
+          }
+        },
+        "definitions": {
+          "ExtractRule": {
+            "title": "Extraction Rule",
+            "description": "Moves one value from a source path to a destination path.\n\nBoth paths are chains of attribute keys separated by **spaces**, not dots — the keys themselves are qualified XML names such as `bldg:measuredHeight`, which may contain colons and dots but never whitespace.",
+            "type": "object",
+            "required": [
+              "destinationPath",
+              "sourcePath"
+            ],
+            "properties": {
+              "destinationPath": {
+                "title": "Destination Path",
+                "description": "Where the value is written, as a space-separated chain of keys. A single segment writes a top-level attribute; several segments write into a nested map, creating it and any missing intermediate map as needed.",
+                "type": "string"
+              },
+              "sourcePath": {
+                "title": "Source Path",
+                "description": "Where the value is read from, as a space-separated chain of keys walked from the feature's top level. A segment matches either a key in a map or the first matching element of a list, so it works whether a wrapper element appears once or many times.",
+                "type": "string"
+              },
+              "dataType": {
+                "title": "Value Type",
+                "description": "Converts the extracted value before writing it. Leave unset to write it unchanged.",
+                "default": null,
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/ExtractDataType"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          },
+          "ExtractDataType": {
+            "oneOf": [
+              {
+                "title": "Integer",
+                "description": "Parses a string value as an integer.",
+                "type": "string",
+                "enum": [
+                  "int"
+                ]
+              },
+              {
+                "title": "Float",
+                "description": "Parses a string value as a floating point number.",
+                "type": "string",
+                "enum": [
+                  "float"
+                ]
+              }
             ]
           }
         }
@@ -2975,16 +3044,19 @@
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Date Time Converter Parameters",
+        "description": "Selects the attribute to convert, how to interpret its current value, and the format to write back.",
         "type": "object",
         "required": [
           "attribute"
         ],
         "properties": {
           "attribute": {
+            "title": "Source Attribute",
             "description": "Attribute containing the datetime value to convert",
             "type": "string"
           },
           "inputFormat": {
+            "title": "Input Format",
             "description": "Format of the input value (default: auto)",
             "default": "auto",
             "allOf": [
@@ -2994,6 +3066,7 @@
             ]
           },
           "outputFormat": {
+            "title": "Output Format",
             "description": "Desired output format (default: auto). Use `auto` to store as typed DateTime value (parser mode). Use other formats to output as string/number (formatter mode).",
             "default": "auto",
             "allOf": [
@@ -3003,6 +3076,7 @@
             ]
           },
           "outputAttribute": {
+            "title": "Output Attribute",
             "description": "Write result to a different attribute (leave input untouched) Defaults to the same as `attribute`",
             "default": null,
             "type": [
@@ -3016,6 +3090,7 @@
             "description": "Input format options for Date Time Converter",
             "oneOf": [
               {
+                "title": "Detect Automatically",
                 "description": "Auto-detect from known formats. Note: Numeric values are always interpreted as Unix seconds. For milliseconds, use the explicit `unix_ms` input format.",
                 "type": "string",
                 "enum": [
@@ -3023,6 +3098,7 @@
                 ]
               },
               {
+                "title": "RFC 3339",
                 "description": "RFC3339 / ISO 8601 format",
                 "type": "string",
                 "enum": [
@@ -3030,20 +3106,23 @@
                 ]
               },
               {
-                "description": "Unix timestamp in seconds",
+                "title": "Unix Seconds",
+                "description": "Seconds elapsed since 1970-01-01 UTC.",
                 "type": "string",
                 "enum": [
-                  "unix_s"
+                  "unixS"
                 ]
               },
               {
-                "description": "Unix timestamp in milliseconds",
+                "title": "Unix Milliseconds",
+                "description": "Milliseconds elapsed since 1970-01-01 UTC.",
                 "type": "string",
                 "enum": [
-                  "unix_ms"
+                  "unixMs"
                 ]
               },
               {
+                "title": "Date Only",
                 "description": "Date only format (YYYY-MM-DD)",
                 "type": "string",
                 "enum": [
@@ -3051,7 +3130,8 @@
                 ]
               },
               {
-                "description": "Custom format using chrono format specifiers",
+                "title": "Custom Pattern",
+                "description": "Field-by-field pattern, for values none of the fixed formats match.",
                 "type": "object",
                 "required": [
                   "custom"
@@ -3069,6 +3149,7 @@
             "description": "Output format options for Date Time Converter",
             "oneOf": [
               {
+                "title": "Typed Datetime",
                 "description": "Auto: Store as typed DateTime value (preserves the native variant). Use this when you want the datetime as a proper DateTime type rather than a string.",
                 "type": "string",
                 "enum": [
@@ -3076,6 +3157,7 @@
                 ]
               },
               {
+                "title": "RFC 3339",
                 "description": "RFC3339 / ISO 8601 format",
                 "type": "string",
                 "enum": [
@@ -3083,20 +3165,23 @@
                 ]
               },
               {
-                "description": "Unix timestamp in seconds",
+                "title": "Unix Seconds",
+                "description": "Writes a number: seconds elapsed since 1970-01-01 UTC.",
                 "type": "string",
                 "enum": [
-                  "unix_s"
+                  "unixS"
                 ]
               },
               {
-                "description": "Unix timestamp in milliseconds",
+                "title": "Unix Milliseconds",
+                "description": "Writes a number: milliseconds elapsed since 1970-01-01 UTC.",
                 "type": "string",
                 "enum": [
-                  "unix_ms"
+                  "unixMs"
                 ]
               },
               {
+                "title": "Date Only",
                 "description": "Date only format (YYYY-MM-DD)",
                 "type": "string",
                 "enum": [
@@ -3104,7 +3189,8 @@
                 ]
               },
               {
-                "description": "Custom format using chrono format specifiers",
+                "title": "Custom Pattern",
+                "description": "Writes a string built from a field-by-field pattern.",
                 "type": "object",
                 "required": [
                   "custom"

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -2875,17 +2875,6 @@
               }
             ]
           },
-          "epsgCode": {
-            "title": "EPSG Code",
-            "description": "EPSG code of the destination CRS. Required when the destination frame is a CRS.",
-            "default": null,
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint16",
-            "minimum": 0.0
-          },
           "basePointSource": {
             "title": "Base Point",
             "description": "How coordinates bridge the Euclidean/CRS boundary.",
@@ -2901,23 +2890,47 @@
         },
         "definitions": {
           "DestinationFrame": {
-            "description": "The destination coordinate frame kind.",
+            "description": "The destination coordinate frame, carrying the input each kind needs.",
             "oneOf": [
               {
                 "title": "CRS",
                 "description": "Reproject to a coordinate reference system identified by an EPSG code.",
-                "type": "string",
-                "enum": [
-                  "crs"
-                ]
+                "type": "object",
+                "required": [
+                  "epsgCode",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "crs"
+                    ]
+                  },
+                  "epsgCode": {
+                    "title": "EPSG Code",
+                    "description": "EPSG code of the destination coordinate reference system.",
+                    "type": "integer",
+                    "format": "uint32",
+                    "minimum": 0.0
+                  }
+                }
               },
               {
                 "title": "Euclidean",
-                "description": "Convert to a non-georeferenced Euclidean frame.",
-                "type": "string",
-                "enum": [
-                  "euclidean"
-                ]
+                "description": "Convert to a non-georeferenced Euclidean frame. This is the frame the planar geometry operations work in, so it is the on-ramp for actions that require flat 2D input.",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "euclidean"
+                    ]
+                  }
+                }
               }
             ]
           },
@@ -3339,7 +3352,7 @@
           },
           "AttributeAccumulationStrategy": {
             "title": "Attribute Accumulation Strategy",
-            "description": "Defines how attributes should be handled when dissolving multiple features into one",
+            "description": "Which attributes a merged feature keeps.",
             "oneOf": [
               {
                 "title": "Drop Incoming Attributes",
@@ -3380,7 +3393,10 @@
       "categories": [
         "Geometry"
       ],
-      "tags": []
+      "tags": [
+        "spatial",
+        "aggregation"
+      ]
     },
     {
       "name": "Echo Processor",

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -3387,7 +3387,7 @@
         "features"
       ],
       "outputPorts": [
-        "area",
+        "features",
         "rejected"
       ],
       "categories": [

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -2911,7 +2911,7 @@
                     "title": "EPSG Code",
                     "description": "EPSG code of the destination coordinate reference system.",
                     "type": "integer",
-                    "format": "uint32",
+                    "format": "uint16",
                     "minimum": 0.0
                   }
                 }
@@ -3104,7 +3104,7 @@
             "oneOf": [
               {
                 "title": "Detect Automatically",
-                "description": "Auto-detect from known formats. Note: Numeric values are always interpreted as Unix seconds. For milliseconds, use the explicit `unix_ms` input format.",
+                "description": "Auto-detect from known formats. Note: Numeric values are always interpreted as Unix seconds. For milliseconds, use the explicit `unixMs` input format.",
                 "type": "string",
                 "enum": [
                   "auto"

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -923,6 +923,7 @@
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Attribute Range Mapper Parameters",
+        "description": "Defines the attribute to classify, the table of ranges to match it against, and where the matched value is written.",
         "type": "object",
         "required": [
           "inputAttribute",
@@ -993,7 +994,9 @@
       "categories": [
         "Attribute"
       ],
-      "tags": []
+      "tags": [
+        "mapping"
+      ]
     },
     {
       "name": "Attribute Table Extractor",
@@ -1032,7 +1035,17 @@
           },
           "inline": {
             "title": "Table en Ligne",
-            "description": "Contenu de la table d'extraction fourni directement en JSON. Utilisé lorsqu'aucune URI de jeu de données n'est fournie"
+            "description": "Contenu de la table d'extraction fourni directement en JSON. Utilisé lorsqu'aucune URI de jeu de données n'est fournie",
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ExtractRule"
+              }
+            }
           },
           "typeAttribute": {
             "title": "Attribut de Type d'Entité",
@@ -1040,6 +1053,62 @@
             "type": [
               "string",
               "null"
+            ]
+          }
+        },
+        "definitions": {
+          "ExtractRule": {
+            "title": "Extraction Rule",
+            "description": "Moves one value from a source path to a destination path.\n\nBoth paths are chains of attribute keys separated by **spaces**, not dots — the keys themselves are qualified XML names such as `bldg:measuredHeight`, which may contain colons and dots but never whitespace.",
+            "type": "object",
+            "required": [
+              "destinationPath",
+              "sourcePath"
+            ],
+            "properties": {
+              "destinationPath": {
+                "title": "Destination Path",
+                "description": "Where the value is written, as a space-separated chain of keys. A single segment writes a top-level attribute; several segments write into a nested map, creating it and any missing intermediate map as needed.",
+                "type": "string"
+              },
+              "sourcePath": {
+                "title": "Source Path",
+                "description": "Where the value is read from, as a space-separated chain of keys walked from the feature's top level. A segment matches either a key in a map or the first matching element of a list, so it works whether a wrapper element appears once or many times.",
+                "type": "string"
+              },
+              "dataType": {
+                "title": "Value Type",
+                "description": "Converts the extracted value before writing it. Leave unset to write it unchanged.",
+                "default": null,
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/ExtractDataType"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          },
+          "ExtractDataType": {
+            "oneOf": [
+              {
+                "title": "Integer",
+                "description": "Parses a string value as an integer.",
+                "type": "string",
+                "enum": [
+                  "int"
+                ]
+              },
+              {
+                "title": "Float",
+                "description": "Parses a string value as a floating point number.",
+                "type": "string",
+                "enum": [
+                  "float"
+                ]
+              }
             ]
           }
         }
@@ -2975,16 +3044,19 @@
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Date Time Converter Parameters",
+        "description": "Selects the attribute to convert, how to interpret its current value, and the format to write back.",
         "type": "object",
         "required": [
           "attribute"
         ],
         "properties": {
           "attribute": {
+            "title": "Source Attribute",
             "description": "Attribute containing the datetime value to convert",
             "type": "string"
           },
           "inputFormat": {
+            "title": "Input Format",
             "description": "Format of the input value (default: auto)",
             "default": "auto",
             "allOf": [
@@ -2994,6 +3066,7 @@
             ]
           },
           "outputFormat": {
+            "title": "Output Format",
             "description": "Desired output format (default: auto). Use `auto` to store as typed DateTime value (parser mode). Use other formats to output as string/number (formatter mode).",
             "default": "auto",
             "allOf": [
@@ -3003,6 +3076,7 @@
             ]
           },
           "outputAttribute": {
+            "title": "Output Attribute",
             "description": "Write result to a different attribute (leave input untouched) Defaults to the same as `attribute`",
             "default": null,
             "type": [
@@ -3016,6 +3090,7 @@
             "description": "Input format options for Date Time Converter",
             "oneOf": [
               {
+                "title": "Detect Automatically",
                 "description": "Auto-detect from known formats. Note: Numeric values are always interpreted as Unix seconds. For milliseconds, use the explicit `unix_ms` input format.",
                 "type": "string",
                 "enum": [
@@ -3023,6 +3098,7 @@
                 ]
               },
               {
+                "title": "RFC 3339",
                 "description": "RFC3339 / ISO 8601 format",
                 "type": "string",
                 "enum": [
@@ -3030,20 +3106,23 @@
                 ]
               },
               {
-                "description": "Unix timestamp in seconds",
+                "title": "Unix Seconds",
+                "description": "Seconds elapsed since 1970-01-01 UTC.",
                 "type": "string",
                 "enum": [
-                  "unix_s"
+                  "unixS"
                 ]
               },
               {
-                "description": "Unix timestamp in milliseconds",
+                "title": "Unix Milliseconds",
+                "description": "Milliseconds elapsed since 1970-01-01 UTC.",
                 "type": "string",
                 "enum": [
-                  "unix_ms"
+                  "unixMs"
                 ]
               },
               {
+                "title": "Date Only",
                 "description": "Date only format (YYYY-MM-DD)",
                 "type": "string",
                 "enum": [
@@ -3051,7 +3130,8 @@
                 ]
               },
               {
-                "description": "Custom format using chrono format specifiers",
+                "title": "Custom Pattern",
+                "description": "Field-by-field pattern, for values none of the fixed formats match.",
                 "type": "object",
                 "required": [
                   "custom"
@@ -3069,6 +3149,7 @@
             "description": "Output format options for Date Time Converter",
             "oneOf": [
               {
+                "title": "Typed Datetime",
                 "description": "Auto: Store as typed DateTime value (preserves the native variant). Use this when you want the datetime as a proper DateTime type rather than a string.",
                 "type": "string",
                 "enum": [
@@ -3076,6 +3157,7 @@
                 ]
               },
               {
+                "title": "RFC 3339",
                 "description": "RFC3339 / ISO 8601 format",
                 "type": "string",
                 "enum": [
@@ -3083,20 +3165,23 @@
                 ]
               },
               {
-                "description": "Unix timestamp in seconds",
+                "title": "Unix Seconds",
+                "description": "Writes a number: seconds elapsed since 1970-01-01 UTC.",
                 "type": "string",
                 "enum": [
-                  "unix_s"
+                  "unixS"
                 ]
               },
               {
-                "description": "Unix timestamp in milliseconds",
+                "title": "Unix Milliseconds",
+                "description": "Writes a number: milliseconds elapsed since 1970-01-01 UTC.",
                 "type": "string",
                 "enum": [
-                  "unix_ms"
+                  "unixMs"
                 ]
               },
               {
+                "title": "Date Only",
                 "description": "Date only format (YYYY-MM-DD)",
                 "type": "string",
                 "enum": [
@@ -3104,7 +3189,8 @@
                 ]
               },
               {
-                "description": "Custom format using chrono format specifiers",
+                "title": "Custom Pattern",
+                "description": "Writes a string built from a field-by-field pattern.",
                 "type": "object",
                 "required": [
                   "custom"

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -2875,17 +2875,6 @@
               }
             ]
           },
-          "epsgCode": {
-            "title": "EPSG Code",
-            "description": "EPSG code of the destination CRS. Required when the destination frame is a CRS.",
-            "default": null,
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint16",
-            "minimum": 0.0
-          },
           "basePointSource": {
             "title": "Base Point",
             "description": "How coordinates bridge the Euclidean/CRS boundary.",
@@ -2901,23 +2890,47 @@
         },
         "definitions": {
           "DestinationFrame": {
-            "description": "The destination coordinate frame kind.",
+            "description": "The destination coordinate frame, carrying the input each kind needs.",
             "oneOf": [
               {
                 "title": "CRS",
                 "description": "Reproject to a coordinate reference system identified by an EPSG code.",
-                "type": "string",
-                "enum": [
-                  "crs"
-                ]
+                "type": "object",
+                "required": [
+                  "epsgCode",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "crs"
+                    ]
+                  },
+                  "epsgCode": {
+                    "title": "EPSG Code",
+                    "description": "EPSG code of the destination coordinate reference system.",
+                    "type": "integer",
+                    "format": "uint32",
+                    "minimum": 0.0
+                  }
+                }
               },
               {
                 "title": "Euclidean",
-                "description": "Convert to a non-georeferenced Euclidean frame.",
-                "type": "string",
-                "enum": [
-                  "euclidean"
-                ]
+                "description": "Convert to a non-georeferenced Euclidean frame. This is the frame the planar geometry operations work in, so it is the on-ramp for actions that require flat 2D input.",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "euclidean"
+                    ]
+                  }
+                }
               }
             ]
           },
@@ -3339,7 +3352,7 @@
           },
           "AttributeAccumulationStrategy": {
             "title": "Attribute Accumulation Strategy",
-            "description": "Defines how attributes should be handled when dissolving multiple features into one",
+            "description": "Which attributes a merged feature keeps.",
             "oneOf": [
               {
                 "title": "Drop Incoming Attributes",
@@ -3380,7 +3393,10 @@
       "categories": [
         "Geometry"
       ],
-      "tags": []
+      "tags": [
+        "spatial",
+        "aggregation"
+      ]
     },
     {
       "name": "Echo Processor",

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -3387,7 +3387,7 @@
         "features"
       ],
       "outputPorts": [
-        "area",
+        "features",
         "rejected"
       ],
       "categories": [

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -2911,7 +2911,7 @@
                     "title": "EPSG Code",
                     "description": "EPSG code of the destination coordinate reference system.",
                     "type": "integer",
-                    "format": "uint32",
+                    "format": "uint16",
                     "minimum": 0.0
                   }
                 }
@@ -3104,7 +3104,7 @@
             "oneOf": [
               {
                 "title": "Detect Automatically",
-                "description": "Auto-detect from known formats. Note: Numeric values are always interpreted as Unix seconds. For milliseconds, use the explicit `unix_ms` input format.",
+                "description": "Auto-detect from known formats. Note: Numeric values are always interpreted as Unix seconds. For milliseconds, use the explicit `unixMs` input format.",
                 "type": "string",
                 "enum": [
                   "auto"

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -2911,7 +2911,7 @@
                     "title": "EPSG Code",
                     "description": "EPSG code of the destination coordinate reference system.",
                     "type": "integer",
-                    "format": "uint32",
+                    "format": "uint16",
                     "minimum": 0.0
                   }
                 }
@@ -3104,7 +3104,7 @@
             "oneOf": [
               {
                 "title": "Detect Automatically",
-                "description": "既知の形式から自動検出する。数値は常に Unix 秒として解釈される。ミリ秒の場合は `unix_ms` 入力形式を明示的に指定する。",
+                "description": "既知の形式から自動検出する。数値は常に Unix 秒として解釈される。ミリ秒の場合は `unixMs` 入力形式を明示的に指定する。",
                 "type": "string",
                 "enum": [
                   "auto"

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -3387,7 +3387,7 @@
         "features"
       ],
       "outputPorts": [
-        "area",
+        "features",
         "rejected"
       ],
       "categories": [

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -923,6 +923,7 @@
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Attribute Range Mapper パラメータ",
+        "description": "Defines the attribute to classify, the table of ranges to match it against, and where the matched value is written.",
         "type": "object",
         "required": [
           "inputAttribute",
@@ -993,7 +994,9 @@
       "categories": [
         "Attribute"
       ],
-      "tags": []
+      "tags": [
+        "mapping"
+      ]
     },
     {
       "name": "Attribute Table Extractor",
@@ -1032,7 +1035,17 @@
           },
           "inline": {
             "title": "インラインテーブル",
-            "description": "抽出テーブルの内容をJSONとして直接指定する。データセットURIを指定しない場合に使う"
+            "description": "抽出テーブルの内容をJSONとして直接指定する。データセットURIを指定しない場合に使う",
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ExtractRule"
+              }
+            }
           },
           "typeAttribute": {
             "title": "地物タイプ属性",
@@ -1040,6 +1053,62 @@
             "type": [
               "string",
               "null"
+            ]
+          }
+        },
+        "definitions": {
+          "ExtractRule": {
+            "title": "Extraction Rule",
+            "description": "Moves one value from a source path to a destination path.\n\nBoth paths are chains of attribute keys separated by **spaces**, not dots — the keys themselves are qualified XML names such as `bldg:measuredHeight`, which may contain colons and dots but never whitespace.",
+            "type": "object",
+            "required": [
+              "destinationPath",
+              "sourcePath"
+            ],
+            "properties": {
+              "destinationPath": {
+                "title": "Destination Path",
+                "description": "Where the value is written, as a space-separated chain of keys. A single segment writes a top-level attribute; several segments write into a nested map, creating it and any missing intermediate map as needed.",
+                "type": "string"
+              },
+              "sourcePath": {
+                "title": "Source Path",
+                "description": "Where the value is read from, as a space-separated chain of keys walked from the feature's top level. A segment matches either a key in a map or the first matching element of a list, so it works whether a wrapper element appears once or many times.",
+                "type": "string"
+              },
+              "dataType": {
+                "title": "Value Type",
+                "description": "Converts the extracted value before writing it. Leave unset to write it unchanged.",
+                "default": null,
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/ExtractDataType"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          },
+          "ExtractDataType": {
+            "oneOf": [
+              {
+                "title": "Integer",
+                "description": "Parses a string value as an integer.",
+                "type": "string",
+                "enum": [
+                  "int"
+                ]
+              },
+              {
+                "title": "Float",
+                "description": "Parses a string value as a floating point number.",
+                "type": "string",
+                "enum": [
+                  "float"
+                ]
+              }
             ]
           }
         }
@@ -2975,16 +3044,19 @@
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Date Time Converter パラメータ",
+        "description": "Selects the attribute to convert, how to interpret its current value, and the format to write back.",
         "type": "object",
         "required": [
           "attribute"
         ],
         "properties": {
           "attribute": {
+            "title": "Source Attribute",
             "description": "変換する日時値を含む属性",
             "type": "string"
           },
           "inputFormat": {
+            "title": "Input Format",
             "description": "入力値の形式（デフォルト: auto）",
             "default": "auto",
             "allOf": [
@@ -2994,6 +3066,7 @@
             ]
           },
           "outputFormat": {
+            "title": "Output Format",
             "description": "希望する出力形式（デフォルト: auto）。`auto` は型付き DateTime 値として格納（パーサーモード）。その他の形式は文字列/数値として出力（フォーマッターモード）。",
             "default": "auto",
             "allOf": [
@@ -3003,6 +3076,7 @@
             ]
           },
           "outputAttribute": {
+            "title": "Output Attribute",
             "description": "結果を別の属性に書き込む（入力をそのまま保持）。デフォルトは `attribute` と同じ。",
             "default": null,
             "type": [
@@ -3016,6 +3090,7 @@
             "description": "Input format options for Date Time Converter",
             "oneOf": [
               {
+                "title": "Detect Automatically",
                 "description": "既知の形式から自動検出する。数値は常に Unix 秒として解釈される。ミリ秒の場合は `unix_ms` 入力形式を明示的に指定する。",
                 "type": "string",
                 "enum": [
@@ -3023,6 +3098,7 @@
                 ]
               },
               {
+                "title": "RFC 3339",
                 "description": "RFC3339 / ISO 8601 形式",
                 "type": "string",
                 "enum": [
@@ -3030,20 +3106,23 @@
                 ]
               },
               {
-                "description": "Unixタイムスタンプ（秒）",
+                "title": "Unix Seconds",
+                "description": "Seconds elapsed since 1970-01-01 UTC.",
                 "type": "string",
                 "enum": [
-                  "unix_s"
+                  "unixS"
                 ]
               },
               {
-                "description": "Unixタイムスタンプ（ミリ秒）",
+                "title": "Unix Milliseconds",
+                "description": "Milliseconds elapsed since 1970-01-01 UTC.",
                 "type": "string",
                 "enum": [
-                  "unix_ms"
+                  "unixMs"
                 ]
               },
               {
+                "title": "Date Only",
                 "description": "日付のみの形式（YYYY-MM-DD）",
                 "type": "string",
                 "enum": [
@@ -3051,7 +3130,8 @@
                 ]
               },
               {
-                "description": "Custom format using chrono format specifiers",
+                "title": "Custom Pattern",
+                "description": "Field-by-field pattern, for values none of the fixed formats match.",
                 "type": "object",
                 "required": [
                   "custom"
@@ -3069,6 +3149,7 @@
             "description": "Output format options for Date Time Converter",
             "oneOf": [
               {
+                "title": "Typed Datetime",
                 "description": "自動: 型付き DateTime 値として格納する（ネイティブのバリアントを保持）。日時を文字列ではなく適切な DateTime 型として扱いたい場合に使用する。",
                 "type": "string",
                 "enum": [
@@ -3076,6 +3157,7 @@
                 ]
               },
               {
+                "title": "RFC 3339",
                 "description": "RFC3339 / ISO 8601 形式",
                 "type": "string",
                 "enum": [
@@ -3083,20 +3165,23 @@
                 ]
               },
               {
-                "description": "Unixタイムスタンプ（秒）",
+                "title": "Unix Seconds",
+                "description": "Writes a number: seconds elapsed since 1970-01-01 UTC.",
                 "type": "string",
                 "enum": [
-                  "unix_s"
+                  "unixS"
                 ]
               },
               {
-                "description": "Unixタイムスタンプ（ミリ秒）",
+                "title": "Unix Milliseconds",
+                "description": "Writes a number: milliseconds elapsed since 1970-01-01 UTC.",
                 "type": "string",
                 "enum": [
-                  "unix_ms"
+                  "unixMs"
                 ]
               },
               {
+                "title": "Date Only",
                 "description": "日付のみの形式（YYYY-MM-DD）",
                 "type": "string",
                 "enum": [
@@ -3104,7 +3189,8 @@
                 ]
               },
               {
-                "description": "Custom format using chrono format specifiers",
+                "title": "Custom Pattern",
+                "description": "Writes a string built from a field-by-field pattern.",
                 "type": "object",
                 "required": [
                   "custom"

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -2875,17 +2875,6 @@
               }
             ]
           },
-          "epsgCode": {
-            "title": "EPSG Code",
-            "description": "EPSG code of the destination CRS. Required when the destination frame is a CRS.",
-            "default": null,
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint16",
-            "minimum": 0.0
-          },
           "basePointSource": {
             "title": "Base Point",
             "description": "How coordinates bridge the Euclidean/CRS boundary.",
@@ -2901,23 +2890,47 @@
         },
         "definitions": {
           "DestinationFrame": {
-            "description": "The destination coordinate frame kind.",
+            "description": "The destination coordinate frame, carrying the input each kind needs.",
             "oneOf": [
               {
                 "title": "CRS",
                 "description": "Reproject to a coordinate reference system identified by an EPSG code.",
-                "type": "string",
-                "enum": [
-                  "crs"
-                ]
+                "type": "object",
+                "required": [
+                  "epsgCode",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "crs"
+                    ]
+                  },
+                  "epsgCode": {
+                    "title": "EPSG Code",
+                    "description": "EPSG code of the destination coordinate reference system.",
+                    "type": "integer",
+                    "format": "uint32",
+                    "minimum": 0.0
+                  }
+                }
               },
               {
                 "title": "Euclidean",
-                "description": "Convert to a non-georeferenced Euclidean frame.",
-                "type": "string",
-                "enum": [
-                  "euclidean"
-                ]
+                "description": "Convert to a non-georeferenced Euclidean frame. This is the frame the planar geometry operations work in, so it is the on-ramp for actions that require flat 2D input.",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "euclidean"
+                    ]
+                  }
+                }
               }
             ]
           },
@@ -3339,7 +3352,7 @@
           },
           "AttributeAccumulationStrategy": {
             "title": "Attribute Accumulation Strategy",
-            "description": "Defines how attributes should be handled when dissolving multiple features into one",
+            "description": "Which attributes a merged feature keeps.",
             "oneOf": [
               {
                 "title": "入力属性を破棄",
@@ -3380,7 +3393,10 @@
       "categories": [
         "Geometry"
       ],
-      "tags": []
+      "tags": [
+        "spatial",
+        "aggregation"
+      ]
     },
     {
       "name": "Echo Processor",

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -2875,17 +2875,6 @@
               }
             ]
           },
-          "epsgCode": {
-            "title": "EPSG Code",
-            "description": "EPSG code of the destination CRS. Required when the destination frame is a CRS.",
-            "default": null,
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint16",
-            "minimum": 0.0
-          },
           "basePointSource": {
             "title": "Base Point",
             "description": "How coordinates bridge the Euclidean/CRS boundary.",
@@ -2901,23 +2890,47 @@
         },
         "definitions": {
           "DestinationFrame": {
-            "description": "The destination coordinate frame kind.",
+            "description": "The destination coordinate frame, carrying the input each kind needs.",
             "oneOf": [
               {
                 "title": "CRS",
                 "description": "Reproject to a coordinate reference system identified by an EPSG code.",
-                "type": "string",
-                "enum": [
-                  "crs"
-                ]
+                "type": "object",
+                "required": [
+                  "epsgCode",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "crs"
+                    ]
+                  },
+                  "epsgCode": {
+                    "title": "EPSG Code",
+                    "description": "EPSG code of the destination coordinate reference system.",
+                    "type": "integer",
+                    "format": "uint32",
+                    "minimum": 0.0
+                  }
+                }
               },
               {
                 "title": "Euclidean",
-                "description": "Convert to a non-georeferenced Euclidean frame.",
-                "type": "string",
-                "enum": [
-                  "euclidean"
-                ]
+                "description": "Convert to a non-georeferenced Euclidean frame. This is the frame the planar geometry operations work in, so it is the on-ramp for actions that require flat 2D input.",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "euclidean"
+                    ]
+                  }
+                }
               }
             ]
           },
@@ -3339,7 +3352,7 @@
           },
           "AttributeAccumulationStrategy": {
             "title": "Attribute Accumulation Strategy",
-            "description": "Defines how attributes should be handled when dissolving multiple features into one",
+            "description": "Which attributes a merged feature keeps.",
             "oneOf": [
               {
                 "title": "Drop Incoming Attributes",
@@ -3380,7 +3393,10 @@
       "categories": [
         "Geometry"
       ],
-      "tags": []
+      "tags": [
+        "spatial",
+        "aggregation"
+      ]
     },
     {
       "name": "Echo Processor",

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -3387,7 +3387,7 @@
         "features"
       ],
       "outputPorts": [
-        "area",
+        "features",
         "rejected"
       ],
       "categories": [

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -923,6 +923,7 @@
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Attribute Range Mapper Parameters",
+        "description": "Defines the attribute to classify, the table of ranges to match it against, and where the matched value is written.",
         "type": "object",
         "required": [
           "inputAttribute",
@@ -993,7 +994,9 @@
       "categories": [
         "Attribute"
       ],
-      "tags": []
+      "tags": [
+        "mapping"
+      ]
     },
     {
       "name": "Attribute Table Extractor",
@@ -1032,7 +1035,17 @@
           },
           "inline": {
             "title": "内联表",
-            "description": "直接以JSON形式提供的抽取表内容。在未提供数据集URI时使用"
+            "description": "直接以JSON形式提供的抽取表内容。在未提供数据集URI时使用",
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ExtractRule"
+              }
+            }
           },
           "typeAttribute": {
             "title": "要素类型属性",
@@ -1040,6 +1053,62 @@
             "type": [
               "string",
               "null"
+            ]
+          }
+        },
+        "definitions": {
+          "ExtractRule": {
+            "title": "Extraction Rule",
+            "description": "Moves one value from a source path to a destination path.\n\nBoth paths are chains of attribute keys separated by **spaces**, not dots — the keys themselves are qualified XML names such as `bldg:measuredHeight`, which may contain colons and dots but never whitespace.",
+            "type": "object",
+            "required": [
+              "destinationPath",
+              "sourcePath"
+            ],
+            "properties": {
+              "destinationPath": {
+                "title": "Destination Path",
+                "description": "Where the value is written, as a space-separated chain of keys. A single segment writes a top-level attribute; several segments write into a nested map, creating it and any missing intermediate map as needed.",
+                "type": "string"
+              },
+              "sourcePath": {
+                "title": "Source Path",
+                "description": "Where the value is read from, as a space-separated chain of keys walked from the feature's top level. A segment matches either a key in a map or the first matching element of a list, so it works whether a wrapper element appears once or many times.",
+                "type": "string"
+              },
+              "dataType": {
+                "title": "Value Type",
+                "description": "Converts the extracted value before writing it. Leave unset to write it unchanged.",
+                "default": null,
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/ExtractDataType"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          },
+          "ExtractDataType": {
+            "oneOf": [
+              {
+                "title": "Integer",
+                "description": "Parses a string value as an integer.",
+                "type": "string",
+                "enum": [
+                  "int"
+                ]
+              },
+              {
+                "title": "Float",
+                "description": "Parses a string value as a floating point number.",
+                "type": "string",
+                "enum": [
+                  "float"
+                ]
+              }
             ]
           }
         }
@@ -2975,16 +3044,19 @@
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Date Time Converter Parameters",
+        "description": "Selects the attribute to convert, how to interpret its current value, and the format to write back.",
         "type": "object",
         "required": [
           "attribute"
         ],
         "properties": {
           "attribute": {
+            "title": "Source Attribute",
             "description": "Attribute containing the datetime value to convert",
             "type": "string"
           },
           "inputFormat": {
+            "title": "Input Format",
             "description": "Format of the input value (default: auto)",
             "default": "auto",
             "allOf": [
@@ -2994,6 +3066,7 @@
             ]
           },
           "outputFormat": {
+            "title": "Output Format",
             "description": "Desired output format (default: auto). Use `auto` to store as typed DateTime value (parser mode). Use other formats to output as string/number (formatter mode).",
             "default": "auto",
             "allOf": [
@@ -3003,6 +3076,7 @@
             ]
           },
           "outputAttribute": {
+            "title": "Output Attribute",
             "description": "Write result to a different attribute (leave input untouched) Defaults to the same as `attribute`",
             "default": null,
             "type": [
@@ -3016,6 +3090,7 @@
             "description": "Input format options for Date Time Converter",
             "oneOf": [
               {
+                "title": "Detect Automatically",
                 "description": "Auto-detect from known formats. Note: Numeric values are always interpreted as Unix seconds. For milliseconds, use the explicit `unix_ms` input format.",
                 "type": "string",
                 "enum": [
@@ -3023,6 +3098,7 @@
                 ]
               },
               {
+                "title": "RFC 3339",
                 "description": "RFC3339 / ISO 8601 format",
                 "type": "string",
                 "enum": [
@@ -3030,20 +3106,23 @@
                 ]
               },
               {
-                "description": "Unix timestamp in seconds",
+                "title": "Unix Seconds",
+                "description": "Seconds elapsed since 1970-01-01 UTC.",
                 "type": "string",
                 "enum": [
-                  "unix_s"
+                  "unixS"
                 ]
               },
               {
-                "description": "Unix timestamp in milliseconds",
+                "title": "Unix Milliseconds",
+                "description": "Milliseconds elapsed since 1970-01-01 UTC.",
                 "type": "string",
                 "enum": [
-                  "unix_ms"
+                  "unixMs"
                 ]
               },
               {
+                "title": "Date Only",
                 "description": "Date only format (YYYY-MM-DD)",
                 "type": "string",
                 "enum": [
@@ -3051,7 +3130,8 @@
                 ]
               },
               {
-                "description": "Custom format using chrono format specifiers",
+                "title": "Custom Pattern",
+                "description": "Field-by-field pattern, for values none of the fixed formats match.",
                 "type": "object",
                 "required": [
                   "custom"
@@ -3069,6 +3149,7 @@
             "description": "Output format options for Date Time Converter",
             "oneOf": [
               {
+                "title": "Typed Datetime",
                 "description": "Auto: Store as typed DateTime value (preserves the native variant). Use this when you want the datetime as a proper DateTime type rather than a string.",
                 "type": "string",
                 "enum": [
@@ -3076,6 +3157,7 @@
                 ]
               },
               {
+                "title": "RFC 3339",
                 "description": "RFC3339 / ISO 8601 format",
                 "type": "string",
                 "enum": [
@@ -3083,20 +3165,23 @@
                 ]
               },
               {
-                "description": "Unix timestamp in seconds",
+                "title": "Unix Seconds",
+                "description": "Writes a number: seconds elapsed since 1970-01-01 UTC.",
                 "type": "string",
                 "enum": [
-                  "unix_s"
+                  "unixS"
                 ]
               },
               {
-                "description": "Unix timestamp in milliseconds",
+                "title": "Unix Milliseconds",
+                "description": "Writes a number: milliseconds elapsed since 1970-01-01 UTC.",
                 "type": "string",
                 "enum": [
-                  "unix_ms"
+                  "unixMs"
                 ]
               },
               {
+                "title": "Date Only",
                 "description": "Date only format (YYYY-MM-DD)",
                 "type": "string",
                 "enum": [
@@ -3104,7 +3189,8 @@
                 ]
               },
               {
-                "description": "Custom format using chrono format specifiers",
+                "title": "Custom Pattern",
+                "description": "Writes a string built from a field-by-field pattern.",
                 "type": "object",
                 "required": [
                   "custom"

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -2911,7 +2911,7 @@
                     "title": "EPSG Code",
                     "description": "EPSG code of the destination coordinate reference system.",
                     "type": "integer",
-                    "format": "uint32",
+                    "format": "uint16",
                     "minimum": 0.0
                   }
                 }
@@ -3104,7 +3104,7 @@
             "oneOf": [
               {
                 "title": "Detect Automatically",
-                "description": "Auto-detect from known formats. Note: Numeric values are always interpreted as Unix seconds. For milliseconds, use the explicit `unix_ms` input format.",
+                "description": "Auto-detect from known formats. Note: Numeric values are always interpreted as Unix seconds. For milliseconds, use the explicit `unixMs` input format.",
                 "type": "string",
                 "enum": [
                   "auto"

--- a/engine/schema/i18n/actions/es.json
+++ b/engine/schema/i18n/actions/es.json
@@ -343,7 +343,8 @@
       "description": "Mapear valores de atributos a rangos y asignar valores de salida correspondientes",
       "parameterI18n": {
         "": {
-          "title": "Attribute Range Mapper Parameters"
+          "title": "Attribute Range Mapper Parameters",
+          "description": "Defines the attribute to classify, the table of ranges to match it against, and where the matched value is written."
         },
         "defaultValue": {
           "title": "Default Value",
@@ -398,6 +399,34 @@
         "typeAttribute": {
           "title": "Atributo de Tipo de Entidad",
           "description": "Atributo cuyo valor selecciona qué conjunto de reglas de la tabla se aplica a la entidad. Por defecto `__citygml_feature_type`"
+        }
+      },
+      "definitionI18n": {
+        "ExtractRule": {
+          "dataType": {
+            "title": "Value Type",
+            "description": "Converts the extracted value before writing it. Leave unset to write it unchanged."
+          },
+          "destinationPath": {
+            "title": "Destination Path",
+            "description": "Where the value is written, as a space-separated chain of keys. A single segment writes a top-level attribute; several segments write into a nested map, creating it and any missing intermediate map as needed."
+          },
+          "sourcePath": {
+            "title": "Source Path",
+            "description": "Where the value is read from, as a space-separated chain of keys walked from the feature's top level. A segment matches either a key in a map or the first matching element of a list, so it works whether a wrapper element appears once or many times."
+          }
+        }
+      },
+      "enumI18n": {
+        "ExtractDataType": {
+          "float": {
+            "title": "Float",
+            "description": "Parses a string value as a floating point number."
+          },
+          "int": {
+            "title": "Integer",
+            "description": "Parses a string value as an integer."
+          }
         }
       }
     },
@@ -997,54 +1026,69 @@
       "description": "Convierte valores de fecha y hora entre diferentes formatos",
       "parameterI18n": {
         "": {
-          "title": "Date Time Converter Parameters"
+          "title": "Date Time Converter Parameters",
+          "description": "Selects the attribute to convert, how to interpret its current value, and the format to write back."
         },
         "attribute": {
+          "title": "Source Attribute",
           "description": "Attribute containing the datetime value to convert"
         },
         "inputFormat": {
+          "title": "Input Format",
           "description": "Format of the input value (default: auto)"
         },
         "outputAttribute": {
+          "title": "Output Attribute",
           "description": "Write result to a different attribute (leave input untouched) Defaults to the same as `attribute`"
         },
         "outputFormat": {
+          "title": "Output Format",
           "description": "Desired output format (default: auto). Use `auto` to store as typed DateTime value (parser mode). Use other formats to output as string/number (formatter mode)."
         }
       },
       "enumI18n": {
         "DateTimeInputFormat": {
           "auto": {
+            "title": "Detect Automatically",
             "description": "Auto-detect from known formats. Note: Numeric values are always interpreted as Unix seconds. For milliseconds, use the explicit `unix_ms` input format."
           },
           "date": {
+            "title": "Date Only",
             "description": "Date only format (YYYY-MM-DD)"
           },
           "rfc3339": {
+            "title": "RFC 3339",
             "description": "RFC3339 / ISO 8601 format"
           },
-          "unix_ms": {
-            "description": "Unix timestamp in milliseconds"
+          "unixMs": {
+            "title": "Unix Milliseconds",
+            "description": "Milliseconds elapsed since 1970-01-01 UTC."
           },
-          "unix_s": {
-            "description": "Unix timestamp in seconds"
+          "unixS": {
+            "title": "Unix Seconds",
+            "description": "Seconds elapsed since 1970-01-01 UTC."
           }
         },
         "DateTimeOutputFormat": {
           "auto": {
+            "title": "Typed Datetime",
             "description": "Auto: Store as typed DateTime value (preserves the native variant). Use this when you want the datetime as a proper DateTime type rather than a string."
           },
           "date": {
+            "title": "Date Only",
             "description": "Date only format (YYYY-MM-DD)"
           },
           "rfc3339": {
+            "title": "RFC 3339",
             "description": "RFC3339 / ISO 8601 format"
           },
-          "unix_ms": {
-            "description": "Unix timestamp in milliseconds"
+          "unixMs": {
+            "title": "Unix Milliseconds",
+            "description": "Writes a number: milliseconds elapsed since 1970-01-01 UTC."
           },
-          "unix_s": {
-            "description": "Unix timestamp in seconds"
+          "unixS": {
+            "title": "Unix Seconds",
+            "description": "Writes a number: seconds elapsed since 1970-01-01 UTC."
           }
         }
       }

--- a/engine/schema/i18n/actions/es.json
+++ b/engine/schema/i18n/actions/es.json
@@ -1034,7 +1034,7 @@
         "DateTimeInputFormat": {
           "auto": {
             "title": "Detect Automatically",
-            "description": "Auto-detect from known formats. Note: Numeric values are always interpreted as Unix seconds. For milliseconds, use the explicit `unix_ms` input format."
+            "description": "Auto-detect from known formats. Note: Numeric values are always interpreted as Unix seconds. For milliseconds, use the explicit `unixMs` input format."
           },
           "date": {
             "title": "Date Only",

--- a/engine/schema/i18n/actions/es.json
+++ b/engine/schema/i18n/actions/es.json
@@ -1002,22 +1002,6 @@
         "destinationFrame": {
           "title": "Destination Frame",
           "description": "Coordinate frame to convert geometry into."
-        },
-        "epsgCode": {
-          "title": "EPSG Code",
-          "description": "EPSG code of the destination CRS. Required when the destination frame is a CRS."
-        }
-      },
-      "enumI18n": {
-        "DestinationFrame": {
-          "crs": {
-            "title": "CRS",
-            "description": "Reproject to a coordinate reference system identified by an EPSG code."
-          },
-          "euclidean": {
-            "title": "Euclidean",
-            "description": "Convert to a non-georeferenced Euclidean frame."
-          }
         }
       }
     },

--- a/engine/schema/i18n/actions/fr.json
+++ b/engine/schema/i18n/actions/fr.json
@@ -343,7 +343,8 @@
       "description": "Mapper les valeurs d'attributs aux plages et attribuer les valeurs de sortie correspondantes",
       "parameterI18n": {
         "": {
-          "title": "Attribute Range Mapper Parameters"
+          "title": "Attribute Range Mapper Parameters",
+          "description": "Defines the attribute to classify, the table of ranges to match it against, and where the matched value is written."
         },
         "defaultValue": {
           "title": "Default Value",
@@ -398,6 +399,34 @@
         "typeAttribute": {
           "title": "Attribut de Type d'Entité",
           "description": "Attribut dont la valeur sélectionne quel ensemble de règles de la table s'applique à l'entité. Par défaut `__citygml_feature_type`"
+        }
+      },
+      "definitionI18n": {
+        "ExtractRule": {
+          "dataType": {
+            "title": "Value Type",
+            "description": "Converts the extracted value before writing it. Leave unset to write it unchanged."
+          },
+          "destinationPath": {
+            "title": "Destination Path",
+            "description": "Where the value is written, as a space-separated chain of keys. A single segment writes a top-level attribute; several segments write into a nested map, creating it and any missing intermediate map as needed."
+          },
+          "sourcePath": {
+            "title": "Source Path",
+            "description": "Where the value is read from, as a space-separated chain of keys walked from the feature's top level. A segment matches either a key in a map or the first matching element of a list, so it works whether a wrapper element appears once or many times."
+          }
+        }
+      },
+      "enumI18n": {
+        "ExtractDataType": {
+          "float": {
+            "title": "Float",
+            "description": "Parses a string value as a floating point number."
+          },
+          "int": {
+            "title": "Integer",
+            "description": "Parses a string value as an integer."
+          }
         }
       }
     },
@@ -997,54 +1026,69 @@
       "description": "Convertit les valeurs de date et heure entre différents formats",
       "parameterI18n": {
         "": {
-          "title": "Date Time Converter Parameters"
+          "title": "Date Time Converter Parameters",
+          "description": "Selects the attribute to convert, how to interpret its current value, and the format to write back."
         },
         "attribute": {
+          "title": "Source Attribute",
           "description": "Attribute containing the datetime value to convert"
         },
         "inputFormat": {
+          "title": "Input Format",
           "description": "Format of the input value (default: auto)"
         },
         "outputAttribute": {
+          "title": "Output Attribute",
           "description": "Write result to a different attribute (leave input untouched) Defaults to the same as `attribute`"
         },
         "outputFormat": {
+          "title": "Output Format",
           "description": "Desired output format (default: auto). Use `auto` to store as typed DateTime value (parser mode). Use other formats to output as string/number (formatter mode)."
         }
       },
       "enumI18n": {
         "DateTimeInputFormat": {
           "auto": {
+            "title": "Detect Automatically",
             "description": "Auto-detect from known formats. Note: Numeric values are always interpreted as Unix seconds. For milliseconds, use the explicit `unix_ms` input format."
           },
           "date": {
+            "title": "Date Only",
             "description": "Date only format (YYYY-MM-DD)"
           },
           "rfc3339": {
+            "title": "RFC 3339",
             "description": "RFC3339 / ISO 8601 format"
           },
-          "unix_ms": {
-            "description": "Unix timestamp in milliseconds"
+          "unixMs": {
+            "title": "Unix Milliseconds",
+            "description": "Milliseconds elapsed since 1970-01-01 UTC."
           },
-          "unix_s": {
-            "description": "Unix timestamp in seconds"
+          "unixS": {
+            "title": "Unix Seconds",
+            "description": "Seconds elapsed since 1970-01-01 UTC."
           }
         },
         "DateTimeOutputFormat": {
           "auto": {
+            "title": "Typed Datetime",
             "description": "Auto: Store as typed DateTime value (preserves the native variant). Use this when you want the datetime as a proper DateTime type rather than a string."
           },
           "date": {
+            "title": "Date Only",
             "description": "Date only format (YYYY-MM-DD)"
           },
           "rfc3339": {
+            "title": "RFC 3339",
             "description": "RFC3339 / ISO 8601 format"
           },
-          "unix_ms": {
-            "description": "Unix timestamp in milliseconds"
+          "unixMs": {
+            "title": "Unix Milliseconds",
+            "description": "Writes a number: milliseconds elapsed since 1970-01-01 UTC."
           },
-          "unix_s": {
-            "description": "Unix timestamp in seconds"
+          "unixS": {
+            "title": "Unix Seconds",
+            "description": "Writes a number: seconds elapsed since 1970-01-01 UTC."
           }
         }
       }

--- a/engine/schema/i18n/actions/fr.json
+++ b/engine/schema/i18n/actions/fr.json
@@ -1034,7 +1034,7 @@
         "DateTimeInputFormat": {
           "auto": {
             "title": "Detect Automatically",
-            "description": "Auto-detect from known formats. Note: Numeric values are always interpreted as Unix seconds. For milliseconds, use the explicit `unix_ms` input format."
+            "description": "Auto-detect from known formats. Note: Numeric values are always interpreted as Unix seconds. For milliseconds, use the explicit `unixMs` input format."
           },
           "date": {
             "title": "Date Only",

--- a/engine/schema/i18n/actions/fr.json
+++ b/engine/schema/i18n/actions/fr.json
@@ -1002,22 +1002,6 @@
         "destinationFrame": {
           "title": "Destination Frame",
           "description": "Coordinate frame to convert geometry into."
-        },
-        "epsgCode": {
-          "title": "EPSG Code",
-          "description": "EPSG code of the destination CRS. Required when the destination frame is a CRS."
-        }
-      },
-      "enumI18n": {
-        "DestinationFrame": {
-          "crs": {
-            "title": "CRS",
-            "description": "Reproject to a coordinate reference system identified by an EPSG code."
-          },
-          "euclidean": {
-            "title": "Euclidean",
-            "description": "Convert to a non-georeferenced Euclidean frame."
-          }
         }
       }
     },

--- a/engine/schema/i18n/actions/ja.json
+++ b/engine/schema/i18n/actions/ja.json
@@ -343,7 +343,8 @@
       "description": "属性値を範囲にマッピングし、対応する出力値を割り当てます",
       "parameterI18n": {
         "": {
-          "title": "Attribute Range Mapper パラメータ"
+          "title": "Attribute Range Mapper パラメータ",
+          "description": "Defines the attribute to classify, the table of ranges to match it against, and where the matched value is written."
         },
         "defaultValue": {
           "title": "デフォルト値",
@@ -398,6 +399,34 @@
         "typeAttribute": {
           "title": "地物タイプ属性",
           "description": "テーブル内のどのルールセットを地物に適用するかを選ぶ属性の値。デフォルトは`__citygml_feature_type`"
+        }
+      },
+      "definitionI18n": {
+        "ExtractRule": {
+          "dataType": {
+            "title": "Value Type",
+            "description": "Converts the extracted value before writing it. Leave unset to write it unchanged."
+          },
+          "destinationPath": {
+            "title": "Destination Path",
+            "description": "Where the value is written, as a space-separated chain of keys. A single segment writes a top-level attribute; several segments write into a nested map, creating it and any missing intermediate map as needed."
+          },
+          "sourcePath": {
+            "title": "Source Path",
+            "description": "Where the value is read from, as a space-separated chain of keys walked from the feature's top level. A segment matches either a key in a map or the first matching element of a list, so it works whether a wrapper element appears once or many times."
+          }
+        }
+      },
+      "enumI18n": {
+        "ExtractDataType": {
+          "float": {
+            "title": "Float",
+            "description": "Parses a string value as a floating point number."
+          },
+          "int": {
+            "title": "Integer",
+            "description": "Parses a string value as an integer."
+          }
         }
       }
     },
@@ -997,54 +1026,69 @@
       "description": "日時値を異なるフォーマット間で変換する",
       "parameterI18n": {
         "": {
-          "title": "Date Time Converter パラメータ"
+          "title": "Date Time Converter パラメータ",
+          "description": "Selects the attribute to convert, how to interpret its current value, and the format to write back."
         },
         "attribute": {
+          "title": "Source Attribute",
           "description": "変換する日時値を含む属性"
         },
         "inputFormat": {
+          "title": "Input Format",
           "description": "入力値の形式（デフォルト: auto）"
         },
         "outputAttribute": {
+          "title": "Output Attribute",
           "description": "結果を別の属性に書き込む（入力をそのまま保持）。デフォルトは `attribute` と同じ。"
         },
         "outputFormat": {
+          "title": "Output Format",
           "description": "希望する出力形式（デフォルト: auto）。`auto` は型付き DateTime 値として格納（パーサーモード）。その他の形式は文字列/数値として出力（フォーマッターモード）。"
         }
       },
       "enumI18n": {
         "DateTimeInputFormat": {
           "auto": {
+            "title": "Detect Automatically",
             "description": "既知の形式から自動検出する。数値は常に Unix 秒として解釈される。ミリ秒の場合は `unix_ms` 入力形式を明示的に指定する。"
           },
           "date": {
+            "title": "Date Only",
             "description": "日付のみの形式（YYYY-MM-DD）"
           },
           "rfc3339": {
+            "title": "RFC 3339",
             "description": "RFC3339 / ISO 8601 形式"
           },
-          "unix_ms": {
-            "description": "Unixタイムスタンプ（ミリ秒）"
+          "unixMs": {
+            "title": "Unix Milliseconds",
+            "description": "Milliseconds elapsed since 1970-01-01 UTC."
           },
-          "unix_s": {
-            "description": "Unixタイムスタンプ（秒）"
+          "unixS": {
+            "title": "Unix Seconds",
+            "description": "Seconds elapsed since 1970-01-01 UTC."
           }
         },
         "DateTimeOutputFormat": {
           "auto": {
+            "title": "Typed Datetime",
             "description": "自動: 型付き DateTime 値として格納する（ネイティブのバリアントを保持）。日時を文字列ではなく適切な DateTime 型として扱いたい場合に使用する。"
           },
           "date": {
+            "title": "Date Only",
             "description": "日付のみの形式（YYYY-MM-DD）"
           },
           "rfc3339": {
+            "title": "RFC 3339",
             "description": "RFC3339 / ISO 8601 形式"
           },
-          "unix_ms": {
-            "description": "Unixタイムスタンプ（ミリ秒）"
+          "unixMs": {
+            "title": "Unix Milliseconds",
+            "description": "Writes a number: milliseconds elapsed since 1970-01-01 UTC."
           },
-          "unix_s": {
-            "description": "Unixタイムスタンプ（秒）"
+          "unixS": {
+            "title": "Unix Seconds",
+            "description": "Writes a number: seconds elapsed since 1970-01-01 UTC."
           }
         }
       }

--- a/engine/schema/i18n/actions/ja.json
+++ b/engine/schema/i18n/actions/ja.json
@@ -1034,7 +1034,7 @@
         "DateTimeInputFormat": {
           "auto": {
             "title": "Detect Automatically",
-            "description": "既知の形式から自動検出する。数値は常に Unix 秒として解釈される。ミリ秒の場合は `unix_ms` 入力形式を明示的に指定する。"
+            "description": "既知の形式から自動検出する。数値は常に Unix 秒として解釈される。ミリ秒の場合は `unixMs` 入力形式を明示的に指定する。"
           },
           "date": {
             "title": "Date Only",

--- a/engine/schema/i18n/actions/ja.json
+++ b/engine/schema/i18n/actions/ja.json
@@ -1002,22 +1002,6 @@
         "destinationFrame": {
           "title": "Destination Frame",
           "description": "Coordinate frame to convert geometry into."
-        },
-        "epsgCode": {
-          "title": "EPSG Code",
-          "description": "EPSG code of the destination CRS. Required when the destination frame is a CRS."
-        }
-      },
-      "enumI18n": {
-        "DestinationFrame": {
-          "crs": {
-            "title": "CRS",
-            "description": "Reproject to a coordinate reference system identified by an EPSG code."
-          },
-          "euclidean": {
-            "title": "Euclidean",
-            "description": "Convert to a non-georeferenced Euclidean frame."
-          }
         }
       }
     },

--- a/engine/schema/i18n/actions/zh.json
+++ b/engine/schema/i18n/actions/zh.json
@@ -1034,7 +1034,7 @@
         "DateTimeInputFormat": {
           "auto": {
             "title": "Detect Automatically",
-            "description": "Auto-detect from known formats. Note: Numeric values are always interpreted as Unix seconds. For milliseconds, use the explicit `unix_ms` input format."
+            "description": "Auto-detect from known formats. Note: Numeric values are always interpreted as Unix seconds. For milliseconds, use the explicit `unixMs` input format."
           },
           "date": {
             "title": "Date Only",

--- a/engine/schema/i18n/actions/zh.json
+++ b/engine/schema/i18n/actions/zh.json
@@ -1002,22 +1002,6 @@
         "destinationFrame": {
           "title": "Destination Frame",
           "description": "Coordinate frame to convert geometry into."
-        },
-        "epsgCode": {
-          "title": "EPSG Code",
-          "description": "EPSG code of the destination CRS. Required when the destination frame is a CRS."
-        }
-      },
-      "enumI18n": {
-        "DestinationFrame": {
-          "crs": {
-            "title": "CRS",
-            "description": "Reproject to a coordinate reference system identified by an EPSG code."
-          },
-          "euclidean": {
-            "title": "Euclidean",
-            "description": "Convert to a non-georeferenced Euclidean frame."
-          }
         }
       }
     },

--- a/engine/schema/i18n/actions/zh.json
+++ b/engine/schema/i18n/actions/zh.json
@@ -343,7 +343,8 @@
       "description": "将属性值映射到范围并分配相应的输出值",
       "parameterI18n": {
         "": {
-          "title": "Attribute Range Mapper Parameters"
+          "title": "Attribute Range Mapper Parameters",
+          "description": "Defines the attribute to classify, the table of ranges to match it against, and where the matched value is written."
         },
         "defaultValue": {
           "title": "Default Value",
@@ -398,6 +399,34 @@
         "typeAttribute": {
           "title": "要素类型属性",
           "description": "其值用于选择表中应用于该要素的规则集的属性。默认为`__citygml_feature_type`"
+        }
+      },
+      "definitionI18n": {
+        "ExtractRule": {
+          "dataType": {
+            "title": "Value Type",
+            "description": "Converts the extracted value before writing it. Leave unset to write it unchanged."
+          },
+          "destinationPath": {
+            "title": "Destination Path",
+            "description": "Where the value is written, as a space-separated chain of keys. A single segment writes a top-level attribute; several segments write into a nested map, creating it and any missing intermediate map as needed."
+          },
+          "sourcePath": {
+            "title": "Source Path",
+            "description": "Where the value is read from, as a space-separated chain of keys walked from the feature's top level. A segment matches either a key in a map or the first matching element of a list, so it works whether a wrapper element appears once or many times."
+          }
+        }
+      },
+      "enumI18n": {
+        "ExtractDataType": {
+          "float": {
+            "title": "Float",
+            "description": "Parses a string value as a floating point number."
+          },
+          "int": {
+            "title": "Integer",
+            "description": "Parses a string value as an integer."
+          }
         }
       }
     },
@@ -997,54 +1026,69 @@
       "description": "在不同格式之间转换日期时间值",
       "parameterI18n": {
         "": {
-          "title": "Date Time Converter Parameters"
+          "title": "Date Time Converter Parameters",
+          "description": "Selects the attribute to convert, how to interpret its current value, and the format to write back."
         },
         "attribute": {
+          "title": "Source Attribute",
           "description": "Attribute containing the datetime value to convert"
         },
         "inputFormat": {
+          "title": "Input Format",
           "description": "Format of the input value (default: auto)"
         },
         "outputAttribute": {
+          "title": "Output Attribute",
           "description": "Write result to a different attribute (leave input untouched) Defaults to the same as `attribute`"
         },
         "outputFormat": {
+          "title": "Output Format",
           "description": "Desired output format (default: auto). Use `auto` to store as typed DateTime value (parser mode). Use other formats to output as string/number (formatter mode)."
         }
       },
       "enumI18n": {
         "DateTimeInputFormat": {
           "auto": {
+            "title": "Detect Automatically",
             "description": "Auto-detect from known formats. Note: Numeric values are always interpreted as Unix seconds. For milliseconds, use the explicit `unix_ms` input format."
           },
           "date": {
+            "title": "Date Only",
             "description": "Date only format (YYYY-MM-DD)"
           },
           "rfc3339": {
+            "title": "RFC 3339",
             "description": "RFC3339 / ISO 8601 format"
           },
-          "unix_ms": {
-            "description": "Unix timestamp in milliseconds"
+          "unixMs": {
+            "title": "Unix Milliseconds",
+            "description": "Milliseconds elapsed since 1970-01-01 UTC."
           },
-          "unix_s": {
-            "description": "Unix timestamp in seconds"
+          "unixS": {
+            "title": "Unix Seconds",
+            "description": "Seconds elapsed since 1970-01-01 UTC."
           }
         },
         "DateTimeOutputFormat": {
           "auto": {
+            "title": "Typed Datetime",
             "description": "Auto: Store as typed DateTime value (preserves the native variant). Use this when you want the datetime as a proper DateTime type rather than a string."
           },
           "date": {
+            "title": "Date Only",
             "description": "Date only format (YYYY-MM-DD)"
           },
           "rfc3339": {
+            "title": "RFC 3339",
             "description": "RFC3339 / ISO 8601 format"
           },
-          "unix_ms": {
-            "description": "Unix timestamp in milliseconds"
+          "unixMs": {
+            "title": "Unix Milliseconds",
+            "description": "Writes a number: milliseconds elapsed since 1970-01-01 UTC."
           },
-          "unix_s": {
-            "description": "Unix timestamp in seconds"
+          "unixS": {
+            "title": "Unix Seconds",
+            "description": "Writes a number: seconds elapsed since 1970-01-01 UTC."
           }
         }
       }

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.121"
+version = "0.2.122"
 edition = "2021"
 
 [features]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.123"
+version = "0.2.124"
 edition = "2021"
 
 [features]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.122"
+version = "0.2.123"
 edition = "2021"
 
 [features]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.124"
+version = "0.2.125"
 edition = "2021"
 
 [features]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.125"
+version = "0.2.126"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.314"
+version = "0.1.315"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.313"
+version = "0.1.314"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.315"
+version = "0.1.316"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.311"
+version = "0.1.312"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.312"
+version = "0.1.313"
 edition = "2021"
 
 [features]

--- a/server/api/internal/app/actions_test.go
+++ b/server/api/internal/app/actions_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const testActionsJSON = `{"actions":[{"name":"CSV Reader","type":"source","description":"Reads features from a CSV file","inputPorts":[],"outputPorts":["output"],"categories":["File"],"tags":[],"parameter":{},"builtin":false}]}`
+const testActionsJSON = `{"actions":[{"name":"GeoJSON Reader","type":"source","description":"Reads features from a GeoJSON file","inputPorts":[],"outputPorts":["output"],"categories":["Input"],"tags":[],"parameter":{},"builtin":false}]}`
 
 // fakeActionsReader serves testActionsJSON, or err if set.
 type fakeActionsReader struct{ err error }
@@ -37,7 +37,7 @@ func TestLoadActionsData_FromBucket(t *testing.T) {
 	resetTestData()
 	data, err := loadActionsData("")
 	assert.NoError(t, err)
-	assert.Equal(t, "CSV Reader", data.Actions[0].Name)
+	assert.Equal(t, "GeoJSON Reader", data.Actions[0].Name)
 }
 
 func TestLoadActionsData_FallbackToHTTP(t *testing.T) {
@@ -135,9 +135,9 @@ func TestListActions(t *testing.T) {
 }
 
 func TestListActionsHiddenFilter(t *testing.T) {
-	// "CSV Reader" is in baseActions; "PLATEAU4.SolarPositionCalculator" is not.
+	// "GeoJSON Reader" is in baseActions; "PLATEAU4.SolarPositionCalculator" is not.
 	testActions := []Action{
-		{Name: "CSV Reader", Type: ActionTypeSource, Description: "visible", Categories: []string{"File"}},
+		{Name: "GeoJSON Reader", Type: ActionTypeSource, Description: "visible", Categories: []string{"Input"}},
 		{Name: "PLATEAU4.SolarPositionCalculator", Type: ActionTypeProcessor, Description: "not in allow-list", Categories: []string{"PLATEAU"}},
 	}
 
@@ -157,7 +157,7 @@ func TestListActionsHiddenFilter(t *testing.T) {
 	err = json.Unmarshal(rec.Body.Bytes(), &response)
 	assert.NoError(t, err)
 	assert.Len(t, response, 1)
-	assert.Equal(t, "CSV Reader", response[0].Name)
+	assert.Equal(t, "GeoJSON Reader", response[0].Name)
 }
 
 func TestGetSegregatedActions(t *testing.T) {
@@ -222,7 +222,7 @@ func TestGetSegregatedActions(t *testing.T) {
 
 func TestGetActionDetails(t *testing.T) {
 	testAction := Action{
-		Name:        "CSV Reader",
+		Name:        "GeoJSON Reader",
 		Type:        ActionTypeSource,
 		Description: "Test action description",
 		Categories:  []string{"File"},
@@ -317,7 +317,7 @@ func TestGetActionDetailsPreservesParameterOrder(t *testing.T) {
 
 	resetTestData()
 	actionsDataMap[""] = ActionsData{Actions: []Action{{
-		Name:      "CSV Reader",
+		Name:      "GeoJSON Reader",
 		Type:      ActionTypeSource,
 		Parameter: json.RawMessage(parameter),
 	}}}
@@ -328,7 +328,7 @@ func TestGetActionDetailsPreservesParameterOrder(t *testing.T) {
 	c := e.NewContext(req, rec)
 	c.SetPath("/actions/:id")
 	c.SetParamNames("id")
-	c.SetParamValues("CSV Reader")
+	c.SetParamValues("GeoJSON Reader")
 
 	assert.NoError(t, getActionDetails(c))
 	assert.Equal(t, http.StatusOK, rec.Code)

--- a/server/api/internal/app/base_actions.go
+++ b/server/api/internal/app/base_actions.go
@@ -2,10 +2,35 @@ package app
 
 // baseActions is the curated set of actions exposed in the Re:Earth Flow SaaS UI palette.
 // All other actions in the schema are available for workflow execution but hidden from the UI.
+//
+// An action is listed here only if it BOTH runs in the shipped build (action-standard.md §7.1)
+// and has passed an engine-side review against that standard. Four reasons an action is absent,
+// each with the trigger that would bring it back. The full inventory, with preliminary findings
+// per action, is engine/dev-docs/action-review-findings.md.
+//
+//  1. Does not run in the shipped build. Its process/start exists only under
+//     #[cfg(not(feature = "new-geometry"))], so it hits the trait default and errors on every
+//     feature. Re-add as each port lands — tracked in Notion FLOW-DEV-182 "GEOM: Actions
+//     Migration".
+//
+//  2. Pending audit. Runs, but has never had an engine-side pass against the action standard,
+//     so its metadata is in whatever state it was authored in. Re-add per action as it is
+//     audited. Note this includes Coordinate Frame Reprojector, so the palette currently
+//     offers no reprojection at all — it is the strongest candidate to audit first.
+//
+//  3. Flagged for removal. Horizontal Reprojector and Vertical Reprojector are absent
+//     permanently: the tracker marks both "To Be Removed", and their new-geometry impls are
+//     stubs that error with a pointer to Coordinate Frame Reprojector. They owe an engine-side
+//     deletion, not a re-exposure.
+//
+//  4. Retired on design grounds, both unused in any workflow:
+//     Attribute File Path Info Extractor duplicates File Property Extractor exactly (same five
+//     output attributes, same values); the File one is documented and stays.
+//     Attribute Bulk Array Joiner joins every array attribute with a hard-coded comma and an
+//     opt-out list, and silently drops non-scalar elements. Its purpose looks to be CityGML
+//     attribute flattening; it needs a decision on scope before it is offered.
 var baseActions = map[string]bool{
 	// Input
-	"CityGML Reader":      true,
-	"CSV Reader":          true,
 	"Feature Creator":     true,
 	"File Path Extractor": true,
 	"GeoJSON Reader":      true,
@@ -17,12 +42,9 @@ var baseActions = map[string]bool{
 	"SQL Reader":          true,
 	// Output
 	"Cesium 3D Tiles Writer": true,
-	"CityGML Writer":         true,
 	"CSV Writer":             true,
 	"Echo Sink":              true,
-	"Excel Writer":           true,
 	"GeoJSON Writer":         true,
-	"GeoPackage Writer":      true,
 	"JSON Writer":            true,
 	"MVT Writer":             true,
 	"Noop Sink":              true,
@@ -30,86 +52,43 @@ var baseActions = map[string]bool{
 	"XML Writer":             true,
 	"Zip File Writer":        true,
 	// Geometry
-	"Appearance Remover":           true,
-	"Area Calculator":              true,
-	"Area On Area Overlayer":       true,
-	"Bounds Extractor":             true,
-	"Bufferer":                     true,
-	"Center Point Replacer":        true,
-	"Clipper":                      true,
-	"Coordinate Frame Reprojector": true,
-	"CSG Builder":                  true,
-	"CSG Evaluator":                true,
-	"Dimension Filter":             true,
-	"Dissolver":                    true,
-	"Elevation Extractor":          true,
-	"Extruder":                     true,
-	"Footprint Replacer":           true,
-	"Geometry Coercer":             true,
-	"Geometry Extractor":           true,
-	"Geometry Filter":              true,
-	"Geometry Part Extractor":      true,
-	"Geometry Remover":             true,
-	"Geometry Replacer":            true,
-	"Geometry Splitter":            true,
-	"Geometry Validator":           true,
-	"Grid Divider":                 true,
-	"Hole Counter":                 true,
-	"Hole Extractor":               true,
-	"Horizontal Reprojector":       true,
-	"Image Rasterizer":             true,
-	"Line On Line Overlayer":       true,
-	"Neighbor Finder":              true,
-	"Offsetter":                    true,
-	"Polygon Normal Extractor":     true,
-	"Ray Intersector":              true,
-	"Refiner":                      true,
-	"Spatial Filter":               true,
-	"Three Dimension Forcer":       true,
-	"Two Dimension Forcer":         true,
-	"Vertical Reprojector":         true,
+	"Appearance Remover":   true,
+	"Bounds Extractor":     true,
+	"Footprint Replacer":   true,
+	"Geometry Extractor":   true,
+	"Geometry Remover":     true,
+	"Geometry Replacer":    true,
+	"Geometry Splitter":    true,
+	"Geometry Validator":   true,
+	"Two Dimension Forcer": true,
 	// Attribute
-	"Attribute Aggregator":               true,
-	"Attribute Bulk Array Joiner":        true,
-	"Attribute Conversion Table":         true,
-	"Attribute Duplicate Filter":         true,
-	"Attribute File Path Info Extractor": true,
-	"Attribute Flattener":                true,
-	"Attribute Manager":                  true,
-	"Attribute Mapper":                   true,
-	"Attribute Range Mapper":             true,
-	"Attribute Table Extractor":          true,
-	"Bulk Attribute Renamer":             true,
-	"Date Time Converter":                true,
-	"Null Attribute Mapper":              true,
-	"Statistics Calculator":              true,
+	"Attribute Aggregator":       true,
+	"Attribute Conversion Table": true,
+	"Attribute Flattener":        true,
+	"Attribute Manager":          true,
+	"Attribute Mapper":           true,
+	"Attribute Range Mapper":     true,
+	"Attribute Table Extractor":  true,
+	"Bulk Attribute Renamer":     true,
+	"Date Time Converter":        true,
+	"Null Attribute Mapper":      true,
+	"Statistics Calculator":      true,
 	// Feature / Flow
 	"Feature CityGML 2 Reader":    true,
-	"Feature CityGML 3 Reader":    true,
-	"Feature CityGML Reader":      true,
 	"Feature Counter":             true,
-	"Feature Duplicate Filter":    true,
 	"Feature File Path Extractor": true,
 	"Feature Filter":              true,
-	"Feature GeoJSON Writer":      true,
 	"Feature Joiner":              true,
-	"Feature LOD Filter":          true,
 	"Feature Merger":              true,
-	"Feature Reader":              true,
 	"Feature Sorter":              true,
 	"Feature Transformer":         true,
 	"Feature Type Filter":         true,
-	"Feature Writer":              true,
 	"Input Router":                true,
-	"JSON Fragmenter":             true,
-	"List Concatenator":           true,
-	"List Indexer":                true,
 	"Output Router":               true,
 	// Utility
 	"Directory Decompressor":  true,
 	"Echo Processor":          true,
 	"File Property Extractor": true,
-	"HTTP Caller":             true,
 	"List Exploder":           true,
 	"Noop Processor":          true,
 	"XML Fragmenter":          true,

--- a/server/api/internal/app/base_actions.go
+++ b/server/api/internal/app/base_actions.go
@@ -15,13 +15,12 @@ package app
 //
 //  2. Pending audit. Runs, but has never had an engine-side pass against the action standard,
 //     so its metadata is in whatever state it was authored in. Re-add per action as it is
-//     audited. Note this includes Coordinate Frame Reprojector, so the palette currently
-//     offers no reprojection at all — it is the strongest candidate to audit first.
+//     audited.
 //
 //  3. Flagged for removal. Horizontal Reprojector and Vertical Reprojector are absent
 //     permanently: the tracker marks both "To Be Removed", and their new-geometry impls are
-//     stubs that error with a pointer to Coordinate Frame Reprojector. They owe an engine-side
-//     deletion, not a re-exposure.
+//     stubs that error with a pointer to Coordinate Frame Reprojector, which is exposed below
+//     and supersedes both. They owe an engine-side deletion, not a re-exposure.
 //
 //  4. Retired on design grounds, both unused in any workflow:
 //     Attribute File Path Info Extractor duplicates File Property Extractor exactly (same five
@@ -52,15 +51,17 @@ var baseActions = map[string]bool{
 	"XML Writer":             true,
 	"Zip File Writer":        true,
 	// Geometry
-	"Appearance Remover":   true,
-	"Bounds Extractor":     true,
-	"Footprint Replacer":   true,
-	"Geometry Extractor":   true,
-	"Geometry Remover":     true,
-	"Geometry Replacer":    true,
-	"Geometry Splitter":    true,
-	"Geometry Validator":   true,
-	"Two Dimension Forcer": true,
+	"Appearance Remover":           true,
+	"Bounds Extractor":             true,
+	"Coordinate Frame Reprojector": true,
+	"Dissolver":                    true,
+	"Footprint Replacer":           true,
+	"Geometry Extractor":           true,
+	"Geometry Remover":             true,
+	"Geometry Replacer":            true,
+	"Geometry Splitter":            true,
+	"Geometry Validator":           true,
+	"Two Dimension Forcer":         true,
 	// Attribute
 	"Attribute Aggregator":       true,
 	"Attribute Conversion Table": true,

--- a/server/api/internal/app/route_encoding_test.go
+++ b/server/api/internal/app/route_encoding_test.go
@@ -11,12 +11,12 @@ import (
 
 func TestGetActionDetailsPercentEncodedName(t *testing.T) {
 	resetTestData()
-	spaced := Action{Name: "CSV Reader", Type: ActionTypeSource, Description: "d"}
+	spaced := Action{Name: "GeoJSON Reader", Type: ActionTypeSource, Description: "d"}
 	actionsDataMap[""] = ActionsData{Actions: []Action{spaced}}
 
 	e := echo.New()
 	e.GET("/actions/:id", getActionDetails)
-	req := httptest.NewRequest(http.MethodGet, "/actions/CSV%20Reader", nil)
+	req := httptest.NewRequest(http.MethodGet, "/actions/GeoJSON%20Reader", nil)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code, "percent-encoded spaced action name should resolve; body: %s", rec.Body.String())


### PR DESCRIPTION
# Overview

Revises the action standard, then applies it. The headline change is that **the exposed palette drops from 105 actions to 59**, because the gate is now strict: an action is listed in `base_actions.go` only if it *both* runs in the shipped build *and* has passed an engine-side review.

**Nothing is deleted.** Every hidden action still executes when a workflow names it, so no existing workflow breaks. `base_actions.go` only controls what the SaaS UI palette offers.

## What I've done

### The palette gate (the part to review first)

22 of the previously-exposed actions **error on every feature in the shipped build**. Their `process`/`start` exists only under `#[cfg(not(feature = "new-geometry"))]`, so they hit the trait default in `node.rs` and fail immediately — and both containers build with default features, where `new-geometry` is on. Among them: `CSV Reader`, `CityGML Reader`, `CityGML Writer`, `GeoPackage Writer`, `Bufferer`, `Clipper`, `Extruder`, `Spatial Filter`.

Verified per action by resolving each factory to its file and checking which `cfg` arm defines the trait method, then validated against 18 actions the migration tracker records as `Migrated` — the check clears all 18, including the `shapefile_next` sibling-module pattern.

The remaining exclusions, all recorded in the file header with the trigger that brings each back:

| Reason | Count | Trigger |
|---|---|---|
| Does not run in the shipped build | 22 | Its new-geometry port landing (Notion FLOW-DEV-182) |
| Pending audit | 20 | An engine-side §8 pass |
| Flagged for removal | 2 | None — they owe a deletion |
| Retired on design grounds | 2 | A scope decision |

`Horizontal Reprojector` and `Vertical Reprojector` are the flagged pair: the tracker marks both "To Be Removed" and their new-geometry impls are stubs that error with a pointer to `Coordinate Frame Reprojector`, which this PR audits and exposes in their place.

### Standard revision

- **§"How to use" rescoped.** The verify-against-implementation duty was worded as a precondition for *adding or editing* a title or description, which exempted anything that already read well. That is the wrong test — a description can be fluent and fully rule-compliant while describing behaviour that does not exist. It now attaches to the action itself.
- **§8 gains an `impl:` line** for parameters never applied, enum variants with no branch, defaults the code contradicts, and ports never emitted. Every other line in the checklist can be answered from the generated schema; this one cannot.
- **§6 rewritten.** It set a floor ("aim for 2–4; 1 is acceptable") while also forbidding tags that duplicate the category, making the floor unreachable for single-domain actions. Tags are now defined by their purpose — cross-category discovery — and zero tags is explicitly valid.

### Actions audited

`Attribute Range Mapper`, `Date Time Converter`, `Attribute Table Extractor`, `Coordinate Frame Reprojector`, `Dissolver` — each with a full implementation trace, not a schema pass.

Two were retired instead: `Attribute File Path Info Extractor` duplicates `File Property Extractor` exactly (same five output attributes, same values), and `Attribute Bulk Array Joiner` needs a scope decision before it is worth documenting.

The two substantive findings: **`Dissolver` never documented that it only accepts flat 2D areas sharing one coordinate frame**, so 3D or mixed-frame input was silently routed to `rejected` — a user could wire it up correctly and lose every feature with no indication why. And **`Attribute Table Extractor`'s `inline` was `Option<Value>`**, so the table a user must author had no documented shape at all and `ExtractRule`'s doc comments never reached the schema.

## Breaking changes

All on actions exposed for the first time three days ago in #2373, and all migrated in-repo. Deliberately landed now rather than after action-level versioning, when each would need a migration.

| Action | Change |
|---|---|
| `Date Time Converter` | enum values `unix_s`/`unix_ms` → `unixS`/`unixMs` (§3.4 prohibits snake_case) |
| `Date Time Converter` | a feature lacking the source attribute now passes through on `features` instead of routing to `failed` (§4.3 — that is a no-op, not a failure) |
| `Attribute Table Extractor` | `jsonPath` → `sourcePath`, `attribute` → `destinationPath`. The old name promised JSONPath; the implementation splits on whitespace, so `$.a.b` failed silently |
| `Coordinate Frame Reprojector` | `epsgCode` moves inside the `crs` variant of a tagged `destinationFrame`, so the schema can no longer express a CRS destination without a code (§3.2) |
| `Dissolver` | output port `area` → `features` |

## What I haven't done

**20 actions remain unaudited** and are hidden until they are. The full inventory — every pending action with its preliminary findings, plus six cross-cutting issues — is the `## HANDOVER` section at the bottom of `engine/dev-docs/action-review-findings.md`, linked from that file's header.

Also not done: `Dissolver` accepting 3D input with a Z-resolution policy (comparable tooling and GEOS/JTS via PostGIS `ST_Union` all compute in XY only, but they accept 3D and resolve Z by a stated rule rather than refusing it); the `Area On Area Overlayer` port rename; and the root-level `oneOf` restructuring that §3.4 now prohibits, which affects five actions including the already-audited `XML Fragmenter`.

## How I tested

`cargo make clippy`, `test-rs`, `test-qc`, `cargo test -p reearth-flow-tests`, schema regeneration confirmed idempotent (the generated-files check), and `go build` + `go test ./internal/app/` for the API.

Two honest gaps:

- **`test-conv` is the only suite that exercises the `Dissolver` port rename.** `plateau-tiles-test` lists all six `data-convert/plateau4/02-tran-rwy-trk-squr-wwy/*` variants, whose edges this PR rewires. It needs a downloaded city model, so I could not run it locally — those jobs are the real verification. `test-qc`'s `03-tran` cases are all `ignored` pending their own migration.
- Rewiring was verified statically instead: matched by Dissolver node id, then every remaining `fromPort: area` edge in the examples tree re-scanned to confirm all 23 originate from `Area On Area Overlayer`.

## Which point I want you to review particularly

The palette reduction. Specifically whether hiding `CSV Reader`, `CityGML Reader`, `CityGML Writer` and `GeoPackage Writer` is the right call — they error on every feature today, so exposing them advertises something broken, but it does remove CSV and CityGML file input from the palette until those ports land. `Feature Reader` still reads CSV/TSV/JSON mid-flow and `Feature CityGML 2 Reader` survives, so neither format is entirely unreachable.

## Memo

Engine version bumped per commit touching `engine/`; the final bump is 0.0.503.

`server/api/internal/app/base_actions.go` and `engine/schema/actions.json` are still coupled only by name strings with no CI check that they agree — the 105 names were verified by hand for this PR. A drift check is proposed in the handover and not implemented here.
