### PR TITLE
fix(api): let readers and writers trigger a debug run

### DIFF
--- a/server/api/internal/usecase/interactor/project.go
+++ b/server/api/internal/usecase/interactor/project.go
@@ -243,9 +243,10 @@ func (i *Project) Run(ctx context.Context, p interfaces.RunProjectParam) (_ *job
 	if proj == nil {
 		return nil, rerror.ErrNotFound
 	}
-	// A debug run exercises the project without changing it. ActionAny is
-	// writer/maintainer/owner, where ActionEdit excludes writers.
-	if err := i.checkPermission(ctx, rbac.ActionAny, proj.Workspace()); err != nil {
+	// A debug run executes the project without changing it, so anyone who can
+	// see the project may run one. ActionRead is the only rule carrying
+	// reader; ActionAny is writer and above, ActionEdit maintainer and above.
+	if err := i.checkPermission(ctx, rbac.ActionRead, proj.Workspace()); err != nil {
 		return nil, err
 	}
 

--- a/server/api/internal/usecase/interactor/project.go
+++ b/server/api/internal/usecase/interactor/project.go
@@ -243,7 +243,9 @@ func (i *Project) Run(ctx context.Context, p interfaces.RunProjectParam) (_ *job
 	if proj == nil {
 		return nil, rerror.ErrNotFound
 	}
-	if err := i.checkPermission(ctx, rbac.ActionEdit, proj.Workspace()); err != nil {
+	// A debug run exercises the project without changing it. ActionAny is
+	// writer/maintainer/owner, where ActionEdit excludes writers.
+	if err := i.checkPermission(ctx, rbac.ActionAny, proj.Workspace()); err != nil {
 		return nil, err
 	}
 

--- a/server/api/internal/usecase/interactor/project_run_permission_test.go
+++ b/server/api/internal/usecase/interactor/project_run_permission_test.go
@@ -1,0 +1,35 @@
+package interactor
+
+import (
+	"testing"
+
+	"github.com/reearth/reearth-flow/api/internal/rbac"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProjectRunActionAdmitsWriters pins the role boundary for a debug run.
+// Project.Run authorizes with ActionAny; gating it on ActionEdit instead
+// (maintainer/owner) is what stopped writers running the editor's debug run.
+//
+// This asserts against DefineResources(), the same input the Cerbos policies
+// are generated from, so it fails if the roles for that action are narrowed.
+func TestProjectRunActionAdmitsWriters(t *testing.T) {
+	var runRoles, editRoles []string
+	for _, r := range rbac.DefineResources() {
+		if r.Resource != rbac.ResourceProject {
+			continue
+		}
+		runRoles = r.Actions[rbac.ActionAny].Roles
+		editRoles = r.Actions[rbac.ActionEdit].Roles
+	}
+	require.NotEmpty(t, runRoles, "ResourceProject must declare the action Run authorizes with")
+
+	assert.Contains(t, runRoles, "writer", "writers must be able to trigger a debug run")
+	assert.Contains(t, runRoles, "maintainer")
+	assert.Contains(t, runRoles, "owner")
+	assert.NotContains(t, runRoles, "reader", "a debug run executes the workflow; readers are not granted it")
+
+	assert.NotContains(t, editRoles, "writer",
+		"ActionEdit stays maintainer/owner: if it ever admits writers, Run should move back to it")
+}

--- a/server/api/internal/usecase/interactor/project_run_permission_test.go
+++ b/server/api/internal/usecase/interactor/project_run_permission_test.go
@@ -8,28 +8,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestProjectRunActionAdmitsWriters pins the role boundary for a debug run.
-// Project.Run authorizes with ActionAny; gating it on ActionEdit instead
-// (maintainer/owner) is what stopped writers running the editor's debug run.
+// TestProjectRunActionAdmitsReadersAndWriters pins the role boundary for a
+// debug run. Project.Run authorizes with ActionRead; gating it on ActionEdit
+// (maintainer/owner) or ActionAny (writer and above) excludes the roles that
+// are meant to be able to run one.
 //
 // This asserts against DefineResources(), the same input the Cerbos policies
 // are generated from, so it fails if the roles for that action are narrowed.
-func TestProjectRunActionAdmitsWriters(t *testing.T) {
-	var runRoles, editRoles []string
+func TestProjectRunActionAdmitsReadersAndWriters(t *testing.T) {
+	var runRoles, anyRoles []string
 	for _, r := range rbac.DefineResources() {
 		if r.Resource != rbac.ResourceProject {
 			continue
 		}
-		runRoles = r.Actions[rbac.ActionAny].Roles
-		editRoles = r.Actions[rbac.ActionEdit].Roles
+		runRoles = r.Actions[rbac.ActionRead].Roles
+		anyRoles = r.Actions[rbac.ActionAny].Roles
 	}
 	require.NotEmpty(t, runRoles, "ResourceProject must declare the action Run authorizes with")
 
-	assert.Contains(t, runRoles, "writer", "writers must be able to trigger a debug run")
-	assert.Contains(t, runRoles, "maintainer")
-	assert.Contains(t, runRoles, "owner")
-	assert.NotContains(t, runRoles, "reader", "a debug run executes the workflow; readers are not granted it")
+	for _, want := range []string{"reader", "writer", "maintainer", "owner"} {
+		assert.Contains(t, runRoles, want, "%s must be able to trigger a debug run", want)
+	}
 
-	assert.NotContains(t, editRoles, "writer",
-		"ActionEdit stays maintainer/owner: if it ever admits writers, Run should move back to it")
+	// Run cannot sit on ActionAny: that rule deliberately excludes reader
+	// because it also gates the editor's save.
+	assert.NotContains(t, anyRoles, "reader",
+		"ActionAny gates FlushToGCS; adding reader there would let readers persist writes")
 }


### PR DESCRIPTION
# Overview

Readers and writers cannot trigger a debug run. `Project.Run` backs the editor's debug run (`ui/src/features/Editor/useDebugRun.ts` → `runProject`) and authorizes with `ActionEdit`, which is maintainer/owner only.

## What I've done

Authorize with `ActionRead` instead — reader, writer, maintainer, owner.

**No policy change, so nothing to redeploy to Cerbos.** `ActionRead` on `ResourceProject` already carries exactly those four roles.

It cannot sit on `ActionAny`: that rule is writer and above, and it deliberately excludes reader because it also gates `FlushToGCS`, the editor's save. Putting reader there would reopen the hole #2402 closed.

## What I haven't done

**No dedicated `run` action**, which would model this better and let run permissions change independently of read. The Build Cerbos Policies workflow generates from the default branch, so a new action can only be published *after* this merges — leaving a window where `flow:project/run` has no rule and Cerbos denies it for everyone, owners included. Doing it safely means a separate PR adding the rule, a policy sync, then the code change. Worth doing if run and read should ever diverge; not worth an outage window today.

`PreviewSchema` still uses `ActionEdit`, so readers and writers cannot preview a schema. It is the sibling operation in the same editor flow and also runs with `debug = true` internally — likely the same report one step later. Left alone because widening a permission that was not asked for should be a deliberate call.

## How I tested

`gofmt` · `go build ./...` · `go vet ./...` · `golangci-lint --new-from-rev=origin/main` (0 issues) · `go test ./internal/... ./pkg/... -race` — 34 packages green.

`TestProjectRunActionAdmitsReadersAndWriters` pins the role boundary against `DefineResources()`, the same input the Cerbos policies are generated from: the action `Run` uses must admit all four roles. It also asserts `ActionAny` still excludes reader, so a future attempt to move `Run` there fails rather than silently reopening the `FlushToGCS` hole.

## Screenshot

N/A — backend only.

## Which point I want you to review particularly

That a debug run belongs on `ActionRead`. It reads oddly for something that executes a workflow and consumes compute, and it couples the two: you can no longer let a reader view a project without also letting them run it. That is the stated intent, so it is coherent — but if you want them separable, that is the dedicated-action path above.

## Memo

Verified against the workspace-role guard, which reads the same `DefineResources()`, so a reader passes both it and Cerbos.
