### PR TITLE
fix(api): make the workspace-role guard's blind spots visible and safe

### DIFF
--- a/server/api/internal/infrastructure/permission/workspace_role.go
+++ b/server/api/internal/infrastructure/permission/workspace_role.go
@@ -64,8 +64,12 @@ func (c *checker) workspaceRoleAllows(ctx context.Context, resource, action stri
 	// No membership at all is a data problem, not an answer: every caller would
 	// be denied. Distinguish it from a populated list the caller is absent
 	// from, which is a real non-member and a real deny.
+	if ws == nil {
+		log.Warnfc(ctx, "permission: workspace %s not found, skipping the workspace-role guard for %s/%s", wsID, resource, action)
+		return true
+	}
 	members := ws.Members()
-	if ws == nil || members == nil || members.Count() == 0 {
+	if members == nil || members.Count() == 0 {
 		log.Warnfc(ctx, "permission: workspace %s has no membership data, skipping the workspace-role guard for %s/%s", wsID, resource, action)
 		return true
 	}

--- a/server/api/internal/infrastructure/permission/workspace_role.go
+++ b/server/api/internal/infrastructure/permission/workspace_role.go
@@ -53,12 +53,24 @@ func (c *checker) workspaceRoleAllows(ctx context.Context, resource, action stri
 		return true // no user principal (integration, API trigger): not a workspace member, leave to Cerbos
 	}
 
+	// Cannot determine the role: keep the Cerbos verdict rather than deny a real
+	// user. Logged because this is the guard's blind spot — a spike here means
+	// it is silently not running, so it needs to be visible in production.
 	ws, err := c.workspaceRepo.FindByID(ctx, wsID.String())
-	if err != nil || ws == nil || ws.Members() == nil {
-		return true // cannot determine the role; keep the Cerbos verdict rather than deny a real user
+	if err != nil {
+		log.Warnfc(ctx, "permission: workspace %s lookup failed, skipping the workspace-role guard for %s/%s: %v", wsID, resource, action, err)
+		return true
+	}
+	// No membership at all is a data problem, not an answer: every caller would
+	// be denied. Distinguish it from a populated list the caller is absent
+	// from, which is a real non-member and a real deny.
+	members := ws.Members()
+	if ws == nil || members == nil || members.Count() == 0 {
+		log.Warnfc(ctx, "permission: workspace %s has no membership data, skipping the workspace-role guard for %s/%s", wsID, resource, action)
+		return true
 	}
 
-	role := string(ws.Members().UserRole(accountsid.UserID(u.ID())))
+	role := string(members.UserRole(accountsid.UserID(u.ID())))
 	if role == "" {
 		log.Warnfc(ctx, "permission: caller is not a member of workspace %s; denying %s/%s", wsID, resource, action)
 		return false

--- a/server/api/internal/infrastructure/permission/workspace_role_test.go
+++ b/server/api/internal/infrastructure/permission/workspace_role_test.go
@@ -2,6 +2,7 @@ package permission
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/reearth/reearth-accounts/server/pkg/gqlclient/cerbos"
@@ -99,4 +100,35 @@ func TestChecker_DeniedByCerbosStaysDenied(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.False(t, allowed, "the guard can only deny; it must never turn a Cerbos deny into an allow")
+}
+
+// The guard has three deliberate fall-throughs where it cannot determine the
+// caller's role and keeps the Cerbos verdict rather than denying a real user.
+// They are pinned so switching any of them to fail-closed is a conscious
+// change rather than an accident, since each one is a hole while it lasts.
+
+func TestChecker_WorkspaceLookupErrorKeepsCerbosVerdict(t *testing.T) {
+	_, ctx, _ := wsWithMember(t, role.RoleReader)
+	cer := &fakeCerbosRepo{result: &cerbos.CheckPermissionResult{Allowed: true}}
+	c := NewChecker(cer, &fakeWorkspaceRepo{err: errors.New("accounts unavailable")}, "flow")
+
+	allowed, err := c.CheckPermission(ctx, "deployment", "any", accountsid.NewWorkspaceID())
+
+	// resolveAlias surfaces the lookup failure first and fails closed.
+	assert.Error(t, err)
+	assert.False(t, allowed)
+}
+
+// An empty membership list means accounts returned no members at all, which
+// would otherwise deny every caller for that workspace.
+func TestChecker_EmptyMembershipKeepsCerbosVerdict(t *testing.T) {
+	_, ctx, _ := wsWithMember(t, role.RoleReader)
+	noMembers := workspace.New().NewID().Alias("acme").MustBuild()
+	cer := &fakeCerbosRepo{result: &cerbos.CheckPermissionResult{Allowed: true}}
+	c := NewChecker(cer, &fakeWorkspaceRepo{ws: noMembers}, "flow")
+
+	allowed, err := c.CheckPermission(ctx, "deployment", "any", noMembers.ID())
+
+	require.NoError(t, err)
+	assert.True(t, allowed, "with no membership data the guard must not deny a real user")
 }

--- a/server/api/internal/infrastructure/permission/workspace_role_test.go
+++ b/server/api/internal/infrastructure/permission/workspace_role_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"testing"
 
+	gqlworkspace "github.com/reearth/reearth-accounts/server/pkg/gqlclient/workspace"
+
 	"github.com/reearth/reearth-accounts/server/pkg/gqlclient/cerbos"
 	accountsid "github.com/reearth/reearth-accounts/server/pkg/id"
 	"github.com/reearth/reearth-accounts/server/pkg/role"
@@ -107,16 +109,68 @@ func TestChecker_DeniedByCerbosStaysDenied(t *testing.T) {
 // They are pinned so switching any of them to fail-closed is a conscious
 // change rather than an accident, since each one is a hole while it lasts.
 
-func TestChecker_WorkspaceLookupErrorKeepsCerbosVerdict(t *testing.T) {
-	_, ctx, _ := wsWithMember(t, role.RoleReader)
+// sequencedWorkspaceRepo returns a different result per FindByID call, so a
+// test can let the alias lookup succeed and fail the guard's membership
+// lookup that follows it.
+type sequencedWorkspaceRepo struct {
+	gqlworkspace.WorkspaceRepo
+	results []struct {
+		ws  *workspace.Workspace
+		err error
+	}
+	calls int
+}
+
+func (r *sequencedWorkspaceRepo) FindByID(_ context.Context, _ string) (*workspace.Workspace, error) {
+	i := r.calls
+	r.calls++
+	if i >= len(r.results) {
+		i = len(r.results) - 1
+	}
+	return r.results[i].ws, r.results[i].err
+}
+
+// TestChecker_MembershipLookupErrorKeepsCerbosVerdict pins the guard's
+// lookup-error fall-through. The alias lookup must succeed first, otherwise
+// resolveAlias fails closed and the guard is never reached.
+func TestChecker_MembershipLookupErrorKeepsCerbosVerdict(t *testing.T) {
+	ws, ctx, _ := wsWithMember(t, role.RoleReader)
+	repo := &sequencedWorkspaceRepo{results: []struct {
+		ws  *workspace.Workspace
+		err error
+	}{
+		{ws: ws}, // resolveAlias
+		{err: errors.New("accounts unavailable")}, // the guard's membership lookup
+	}}
 	cer := &fakeCerbosRepo{result: &cerbos.CheckPermissionResult{Allowed: true}}
-	c := NewChecker(cer, &fakeWorkspaceRepo{err: errors.New("accounts unavailable")}, "flow")
+	c := NewChecker(cer, repo, "flow")
 
-	allowed, err := c.CheckPermission(ctx, "deployment", "any", accountsid.NewWorkspaceID())
+	allowed, err := c.CheckPermission(ctx, "deployment", "any", ws.ID())
 
-	// resolveAlias surfaces the lookup failure first and fails closed.
-	assert.Error(t, err)
-	assert.False(t, allowed)
+	require.NoError(t, err)
+	assert.True(t, allowed, "an unavailable membership lookup must not deny a real user")
+	assert.Equal(t, 2, repo.calls, "the guard must make its own membership lookup after the alias resolves")
+}
+
+// TestChecker_NilWorkspaceKeepsCerbosVerdict: FindByID may return (nil, nil).
+// Reading Members() off that would panic.
+func TestChecker_NilWorkspaceKeepsCerbosVerdict(t *testing.T) {
+	ws, ctx, _ := wsWithMember(t, role.RoleReader)
+	repo := &sequencedWorkspaceRepo{results: []struct {
+		ws  *workspace.Workspace
+		err error
+	}{
+		{ws: ws},  // resolveAlias
+		{ws: nil}, // the guard's membership lookup finds nothing
+	}}
+	cer := &fakeCerbosRepo{result: &cerbos.CheckPermissionResult{Allowed: true}}
+	c := NewChecker(cer, repo, "flow")
+
+	require.NotPanics(t, func() {
+		allowed, err := c.CheckPermission(ctx, "deployment", "any", ws.ID())
+		require.NoError(t, err)
+		assert.True(t, allowed)
+	})
 }
 
 // An empty membership list means accounts returned no members at all, which


### PR DESCRIPTION
# Overview

Follow-up to #2406, from review feedback: the workspace-role guard falls through to the Cerbos verdict whenever it cannot determine the caller's role, and did so silently. That is deliberate — denying a real user on a transient accounts failure would be worse — but it means the guard can stop running with nothing in the logs to say so.

## What I've done

Log a warning on each fall-through, so a spike is visible rather than invisible.

Writing the tests for those branches surfaced a worse problem, which is the real content of this PR. **A workspace with no membership data did not take the fall-through.** `Members()` comes back empty rather than nil, so `UserRole` returns `""`, which the guard read as "not a member" and denied. If accounts ever returned a workspace without members populated, every caller would have been locked out of it — the guard's failure mode was an outage, not a bypass.

Empty membership is now treated as undeterminable and falls through. Only a populated list the caller is absent from is a genuine non-member deny.

## What I haven't done

Didn't make the fall-throughs fail closed. Each is a hole while it lasts, but denying real users on a transient upstream failure is the worse trade for a mitigation that exists only until [reearth-accounts#266](https://github.com/reearth/reearth-accounts/issues/266) lands. The warnings make the choice observable; if the logs show it firing in normal operation, that changes the answer.

## How I tested

`gofmt` · `go build ./...` · `go vet ./...` · `golangci-lint --new-from-rev=origin/main` (0 issues) · `go test ./internal/... ./pkg/... -race` — green.

Both fall-throughs are now pinned: a lookup error, and empty membership. The empty-membership test is the one that caught the deny-everyone bug — it failed against the previous implementation, which is how the bug was found.

## Screenshot

N/A — backend only.

## Which point I want you to review particularly

Whether empty membership should really fall through. It is the safe default, but it is also indistinguishable from a workspace that genuinely has no members. I could not confirm from production data that membership is always populated for the workspaces Flow queries, which is exactly why I did not make it deny.

## Memo

Removed together with the guard once #266 lands.
