### PR TITLE
fix(api): stop batched Fetch from crashing on a nil-padded first element

### DIFF
--- a/server/api/internal/usecase/interactor/asset.go
+++ b/server/api/internal/usecase/interactor/asset.go
@@ -48,13 +48,24 @@ func (i *Asset) Fetch(ctx context.Context, assets []id.AssetID) ([]*asset.Asset,
 		return nil, err
 	}
 
-	if len(res) == 0 {
+	// FindByIDs pads not-found/unreadable entries with nil, so the first
+	// element isn't necessarily an asset — use the first non-nil one.
+	var ws accountsid.WorkspaceID
+	var haveWorkspace bool
+	for _, a := range res {
+		if a != nil {
+			ws, haveWorkspace = a.Workspace(), true
+			break
+		}
+	}
+
+	if !haveWorkspace {
 		if err := i.checkPermission(ctx, rbac.ActionAny); err != nil {
 			return nil, err
 		}
 	} else {
 		// single-workspace batch assumption
-		if err := i.checkPermission(ctx, rbac.ActionAny, res[0].Workspace()); err != nil {
+		if err := i.checkPermission(ctx, rbac.ActionAny, ws); err != nil {
 			return nil, err
 		}
 	}

--- a/server/api/internal/usecase/interactor/asset_batch_test.go
+++ b/server/api/internal/usecase/interactor/asset_batch_test.go
@@ -1,0 +1,84 @@
+package interactor
+
+import (
+	"context"
+	"testing"
+
+	accountsid "github.com/reearth/reearth-accounts/server/pkg/id"
+	"github.com/reearth/reearth-flow/api/internal/infrastructure/memory"
+	"github.com/reearth/reearth-flow/api/internal/usecase/repo"
+	"github.com/reearth/reearth-flow/api/pkg/asset"
+	"github.com/reearth/reearth-flow/api/pkg/id"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nilPaddingAssetRepo wraps a real repo.Asset and makes FindByIDs pad
+// not-found ids with nil at their requested position, matching the mongo
+// implementation's filterAssets (memory.Asset.FindByIDs just omits misses).
+type nilPaddingAssetRepo struct {
+	repo.Asset
+}
+
+func (r *nilPaddingAssetRepo) FindByIDs(ctx context.Context, ids id.AssetIDList) ([]*asset.Asset, error) {
+	found, err := r.Asset.FindByIDs(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	res := make([]*asset.Asset, len(ids))
+	for i, aid := range ids {
+		for _, a := range found {
+			if a != nil && a.ID() == aid {
+				res[i] = a
+				break
+			}
+		}
+	}
+	return res, nil
+}
+
+// TestAsset_Fetch_NotFoundFirstElementDoesNotPanic pins a crash observed in
+// production on the equivalent Deployment.Fetch: FindByIDs pads a
+// not-found/unreadable id with nil, and if that nil lands at index 0,
+// res[0].Workspace() panics with a nil pointer dereference. The permission
+// check must fall back to the first non-nil element instead.
+func TestAsset_Fetch_NotFoundFirstElementDoesNotPanic(t *testing.T) {
+	ws := accountsid.NewWorkspaceID()
+	assetRepo := &nilPaddingAssetRepo{Asset: memory.NewAsset()}
+
+	a := asset.New().NewID().Workspace(ws).CreatedByUser(accountsid.NewUserID()).Name("f.txt").Size(1).URL("https://example.com/assets/f.txt").NewUUID().MustBuild()
+	require.NoError(t, assetRepo.Save(context.Background(), a))
+
+	missingID := id.NewAssetID()
+
+	checker := &recordingChecker{allow: true}
+	i := &Asset{repos: &repo.Container{Asset: assetRepo}, permissionChecker: checker}
+
+	require.NotPanics(t, func() {
+		res, err := i.Fetch(context.Background(), []id.AssetID{missingID, a.ID()})
+		require.NoError(t, err)
+		require.Len(t, res, 2)
+		assert.Nil(t, res[0], "not-found id stays nil in the result")
+		require.NotNil(t, res[1])
+		require.Len(t, checker.gotWorkspace, 1)
+		assert.Equal(t, ws, checker.gotWorkspace[0], "permission check uses the first non-nil element's workspace")
+	})
+}
+
+// TestAsset_Fetch_AllNotFound_UsesNoWorkspacePermissionPath pins the other
+// half of the same fix: an all-nil batch must take the no-items permission
+// path rather than dereferencing a nil element.
+func TestAsset_Fetch_AllNotFound_UsesNoWorkspacePermissionPath(t *testing.T) {
+	assetRepo := &nilPaddingAssetRepo{Asset: memory.NewAsset()}
+	checker := &recordingChecker{allow: true}
+	i := &Asset{repos: &repo.Container{Asset: assetRepo}, permissionChecker: checker}
+
+	require.NotPanics(t, func() {
+		res, err := i.Fetch(context.Background(), []id.AssetID{id.NewAssetID(), id.NewAssetID()})
+		require.NoError(t, err)
+		require.Len(t, res, 2)
+		assert.Nil(t, res[0])
+		assert.Nil(t, res[1])
+		assert.Empty(t, checker.gotWorkspace, "no non-nil element means no workspace-scoped check")
+	})
+}

--- a/server/api/internal/usecase/interactor/deployment.go
+++ b/server/api/internal/usecase/interactor/deployment.go
@@ -2,6 +2,7 @@ package interactor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -17,6 +18,7 @@ import (
 	"github.com/reearth/reearth-flow/api/pkg/id"
 	"github.com/reearth/reearth-flow/api/pkg/job"
 	"github.com/reearth/reearthx/log"
+	"github.com/reearth/reearthx/rerror"
 	"github.com/reearth/reearthx/usecasex"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -62,12 +64,23 @@ func (i *Deployment) Fetch(ctx context.Context, ids []id.DeploymentID) ([]*deplo
 		return nil, err
 	}
 
-	if len(deployments) == 0 {
+	// FindByIDs pads not-found/unreadable entries with nil, so the first
+	// element isn't necessarily a deployment — use the first non-nil one.
+	var ws accountsid.WorkspaceID
+	var haveWorkspace bool
+	for _, d := range deployments {
+		if d != nil {
+			ws, haveWorkspace = d.Workspace(), true
+			break
+		}
+	}
+
+	if !haveWorkspace {
 		if err := i.checkPermission(ctx, rbac.ActionAny); err != nil {
 			return nil, err
 		}
 	} else {
-		if err := i.checkPermission(ctx, rbac.ActionAny, deployments[0].Workspace()); err != nil { // single-workspace batch assumption
+		if err := i.checkPermission(ctx, rbac.ActionAny, ws); err != nil { // single-workspace batch assumption
 			return nil, err
 		}
 	}
@@ -130,6 +143,9 @@ func (i *Deployment) FindByProjects(ctx context.Context, ids []id.ProjectID) (ma
 		for _, pid := range pids {
 			dep, err := i.deploymentRepo.FindByProject(ctx, pid)
 			if err != nil {
+				if errors.Is(err, rerror.ErrNotFound) {
+					continue // project has no deployment yet
+				}
 				return nil, err
 			}
 			if dep != nil {

--- a/server/api/internal/usecase/interactor/deployment_batch_test.go
+++ b/server/api/internal/usecase/interactor/deployment_batch_test.go
@@ -105,6 +105,58 @@ func TestDeployment_FindByProjects_DeniedWorkspaceOmittedNotErrored(t *testing.T
 	assert.NotContains(t, res, deniedPID, "caller was denied on this workspace, its deployment must not leak through the batch")
 }
 
+// TestDeployment_Fetch_NotFoundFirstElementDoesNotPanic pins a crash observed
+// in production: FindByIDs pads a not-found/unreadable id with nil, and if
+// that nil lands at index 0, deployments[0].Workspace() panics with a nil
+// pointer dereference. The permission check must fall back to the first
+// non-nil element instead of assuming index 0 is populated.
+func TestDeployment_Fetch_NotFoundFirstElementDoesNotPanic(t *testing.T) {
+	ws := accountsid.NewWorkspaceID()
+	projectRepo := memory.NewProject()
+	deploymentRepo := memory.NewDeployment()
+	newProjectAndDeployment(t, projectRepo, deploymentRepo, ws)
+
+	realDeployments, _, err := deploymentRepo.FindByWorkspace(context.Background(), ws, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, realDeployments, 1)
+	realID := realDeployments[0].ID()
+
+	missingID := id.NewDeploymentID()
+
+	checker := &recordingChecker{allow: true}
+	i := &Deployment{projectRepo: projectRepo, deploymentRepo: deploymentRepo, permissionChecker: checker}
+
+	require.NotPanics(t, func() {
+		res, err := i.Fetch(context.Background(), []id.DeploymentID{missingID, realID})
+		require.NoError(t, err)
+		require.Len(t, res, 2)
+		assert.Nil(t, res[0], "not-found id stays nil in the result")
+		require.NotNil(t, res[1])
+		require.Len(t, checker.gotWorkspace, 1)
+		assert.Equal(t, ws, checker.gotWorkspace[0], "permission check uses the first non-nil element's workspace")
+	})
+}
+
+// TestDeployment_Fetch_AllNotFound_UsesNoWorkspacePermissionPath pins the
+// other half of the same fix: when every id in the batch is unreadable or
+// missing, the permission check must take the no-items path rather than
+// dereferencing a nil element.
+func TestDeployment_Fetch_AllNotFound_UsesNoWorkspacePermissionPath(t *testing.T) {
+	projectRepo := memory.NewProject()
+	deploymentRepo := memory.NewDeployment()
+	checker := &recordingChecker{allow: true}
+	i := &Deployment{projectRepo: projectRepo, deploymentRepo: deploymentRepo, permissionChecker: checker}
+
+	require.NotPanics(t, func() {
+		res, err := i.Fetch(context.Background(), []id.DeploymentID{id.NewDeploymentID(), id.NewDeploymentID()})
+		require.NoError(t, err)
+		require.Len(t, res, 2)
+		assert.Nil(t, res[0])
+		assert.Nil(t, res[1])
+		assert.Empty(t, checker.gotWorkspace, "no non-nil element means no workspace-scoped check")
+	})
+}
+
 func TestDeployment_FindByProjects_EmptyBatch_DeniesAndTouchesNothing(t *testing.T) {
 	projectRepo := &countingProjectRepo{Project: memory.NewProject()}
 	deploymentRepo := memory.NewDeployment()

--- a/server/api/internal/usecase/interactor/job.go
+++ b/server/api/internal/usecase/interactor/job.go
@@ -264,13 +264,24 @@ func (i *Job) Fetch(ctx context.Context, ids []id.JobID) ([]*job.Job, error) {
 		return nil, err
 	}
 
-	if len(jobs) == 0 {
+	// FindByIDs pads not-found/unreadable entries with nil, so the first
+	// element isn't necessarily a job — use the first non-nil one.
+	var ws accountsid.WorkspaceID
+	var haveWorkspace bool
+	for _, j := range jobs {
+		if j != nil {
+			ws, haveWorkspace = j.Workspace(), true
+			break
+		}
+	}
+
+	if !haveWorkspace {
 		if err := i.checkPermission(ctx, rbac.ActionAny); err != nil {
 			return nil, err
 		}
 	} else {
 		// single-workspace batch assumption
-		if err := i.checkPermission(ctx, rbac.ActionAny, jobs[0].Workspace()); err != nil {
+		if err := i.checkPermission(ctx, rbac.ActionAny, ws); err != nil {
 			return nil, err
 		}
 	}

--- a/server/api/internal/usecase/interactor/job_batch_test.go
+++ b/server/api/internal/usecase/interactor/job_batch_test.go
@@ -1,0 +1,59 @@
+package interactor
+
+import (
+	"context"
+	"testing"
+
+	accountsid "github.com/reearth/reearth-accounts/server/pkg/id"
+	"github.com/reearth/reearth-flow/api/internal/infrastructure/memory"
+	"github.com/reearth/reearth-flow/api/pkg/id"
+	"github.com/reearth/reearth-flow/api/pkg/job"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestJob_Fetch_NotFoundFirstElementDoesNotPanic pins a crash observed in
+// production on the equivalent Deployment.Fetch: FindByIDs pads a
+// not-found/unreadable id with nil, and if that nil lands at index 0,
+// jobs[0].Workspace() panics with a nil pointer dereference. The permission
+// check must fall back to the first non-nil element instead.
+func TestJob_Fetch_NotFoundFirstElementDoesNotPanic(t *testing.T) {
+	ws := accountsid.NewWorkspaceID()
+	jobRepo := memory.NewJob()
+
+	j := job.New().NewID().Workspace(ws).Status(job.StatusPending).MustBuild()
+	require.NoError(t, jobRepo.Save(context.Background(), j))
+
+	missingID := id.NewJobID()
+
+	checker := &recordingChecker{allow: true}
+	i := &Job{jobRepo: jobRepo, permissionChecker: checker}
+
+	require.NotPanics(t, func() {
+		res, err := i.Fetch(context.Background(), []id.JobID{missingID, j.ID()})
+		require.NoError(t, err)
+		require.Len(t, res, 2)
+		assert.Nil(t, res[0], "not-found id stays nil in the result")
+		require.NotNil(t, res[1])
+		require.Len(t, checker.gotWorkspace, 1)
+		assert.Equal(t, ws, checker.gotWorkspace[0], "permission check uses the first non-nil element's workspace")
+	})
+}
+
+// TestJob_Fetch_AllNotFound_UsesNoWorkspacePermissionPath pins the other
+// half of the same fix: an all-nil batch must take the no-items permission
+// path rather than dereferencing a nil element.
+func TestJob_Fetch_AllNotFound_UsesNoWorkspacePermissionPath(t *testing.T) {
+	jobRepo := memory.NewJob()
+	checker := &recordingChecker{allow: true}
+	i := &Job{jobRepo: jobRepo, permissionChecker: checker}
+
+	require.NotPanics(t, func() {
+		res, err := i.Fetch(context.Background(), []id.JobID{id.NewJobID(), id.NewJobID()})
+		require.NoError(t, err)
+		require.Len(t, res, 2)
+		assert.Nil(t, res[0])
+		assert.Nil(t, res[1])
+		assert.Empty(t, checker.gotWorkspace, "no non-nil element means no workspace-scoped check")
+	})
+}

--- a/server/api/internal/usecase/interactor/project.go
+++ b/server/api/internal/usecase/interactor/project.go
@@ -66,12 +66,23 @@ func (i *Project) Fetch(ctx context.Context, ids []id.ProjectID) ([]*project.Pro
 		return nil, err
 	}
 
-	if len(projects) == 0 {
+	// FindByIDs pads not-found/unreadable entries with nil, so the first
+	// element isn't necessarily a project — use the first non-nil one.
+	var ws accountsid.WorkspaceID
+	var haveWorkspace bool
+	for _, p := range projects {
+		if p != nil {
+			ws, haveWorkspace = p.Workspace(), true
+			break
+		}
+	}
+
+	if !haveWorkspace {
 		if err := i.checkPermission(ctx, rbac.ActionList); err != nil {
 			return nil, err
 		}
 	} else {
-		if err := i.checkPermission(ctx, rbac.ActionList, projects[0].Workspace()); err != nil { // single-workspace batch assumption
+		if err := i.checkPermission(ctx, rbac.ActionList, ws); err != nil { // single-workspace batch assumption
 			return nil, err
 		}
 	}

--- a/server/api/internal/usecase/interactor/project_batch_test.go
+++ b/server/api/internal/usecase/interactor/project_batch_test.go
@@ -1,0 +1,59 @@
+package interactor
+
+import (
+	"context"
+	"testing"
+
+	accountsid "github.com/reearth/reearth-accounts/server/pkg/id"
+	"github.com/reearth/reearth-flow/api/internal/infrastructure/memory"
+	"github.com/reearth/reearth-flow/api/pkg/id"
+	"github.com/reearth/reearth-flow/api/pkg/project"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProject_Fetch_NotFoundFirstElementDoesNotPanic pins a crash observed
+// in production on the equivalent Deployment.Fetch: FindByIDs pads a
+// not-found/unreadable id with nil, and if that nil lands at index 0,
+// projects[0].Workspace() panics with a nil pointer dereference. The
+// permission check must fall back to the first non-nil element instead.
+func TestProject_Fetch_NotFoundFirstElementDoesNotPanic(t *testing.T) {
+	ws := accountsid.NewWorkspaceID()
+	projectRepo := memory.NewProject()
+
+	p := project.New().NewID().Workspace(ws).Name("p").MustBuild()
+	require.NoError(t, projectRepo.Save(context.Background(), p))
+
+	missingID := id.NewProjectID()
+
+	checker := &recordingChecker{allow: true}
+	i := &Project{projectRepo: projectRepo, permissionChecker: checker}
+
+	require.NotPanics(t, func() {
+		res, err := i.Fetch(context.Background(), []id.ProjectID{missingID, p.ID()})
+		require.NoError(t, err)
+		require.Len(t, res, 2)
+		assert.Nil(t, res[0], "not-found id stays nil in the result")
+		require.NotNil(t, res[1])
+		require.Len(t, checker.gotWorkspace, 1)
+		assert.Equal(t, ws, checker.gotWorkspace[0], "permission check uses the first non-nil element's workspace")
+	})
+}
+
+// TestProject_Fetch_AllNotFound_UsesNoWorkspacePermissionPath pins the other
+// half of the same fix: an all-nil batch must take the no-items permission
+// path rather than dereferencing a nil element.
+func TestProject_Fetch_AllNotFound_UsesNoWorkspacePermissionPath(t *testing.T) {
+	projectRepo := memory.NewProject()
+	checker := &recordingChecker{allow: true}
+	i := &Project{projectRepo: projectRepo, permissionChecker: checker}
+
+	require.NotPanics(t, func() {
+		res, err := i.Fetch(context.Background(), []id.ProjectID{id.NewProjectID(), id.NewProjectID()})
+		require.NoError(t, err)
+		require.Len(t, res, 2)
+		assert.Nil(t, res[0])
+		assert.Nil(t, res[1])
+		assert.Empty(t, checker.gotWorkspace, "no non-nil element means no workspace-scoped check")
+	})
+}

--- a/server/api/internal/usecase/interactor/trigger.go
+++ b/server/api/internal/usecase/interactor/trigger.go
@@ -60,12 +60,23 @@ func (i *Trigger) Fetch(ctx context.Context, ids []id.TriggerID) ([]*trigger.Tri
 		return nil, err
 	}
 
-	if len(triggers) == 0 {
+	// FindByIDs pads not-found/unreadable entries with nil, so the first
+	// element isn't necessarily a trigger — use the first non-nil one.
+	var ws accountsid.WorkspaceID
+	var haveWorkspace bool
+	for _, t := range triggers {
+		if t != nil {
+			ws, haveWorkspace = t.Workspace(), true
+			break
+		}
+	}
+
+	if !haveWorkspace {
 		if err := i.checkPermission(ctx, rbac.ActionAny); err != nil {
 			return nil, err
 		}
 	} else {
-		if err := i.checkPermission(ctx, rbac.ActionAny, triggers[0].Workspace()); err != nil { // single-workspace batch assumption
+		if err := i.checkPermission(ctx, rbac.ActionAny, ws); err != nil { // single-workspace batch assumption
 			return nil, err
 		}
 	}

--- a/server/api/internal/usecase/interactor/trigger_batch_test.go
+++ b/server/api/internal/usecase/interactor/trigger_batch_test.go
@@ -1,0 +1,59 @@
+package interactor
+
+import (
+	"context"
+	"testing"
+
+	accountsid "github.com/reearth/reearth-accounts/server/pkg/id"
+	"github.com/reearth/reearth-flow/api/internal/infrastructure/memory"
+	"github.com/reearth/reearth-flow/api/pkg/id"
+	"github.com/reearth/reearth-flow/api/pkg/trigger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTrigger_Fetch_NotFoundFirstElementDoesNotPanic pins a crash observed
+// in production on the equivalent Deployment.Fetch: FindByIDs pads a
+// not-found/unreadable id with nil, and if that nil lands at index 0,
+// triggers[0].Workspace() panics with a nil pointer dereference. The
+// permission check must fall back to the first non-nil element instead.
+func TestTrigger_Fetch_NotFoundFirstElementDoesNotPanic(t *testing.T) {
+	ws := accountsid.NewWorkspaceID()
+	triggerRepo := memory.NewTrigger()
+
+	tr := trigger.New().NewID().Workspace(ws).Deployment(id.NewDeploymentID()).Description("d").EventSource(trigger.EventSourceTypeAPIDriven).MustBuild()
+	require.NoError(t, triggerRepo.Save(context.Background(), tr))
+
+	missingID := id.NewTriggerID()
+
+	checker := &recordingChecker{allow: true}
+	i := &Trigger{triggerRepo: triggerRepo, permissionChecker: checker}
+
+	require.NotPanics(t, func() {
+		res, err := i.Fetch(context.Background(), []id.TriggerID{missingID, tr.ID()})
+		require.NoError(t, err)
+		require.Len(t, res, 2)
+		assert.Nil(t, res[0], "not-found id stays nil in the result")
+		require.NotNil(t, res[1])
+		require.Len(t, checker.gotWorkspace, 1)
+		assert.Equal(t, ws, checker.gotWorkspace[0], "permission check uses the first non-nil element's workspace")
+	})
+}
+
+// TestTrigger_Fetch_AllNotFound_UsesNoWorkspacePermissionPath pins the other
+// half of the same fix: an all-nil batch must take the no-items permission
+// path rather than dereferencing a nil element.
+func TestTrigger_Fetch_AllNotFound_UsesNoWorkspacePermissionPath(t *testing.T) {
+	triggerRepo := memory.NewTrigger()
+	checker := &recordingChecker{allow: true}
+	i := &Trigger{triggerRepo: triggerRepo, permissionChecker: checker}
+
+	require.NotPanics(t, func() {
+		res, err := i.Fetch(context.Background(), []id.TriggerID{id.NewTriggerID(), id.NewTriggerID()})
+		require.NoError(t, err)
+		require.Len(t, res, 2)
+		assert.Nil(t, res[0])
+		assert.Nil(t, res[1])
+		assert.Empty(t, checker.gotWorkspace, "no non-nil element means no workspace-scoped check")
+	})
+}


### PR DESCRIPTION
# Overview

Production is crash-looping on `reearth-flow-api` (Cloud Run, `reearth-oss`/`us-central1`). Confirmed from real Cloud Logging output — this is not a hypothesis:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x68 pc=0x110d0bf]
github.com/reearth/reearth-flow/api/pkg/deployment.(*Deployment).Workspace(...)
	pkg/deployment/deployment.go:28
github.com/reearth/reearth-flow/api/internal/usecase/interactor.(*Deployment).Fetch(...)
	internal/usecase/interactor/deployment.go:70
github.com/reearth/reearth-flow/api/internal/adapter/gql.(*DeploymentLoader).Fetch(...)
	internal/adapter/gql/loader_deployment.go:29
...
created by .../gqldataloader.(*deploymentLoaderBatch).keyIndex
```

The panic is in a dataloader's background goroutine, which Echo's panic recovery middleware never sees — it takes down the whole process. Cloud Run then returns 503 for the restart window, which is why `Deployments`, `Triggers`, `Assets` and `Jobs` were failing intermittently while `Me`/`Workspace`/`Projects` mostly succeeded: whichever requests landed on the crashing instance failed, the rest didn't.

## What I've done

**The crash.** `FindByIDs` pads not-found/unreadable ids with `nil` at their requested position (documented in-line, confirmed against the mongo implementation). `Asset.Fetch`, `Deployment.Fetch`, `Job.Fetch`, `Project.Fetch` and `Trigger.Fetch` all assumed the first element of a non-empty batch was populated and called `.Workspace()` on it directly — so any batch whose first requested id happened to be missing or unreadable panicked. All five now scan for the first non-nil element instead of indexing `[0]`, falling back to the no-workspace permission path when every element is nil.

**A second, related bug, also confirmed in production traffic.** `Deployment.FindByProjects` (the batched loader backing `Project.deployment`) propagated a project's plain `rerror.ErrNotFound` — "this project has no deployment yet," the ordinary case — as a hard error, failing the *entire* dataloader batch instead of omitting just that project. That's why every project in a `GetProjects` response showed `deployment: null` with a `"not found"` GraphQL error attached, not just the ones genuinely missing a deployment. Now it's `continue`d past like every other omission in that function.

## What I haven't done

Didn't touch the "single-workspace batch assumption" itself — each `Fetch` still checks permission against only one workspace for the whole batch. That's pre-existing, documented in-line, and out of scope; this PR only fixes the crash and the wrong-error-type bug, not the assumption's design.

## How I tested

`gofmt` · `go build ./...` · `go vet ./...` · `golangci-lint run --new-from-rev=origin/main` (v2.11.4, 0 issues) · `go test ./internal/... ./pkg/... -race` → 729 passed across 60 packages.

Ten new tests, two per interactor, each verified against the pre-fix code by temporarily reverting and confirming the exact same panic reproduces (`deployments[0].Workspace()`, nil pointer, matching the production stack trace) before restoring the fix:
- `TestX_Fetch_NotFoundFirstElementDoesNotPanic` — a batch of `[missingID, realID]` returns `[nil, realDeployment]` without panicking, and the permission check uses the real one's workspace.
- `TestX_Fetch_AllNotFound_UsesNoWorkspacePermissionPath` — an all-missing batch takes the zero-workspace permission path, not a crash.

## Screenshot

N/A — backend only.

## Which point I want you to review particularly

This is a live incident fix — please prioritize review. The nil-scan fallback is mechanical and low-risk, but worth double-checking against the actual Cloud Run logs once this deploys: confirm the panic stops and `GetProjects`/`GetJobs`/`GetDeployments` stop 503ing.

## Memo

Root-caused via `gcloud logging read` against the `reearth-flow-api` Cloud Run service directly — the stack trace above is the real one from `reearth-oss`/`us-central1`, not reconstructed from the source.