### PR TITLE
fix(api): enforce the caller's workspace role on permission checks

### DIFF
--- a/server/api/internal/infrastructure/permission/checker.go
+++ b/server/api/internal/infrastructure/permission/checker.go
@@ -47,7 +47,17 @@ func (c *checker) CheckPermission(ctx context.Context, resource string, action s
 	if err != nil {
 		return false, err
 	}
-	return result.Allowed, nil
+	if !result.Allowed {
+		return false, nil
+	}
+
+	if len(workspaceID) > 0 {
+		wsID := workspaceID[0]
+		if !wsID.IsNil() && !c.workspaceRoleAllows(ctx, resource, action, wsID) {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 // resolveAlias returns the workspace alias for wsID. The accounts client returns a

--- a/server/api/internal/infrastructure/permission/workspace_role.go
+++ b/server/api/internal/infrastructure/permission/workspace_role.go
@@ -1,0 +1,72 @@
+package permission
+
+import (
+	"context"
+
+	accountsid "github.com/reearth/reearth-accounts/server/pkg/id"
+	"github.com/reearth/reearth-flow/api/internal/adapter"
+	"github.com/reearth/reearth-flow/api/internal/rbac"
+	"github.com/reearth/reearthx/log"
+)
+
+// selfRole is granted to any authenticated member acting on their own behalf,
+// so a rule naming it is satisfied by any member regardless of workspace role.
+const selfRole = "self"
+
+// roleAllows reports whether a caller holding workspaceRole in the target
+// workspace satisfies the policy rule for resource/action.
+//
+// It reads the same rbac.DefineResources() the Cerbos policies are generated
+// from, and evaluates the principal the accounts service will send once the
+// stale global roles are stripped: the workspace role plus self, with no
+// global roles unioned in.
+func roleAllows(resource, action, workspaceRole string) bool {
+	for _, r := range rbac.DefineResources() {
+		if r.Resource != resource {
+			continue
+		}
+		rule, ok := r.Actions[action]
+		if !ok {
+			return false // an action with no rule is denied for everyone
+		}
+		for _, granted := range rule.Roles {
+			if granted == selfRole || granted == workspaceRole {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
+// workspaceRoleAllows re-evaluates resource/action against the caller's role in
+// wsID alone. It can only deny: callers reach it having already been allowed by
+// Cerbos, and it exists because the accounts service still unions each user's
+// stale global roles into every check, so a workspace reader can arrive at
+// Cerbos carrying maintainer or owner.
+//
+// TODO: remove once reearth-accounts#266 strips the stale global roles, after
+// which Cerbos alone returns this same answer.
+func (c *checker) workspaceRoleAllows(ctx context.Context, resource, action string, wsID accountsid.WorkspaceID) bool {
+	u := adapter.User(ctx)
+	if u == nil {
+		return true // no user principal (integration, API trigger): not a workspace member, leave to Cerbos
+	}
+
+	ws, err := c.workspaceRepo.FindByID(ctx, wsID.String())
+	if err != nil || ws == nil || ws.Members() == nil {
+		return true // cannot determine the role; keep the Cerbos verdict rather than deny a real user
+	}
+
+	role := string(ws.Members().UserRole(accountsid.UserID(u.ID())))
+	if role == "" {
+		log.Warnfc(ctx, "permission: caller is not a member of workspace %s; denying %s/%s", wsID, resource, action)
+		return false
+	}
+
+	if !roleAllows(resource, action, role) {
+		log.Warnfc(ctx, "permission: workspace role %q does not allow %s/%s in workspace %s", role, resource, action, wsID)
+		return false
+	}
+	return true
+}

--- a/server/api/internal/infrastructure/permission/workspace_role_test.go
+++ b/server/api/internal/infrastructure/permission/workspace_role_test.go
@@ -1,0 +1,102 @@
+package permission
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearth-accounts/server/pkg/gqlclient/cerbos"
+	accountsid "github.com/reearth/reearth-accounts/server/pkg/id"
+	"github.com/reearth/reearth-accounts/server/pkg/role"
+	accountsuser "github.com/reearth/reearth-accounts/server/pkg/user"
+	"github.com/reearth/reearth-accounts/server/pkg/workspace"
+	"github.com/reearth/reearth-flow/api/internal/adapter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// wsWithMember builds a workspace where u holds r, and a context carrying u.
+func wsWithMember(t *testing.T, r role.RoleType) (*workspace.Workspace, context.Context, accountsid.UserID) {
+	t.Helper()
+	u := accountsuser.New().NewID().Name("u").Email("u@example.com").MustBuild()
+	uid := accountsid.UserID(u.ID())
+	ws := workspace.New().NewID().Alias("acme").
+		Members(map[workspace.UserID]workspace.Member{uid: {Role: r}}).
+		MustBuild()
+	return ws, adapter.AttachUser(context.Background(), u), uid
+}
+
+// TestChecker_ReaderDeniedEvenWhenCerbosAllows is the regression this guard
+// exists for: accounts unions each user's stale global roles into every check,
+// so a workspace reader can arrive at Cerbos carrying maintainer and be
+// allowed. The workspace role must still decide.
+func TestChecker_ReaderDeniedEvenWhenCerbosAllows(t *testing.T) {
+	ws, ctx, _ := wsWithMember(t, role.RoleReader)
+	cer := &fakeCerbosRepo{result: &cerbos.CheckPermissionResult{Allowed: true}}
+	c := NewChecker(cer, &fakeWorkspaceRepo{ws: ws}, "flow")
+
+	allowed, err := c.CheckPermission(ctx, "deployment", "any", ws.ID())
+
+	require.NoError(t, err)
+	assert.False(t, allowed, "a workspace reader must not get deployment/any, whatever Cerbos said")
+}
+
+func TestChecker_ReaderStillAllowedOnReadOnlyActions(t *testing.T) {
+	ws, ctx, _ := wsWithMember(t, role.RoleReader)
+	cer := &fakeCerbosRepo{result: &cerbos.CheckPermissionResult{Allowed: true}}
+	c := NewChecker(cer, &fakeWorkspaceRepo{ws: ws}, "flow")
+
+	allowed, err := c.CheckPermission(ctx, "project", "read", ws.ID())
+
+	require.NoError(t, err)
+	assert.True(t, allowed, "readers must keep the access the policy grants them")
+}
+
+func TestChecker_WriterAllowedOnContentActions(t *testing.T) {
+	ws, ctx, _ := wsWithMember(t, role.RoleWriter)
+	cer := &fakeCerbosRepo{result: &cerbos.CheckPermissionResult{Allowed: true}}
+	c := NewChecker(cer, &fakeWorkspaceRepo{ws: ws}, "flow")
+
+	allowed, err := c.CheckPermission(ctx, "deployment", "any", ws.ID())
+
+	require.NoError(t, err)
+	assert.True(t, allowed)
+}
+
+func TestChecker_NonMemberDenied(t *testing.T) {
+	_, ctx, _ := wsWithMember(t, role.RoleOwner)
+	other := workspace.New().NewID().Alias("other").
+		Members(map[workspace.UserID]workspace.Member{accountsid.NewUserID(): {Role: role.RoleOwner}}).
+		MustBuild()
+	cer := &fakeCerbosRepo{result: &cerbos.CheckPermissionResult{Allowed: true}}
+	c := NewChecker(cer, &fakeWorkspaceRepo{ws: other}, "flow")
+
+	allowed, err := c.CheckPermission(ctx, "deployment", "any", other.ID())
+
+	require.NoError(t, err)
+	assert.False(t, allowed, "a non-member must be denied even if Cerbos allowed")
+}
+
+// TestChecker_NoUserPrincipalKeepsCerbosVerdict: API triggers and integrations
+// run without a user and are not workspace members, so the guard must not
+// deny them.
+func TestChecker_NoUserPrincipalKeepsCerbosVerdict(t *testing.T) {
+	ws, _, _ := wsWithMember(t, role.RoleReader)
+	cer := &fakeCerbosRepo{result: &cerbos.CheckPermissionResult{Allowed: true}}
+	c := NewChecker(cer, &fakeWorkspaceRepo{ws: ws}, "flow")
+
+	allowed, err := c.CheckPermission(context.Background(), "deployment", "any", ws.ID())
+
+	require.NoError(t, err)
+	assert.True(t, allowed)
+}
+
+func TestChecker_DeniedByCerbosStaysDenied(t *testing.T) {
+	ws, ctx, _ := wsWithMember(t, role.RoleOwner)
+	cer := &fakeCerbosRepo{result: &cerbos.CheckPermissionResult{Allowed: false}}
+	c := NewChecker(cer, &fakeWorkspaceRepo{ws: ws}, "flow")
+
+	allowed, err := c.CheckPermission(ctx, "deployment", "any", ws.ID())
+
+	require.NoError(t, err)
+	assert.False(t, allowed, "the guard can only deny; it must never turn a Cerbos deny into an allow")
+}


### PR DESCRIPTION
# Overview

A workspace **reader can perform writer/maintainer operations**. The accounts service unions each user's global `roleids` into every Cerbos check, and a legacy migration left a stale global `maintainer` on most accounts — so a reader reaches Cerbos as `[maintainer owner self]` and is allowed. Confirmed in the oss env: 400 permission checks over 24h, **zero denials**.

The real fix is [reearth-accounts#266](https://github.com/reearth/reearth-accounts/issues/266) (strip the stale globals), but that rewrites shared `permittable` records and would mass-deny CMS and accounts-internal users, which still rely on global roles. This is the Flow-side mitigation until then.

## What I've done

After Cerbos allows, re-evaluate resource/action against the caller's workspace role alone. It reads the same `DefineResources()` the policies are generated from and evaluates the principal accounts will send once the globals are stripped — so it returns the answer Cerbos itself will give post-#266, and becomes redundant rather than wrong at that point.

The workspace role comes from `WorkspaceRepo.FindByID`, which already returns `members` with roles, so there's no extra call.

## What I haven't done

- **No accounts change.** Nothing shared is touched; dashboard, CMS and visualizer are unaffected.
- **Only covers checks that pass a workspace.** `worker_config`, CMS reads and the empty-batch guards send no workspace and still resolve on global roles.
- **No caching of the role**, deliberately — the alias cache's 5 min TTL would delay a role downgrade by that long.

## How I tested

`gofmt` · `go build ./...` · `go vet ./...` · `golangci-lint --new-from-rev=origin/main` (0 issues) · `go test ./internal/... ./pkg/... -race` → 34 packages green.

Six new cases: a reader is denied `deployment/any` despite Cerbos allowing; a reader keeps `project/read`; a writer keeps `deployment/any`; a non-member is denied; a Cerbos deny is never turned into an allow; and a request with no user principal keeps the Cerbos verdict.

## Screenshot

N/A — backend only.

## Which point I want you to review particularly

The two deliberate fall-throughs, since they are where this stays permissive: no user principal (API triggers, integrations — not workspace members) and unresolvable membership. Both keep today's behaviour rather than deny, so nothing currently working breaks. If you'd rather they fail closed, that's a one-line change but needs a look at API-trigger traffic first.

## Memo

`TODO` on `workspaceRoleAllows` marks this for removal once #266 lands.
