### PR TITLE
test(api): tie the reader-denial assertion to the policy definition

### DIFF
--- a/server/api/internal/usecase/interactor/websocket_permission_test.go
+++ b/server/api/internal/usecase/interactor/websocket_permission_test.go
@@ -203,21 +203,68 @@ func TestWebsocket_ChecksTargetProjectWorkspace(t *testing.T) {
 	assertChecks(t, "DeleteDocument", rbac.ActionDelete, deleteDocument)
 }
 
-// TestWebsocket_ReaderCannotFlushToGCS is the exact regression this fix
-// closes: a reader-scoped caller must be denied FlushToGCS, the write that
-// persists live document state to storage. Before this fix, ResourceProject's
-// live Cerbos policy granted ActionAny — which FlushToGCS is gated by — to
-// role "reader" as well as writer/maintainer/owner, so a Reader could
-// silently persist writes to a document they could only view. This test
-// pins the code-side half of the fix (the action FlushToGCS requests); the
-// role→action mapping itself is enforced by the deployed Cerbos policy, not
-// by this codebase, and was independently verified against the live service.
+// rolesGrantedFor returns the roles the policy definition grants for an
+// action on a resource. It reads the same DefineResources() the Cerbos
+// policies are generated from, so a test can tie an action the interactor
+// requests to the roles that action actually admits.
+func rolesGrantedFor(t *testing.T, resource, action string) []string {
+	t.Helper()
+	for _, r := range rbac.DefineResources() {
+		if r.Resource != resource {
+			continue
+		}
+		rule, ok := r.Actions[action]
+		require.True(t, ok, "resource %q declares no rule for action %q; Cerbos denies unruled actions for everyone", resource, action)
+		return rule.Roles
+	}
+	t.Fatalf("resource %q is not declared in DefineResources", resource)
+	return nil
+}
+
+// TestWebsocket_ReaderCannotFlushToGCS is the regression this fix closes.
+// FlushToGCS persists live document state to storage, so a reader-scoped
+// caller must not be able to invoke it. Previously ResourceProject granted
+// ActionAny — which FlushToGCS is gated by — to "reader" alongside
+// writer/maintainer/owner, so a Reader could silently persist writes to a
+// document they could only view.
+//
+// This closes the loop rather than asserting half of it: it captures the
+// action FlushToGCS actually requests, then looks that action up in the
+// policy definition and asserts "reader" is not among its roles. Asserting
+// only the requested action would still pass if the policy re-granted it to
+// readers, which is precisely the bug that shipped.
 func TestWebsocket_ReaderCannotFlushToGCS(t *testing.T) {
 	i, client, rc, docID, _ := wsFixture(t, true)
 	require.NoError(t, i.FlushToGCS(context.Background(), docID))
-	assert.Equal(t, rbac.ActionAny, rc.gotAction, "FlushToGCS must request an action whose live policy excludes reader")
-	assert.NotEqual(t, rbac.ActionRead, rc.gotAction, "ActionRead is reader-inclusive by design; FlushToGCS must never use it")
-	assert.Equal(t, 1, client.calls)
+	require.Equal(t, 1, client.calls)
+
+	roles := rolesGrantedFor(t, rbac.ResourceProject, rc.gotAction)
+	assert.NotContains(t, roles, "reader",
+		"FlushToGCS is a write; it requests %q on %s, which must not be granted to reader",
+		rc.gotAction, rbac.ResourceProject)
+	assert.Contains(t, roles, "writer",
+		"writers must still be able to save; FlushToGCS requests %q", rc.gotAction)
+}
+
+// TestWebsocket_ReadOnlyCallsUseAReaderInclusiveAction is the counterpart:
+// the read-only document calls must request an action readers *are* granted,
+// otherwise fixing the write hole would silently take view access away.
+func TestWebsocket_ReadOnlyCallsUseAReaderInclusiveAction(t *testing.T) {
+	for name, call := range map[string]func(context.Context, *Websocket, string) error{
+		"GetLatest":          getLatest,
+		"GetHistory":         getHistory,
+		"GetHistoryMetadata": getHistoryMetadata,
+		"GetNamedSnapshots":  getNamedSnapshots,
+		"GetSnapshotState":   getSnapshotState,
+	} {
+		t.Run(name, func(t *testing.T) {
+			i, _, rc, docID, _ := wsFixture(t, true)
+			require.NoError(t, call(context.Background(), i, docID))
+			roles := rolesGrantedFor(t, rbac.ResourceProject, rc.gotAction)
+			assert.Contains(t, roles, "reader",
+				"%s is read-only; it requests %q, which readers must be granted", name, rc.gotAction)
+		})
+	}
 }
 
 // TestWebsocket_UnresolvableProjectIsDenied: authorization depends on resolving


### PR DESCRIPTION
# Overview

Follow-up to #2402. A reviewer correctly pointed out that `TestWebsocket_ReaderCannotFlushToGCS` — the regression test named for that fix — never actually exercised a reader.

It asserted only *which action* `FlushToGCS` requests, using `recordingChecker`, which has no concept of roles and unconditionally allows. So despite its name it proved nothing about readers, and would have stayed green if the policy re-granted that action to readers — which is precisely the bug it existed to pin. For a security regression test that is a real liability: the test list implies reader-denial is covered when it wasn't.

## What I've done

Closed the loop rather than just renaming it to an action-routing test. The missing link turned out to be cheap to add in pure Go, with no Cerbos process needed: the test now captures the action `FlushToGCS` actually requests, looks that action up in `rbac.DefineResources()` — the same input the Cerbos policies are generated from — and asserts `reader` is absent from its role list and `writer` present.

Added `TestWebsocket_ReadOnlyCallsUseAReaderInclusiveAction` as the counterpart: the read-only document calls must request an action readers *are* granted, so closing the write hole can't silently take view access away. That direction was previously unguarded too.

Both go through a small `rolesGrantedFor` helper, which also fails loudly if a resource declares no rule for an action — Cerbos denies unruled actions for everyone, so that is worth catching in a unit test rather than in production.

## What I haven't done

No production behaviour change — this is tests only. The policy and interactor fix already shipped in #2402 and is live.

Didn't reach for a full Cerbos-in-the-loop integration test. It would be the most faithful check, but it needs a running Cerbos and a policy build, which is a different (and much heavier) shape than the rest of this package's tests. Asserting against `DefineResources()` catches the same class of regression at unit-test cost, since that is the single source the deployed policies are generated from. Worth revisiting if policy logic ever grows conditions that can't be read off the role lists.

## How I tested

`gofmt` · `go build ./...` · `go vet ./...` · `golangci-lint run --new-from-rev=origin/main` (v2.11.4, 0 issues) · `go test ./internal/... ./pkg/... -race` → 736 passed across 60 packages.

Confirmed the new test actually catches the original bug by reintroducing it — adding `roleReader` back into `ResourceProject`'s `ActionAny` — and re-running:

```
--- FAIL: TestWebsocket_ReaderCannotFlushToGCS
    []string{"reader", "writer", "owner", "maintainer"} should not contain "reader"
    FlushToGCS is a write; it requests "any" on project, which must not be granted to reader
```

The previous version of the test passed under that exact condition, which is the whole point of this change. Restored afterwards and confirmed green.

## Screenshot

N/A — tests only.

## Which point I want you to review particularly

Whether asserting against `DefineResources()` is the right altitude, or whether you'd rather see a real Cerbos evaluation in CI. `ci-policies` already spins up a real `cerbos compile`, so there is a plausible home for a policy-evaluation test if you want the stronger guarantee.

## Memo

Unchanged from #2402 and still worth a policy owner's eyes: `ResourceProjectDocument` is declared but has never been published to the live policy store. The next run of the deployment workflow will publish it for the first time, since the generator emits it. It is inert — nothing checks `flow:projectDocument` — but at that point the comment in `websocket.go` explaining why it avoids that resource stops being accurate.
