### PR TITLE
fix(api): give initEcho test the client the boot-time container needs

### DIFF
--- a/server/api/internal/app/body_limit_test.go
+++ b/server/api/internal/app/body_limit_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"github.com/reearth/reearth-accounts/server/pkg/gqlclient"
 	"github.com/reearth/reearth-flow/api/internal/app/config"
 	"github.com/reearth/reearth-flow/api/internal/usecase/gateway"
 	"github.com/reearth/reearth-flow/api/internal/usecase/repo"
@@ -146,13 +147,16 @@ func TestGraphqlBodyLimitMiddleware_UsesConfiguredMaxUploadSize(t *testing.T) {
 func TestInitEcho_EnforcesNonGraphQLBodyLimit(t *testing.T) {
 	t.Parallel()
 
+	// initEcho builds the usecase container at boot, so the client it reads
+	// repos off must be present even though no request here reaches it.
 	cfg := &ServerConfig{
 		Config: &config.Config{
 			Web_Disabled: true,
 			AuthSrv:      config.AuthSrvConfig{Disabled: true},
 		},
-		Repos:    &repo.Container{},
-		Gateways: &gateway.Container{},
+		Repos:            &repo.Container{},
+		Gateways:         &gateway.Container{},
+		AccountGQLClient: gqlclient.NewClient("http://localhost", 1, nil),
 	}
 	e := initEcho(context.Background(), cfg)
 


### PR DESCRIPTION
# Overview

`main` is red. `TestInitEcho_EnforcesNonGraphQLBodyLimit` panics with a nil pointer dereference in `interactor.NewContainer` (`common.go:51`), reached from `initEcho` (`app.go:111`):

```
--- FAIL: TestInitEcho_EnforcesNonGraphQLBodyLimit (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference
	interactor.NewContainer(...) internal/usecase/interactor/common.go:51
	app.initEcho(...)            internal/app/app.go:111
	app.TestInitEcho_EnforcesNonGraphQLBodyLimit(...) internal/app/body_limit_test.go:157
```

Two changes that were each green in isolation collide. #2380 added a test that boots the real `initEcho` with a deliberately minimal `ServerConfig` — no `AccountGQLClient`, because nothing on that path needed one: `NewContainer` ran per request, and this test's request short-circuits in `BodyLimit` on `Content-Length` before any middleware runs. #2386 then moved `NewContainer` out of the per-request middleware into `initEcho`, where it now runs unconditionally at boot, dereferences the nil client at `GQLClient.WorkspaceRepo`, and panics.

## What I've done

The test's `ServerConfig` now supplies an `AccountGQLClient`. `gqlclient.NewClient` does no I/O — it just builds repo structs around an HTTP client — so this stays a pure unit test, and the request still never reaches the container.

## What I haven't done

Didn't make `NewContainer` tolerate a nil client. It is called once at boot with real configuration, so a nil there is a genuine misconfiguration and should fail loudly rather than be papered over in the constructor.

## How I tested

`gofmt` · `go build ./...` · `go vet ./...` · `golangci-lint run --new-from-rev=origin/main` (v2.11.4, 0 issues).

`go test ./internal/...` → 468 passed across 36 packages, and again under `-race`. The previously panicking test passes over repeated runs.

## Screenshot

N/A — backend only.

## Which point I want you to review particularly

Nothing subtle — it is a one-line test fixture change. The point worth carrying forward is in the memo.

## Memo

Since #2386, any test that boots `initEcho` needs a `ServerConfig` complete enough to construct the usecase container, whether or not the test exercises it. This is the only such test today.
