### PR TITLE
chore(websocket-go): bump ygo to v1.49.1 (fixes the cutover data-loss decode bug)

### DIFF
--- a/server/websocket-go/go.mod
+++ b/server/websocket-go/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fsouza/fake-gcs-server v1.54.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/redis/go-redis/v9 v9.20.0
-	github.com/reearth/ygo v1.41.0
+	github.com/reearth/ygo v1.49.1
 	go.opentelemetry.io/contrib/detectors/gcp v1.43.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/otel v1.44.0

--- a/server/websocket-go/go.sum
+++ b/server/websocket-go/go.sum
@@ -149,8 +149,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/redis/go-redis/v9 v9.20.0 h1:WnQYxLkgO2xiXTCJY0ldIiI8dNqCDlQAG+AtaH7a2a0=
 github.com/redis/go-redis/v9 v9.20.0/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3baQf57KlIkA=
-github.com/reearth/ygo v1.41.0 h1:ouSMKGQauXI3a0wBwHR7Z0VWdg4DHg2qYcug4Mmc28g=
-github.com/reearth/ygo v1.41.0/go.mod h1:QN5MsM+QBk9cP6Sr/iaKlkJtnJ9Fo0fT+MJqSw2xPUA=
+github.com/reearth/ygo v1.49.1 h1:BPC/lUHOJoo9n8vM2/WdZR87yOj7iXyvpzZOvZErscU=
+github.com/reearth/ygo v1.49.1/go.mod h1:QN5MsM+QBk9cP6Sr/iaKlkJtnJ9Fo0fT+MJqSw2xPUA=
 github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=


### PR DESCRIPTION
Bumps `server/websocket-go` from ygo v1.41.0 to **v1.49.1**.

Refs #2412. This is the library half of the 2026-08-24 cutover incident.

## Why

Three separate data-loss fixes we were missing by sitting on v1.41.0.

### reearth/ygo#231 — `ApplyUpdateV2` silently dropped document content (fixed v1.49.1)

The cause of the incident. The V2 decoder recorded a GC struct's clock range in the delete set but never occupied that range in the client's struct list, so every later struct from that client looked like a same-client clock gap and was parked in the pending queue permanently, waiting on a predecessor that had arrived in the same self-contained update. It returned `nil` throughout, so the server treated a partially-decoded document as the room state and flushed it back over the original.

The trigger is GC structs, which appear once a document has deletion history. Measured on **94 real `yrs`-written production documents**:

| decoder | nodes | edges | documents disagreeing with yjs |
|---|---|---|---|
| yjs 13.6.32 (reference) | 974 | 951 | 0 |
| **ygo v1.41.0 (deployed)** | **535** | **451** | **63 of 94** |
| ygo v1.49.1 | 974 | 951 | **0** |

Re-verified against the published v1.49.1 pulled from the module proxy, not a local build.

### reearth/ygo#202 — `Server.Shutdown` discarded queued relay updates (fixed v1.46.0)

Shutdown cancelled the relay context before draining, so everything peers committed during that window vanished with `RelayStats().Dropped` and `HardDrops` both reading zero.

### reearth/ygo#229 — commits during `Shutdown` dropped by the persistence worker (fixed v1.49.0)

Affected the default configuration and every adapter. `cmd/websocket/main.go` calls `srv.WSProvider().Shutdown()` on SIGTERM, and Cloud Run stops instances routinely, so every stop was a loss window. This is the likely explanation for the reports of a single edit vanishing after a refresh.

## What this does and does not fix

It stops **future** overwrites. It does not recover the 22 already-damaged projects — those need their pre-cutover generations restored from GCS soft-delete, which hard-deletes starting **2026-08-31**. Tracked in #2412.

## Verification

- `GOWORK=off go build ./...` clean
- `GOWORK=off go test ./...` green across all ten packages
- Only `server/websocket-go/go.mod` and `go.sum` change; nothing else in the repo pins ygo
- No source changes needed — no API breaks between v1.41.0 and v1.49.1 for anything we use

## Worth knowing about the release

Two behaviour changes in the range that I checked against our usage:

- **v1.44.0** made `YMap.Set` and friends **panic** on invalid UTF-8. We only touch those APIs in two places ([rollback_signal.go:34](server/websocket-go/internal/server/rollback_signal.go), [adapter.go:326](server/websocket-go/internal/gcs/adapter.go)), both setting constant ASCII keys with a bool, so the exposure is nil. Client content arrives as decoded updates, where invalid UTF-8 was already rejected.
- **v1.45.0** made `KeepSnapshots` a per-label bound rather than per-room. It retains *more*, not less, so it cannot evict a named snapshot, but it touches the version-history feature and is worth a reviewer's eye.
