### PR TITLE
feat(engine): port the plateau4 03-tran quality check to new geometry

### DIFF
--- a/engine/runtime/action-processor/src/citygml_parser/geometry_next.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/geometry_next.rs
@@ -27,12 +27,24 @@ pub(super) struct PendingGeom {
     pub(super) lod: Option<u8>,
     pub(super) node: GeomNode,
     pub(super) owner_ids: Vec<String>,
+    /// The nearest `gml:id`-bearing ancestor: the city object owning this
+    /// geometry, which may be a nested child of the feature rather than the
+    /// feature itself.
+    pub(super) city_object: Option<CityObjectRef>,
+}
+
+/// Identifies one city object within its document.
+pub(super) struct CityObjectRef {
+    pub(super) gml_id: String,
+    /// The qualified element name, e.g. `tran:TrafficArea`.
+    pub(super) feature_type: String,
 }
 
 /// A `gml:id`-bearing ancestor, chained on the stack so the enclosing-id list is
 /// materialized only where a geometry is actually found.
 struct Owner<'a> {
     id: &'a str,
+    name: &'a str,
     parent: Option<&'a Owner<'a>>,
 }
 
@@ -68,7 +80,11 @@ impl Parser {
         owner: Option<&Owner>,
         geoms: &mut Vec<PendingGeom>,
     ) -> Arc<RawNode> {
-        let here = gml_id_ref(node).map(|id| Owner { id, parent: owner });
+        let here = gml_id_ref(node).map(|id| Owner {
+            id,
+            name: node.name.0.as_str(),
+            parent: owner,
+        });
         let owner = here.as_ref().or(owner);
         let mut new_children: Option<Vec<RawChild>> = None;
 
@@ -102,6 +118,10 @@ impl Parser {
                         lod,
                         node: gnode,
                         owner_ids,
+                        city_object: owner.map(|o| CityObjectRef {
+                            gml_id: o.id.to_string(),
+                            feature_type: o.name.to_string(),
+                        }),
                     });
                 }
                 if new_children.is_none() {

--- a/engine/runtime/action-processor/src/citygml_parser/pipeline.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/pipeline.rs
@@ -20,6 +20,15 @@ use super::{
 /// `GeometryCollection` member's source LOD (absent for a `tin`, which has none).
 pub const MEMBER_LOD_KEY: &str = "lod";
 
+/// Per-member attribute key holding the `gml:id` of the city object a geometry
+/// belongs to — the feature itself, or one of its nested city objects — so a
+/// surface split off from the feature stays attributable.
+pub const MEMBER_GEOMETRY_GML_ID_KEY: &str = "__citygml_geometry_gml_id";
+
+/// Per-member attribute key holding the feature type of the city object a
+/// geometry belongs to, the counterpart of [`MEMBER_GEOMETRY_GML_ID_KEY`].
+pub const MEMBER_GEOMETRY_FEATURE_TYPE_KEY: &str = "__citygml_geometry_feature_type";
+
 /// Resolves the parsed document (xlink + codespace) and returns one feature per top-level city
 /// object, or — when `extract_tags` is non-empty — one feature per matching flattened node.
 /// `base_attributes` maps a source file URL to the input feature's attributes (e.g. `package`),
@@ -167,7 +176,7 @@ mod build_next {
         CITYGML_ROOT_GML_ID_KEY,
     };
 
-    use super::MEMBER_LOD_KEY;
+    use super::{MEMBER_GEOMETRY_FEATURE_TYPE_KEY, MEMBER_GEOMETRY_GML_ID_KEY, MEMBER_LOD_KEY};
 
     use crate::citygml_parser::{
         appearance::{self, AppearanceIndex},
@@ -182,11 +191,11 @@ mod build_next {
     /// `extract_tags` is non-empty — one feature per matching flattened node, each with its
     /// geometry attached. Signature mirrors the legacy `build_features` so the readers share one
     /// `finish` across geometry worlds.
-    // TODO: honor `base_attributes` and `flatten_single_child_objects` in the new-geometry path.
+    // TODO: honor `flatten_single_child_objects` in the new-geometry path.
     pub fn build_features(
         parser: Parser,
         extract_tags: &HashSet<String>,
-        _base_attributes: &HashMap<String, Attributes>,
+        base_attributes: &HashMap<String, Attributes>,
         citygml_attribute_key: Option<&str>,
         keep_attributes: bool,
         _flatten_single_child_objects: bool,
@@ -209,6 +218,7 @@ mod build_next {
             &srs_by_file,
             &ns_registry,
             extract_tags,
+            base_attributes,
             citygml_attribute_key,
             keep_attributes,
             flatten_leaf_attributes,
@@ -227,6 +237,7 @@ mod build_next {
         srs_by_file: &HashMap<String, EpsgCode>,
         ns_registry: &NamespaceRegistry,
         extract_tags: &HashSet<String>,
+        base_attributes: &HashMap<String, Attributes>,
         citygml_attribute_key: Option<&str>,
         keep_attributes: bool,
         flatten_leaf_attributes: &[String],
@@ -245,6 +256,8 @@ mod build_next {
                 continue;
             };
 
+            let base = base_attributes.get(feature_root.source_url.as_str());
+
             if extract_tags.is_empty() {
                 let mut feature = parser::to_feature(
                     &feature_root,
@@ -253,6 +266,9 @@ mod build_next {
                     flatten_leaf_attributes,
                 );
                 attach_geometry(&mut feature, &geoms, geom_registry, appearance, srs_by_file);
+                if let Some(base) = base {
+                    feature.extend(base.clone());
+                }
                 out.push(feature);
             } else {
                 let root_gml_id = gml_id_attr(&feature_root.attrs);
@@ -299,6 +315,9 @@ mod build_next {
                             srs_by_file,
                         );
                     }
+                    if let Some(base) = base {
+                        feature.extend(base.clone());
+                    }
                     out.push(feature);
                 }
             }
@@ -316,7 +335,8 @@ mod build_next {
         srs_by_file: &HashMap<String, EpsgCode>,
     ) {
         // Each member records its source LOD (a `tin` has none) so downstream
-        // sinks can select a single LOD; gml:id is still TODO.
+        // sinks can select a single LOD, and its owning city object so a
+        // split-off surface stays attributable.
         let mut members: Vec<Geometry> = Vec::new();
         let mut attrs: Vec<Attributes> = Vec::new();
         for pending in geoms {
@@ -331,6 +351,16 @@ mod build_next {
                 member_attrs.insert(
                     Attribute::new(MEMBER_LOD_KEY),
                     AttributeValue::Number(lod.into()),
+                );
+            }
+            if let Some(city_object) = &pending.city_object {
+                member_attrs.insert(
+                    Attribute::new(MEMBER_GEOMETRY_GML_ID_KEY),
+                    AttributeValue::String(city_object.gml_id.clone()),
+                );
+                member_attrs.insert(
+                    Attribute::new(MEMBER_GEOMETRY_FEATURE_TYPE_KEY),
+                    AttributeValue::String(city_object.feature_type.clone()),
                 );
             }
             members.push(member);
@@ -357,6 +387,15 @@ mod build_next {
         /// Parse one CityModel wrapping `members`, then assemble features under
         /// `extract_tags` (the full pass-2 pipeline, minus forwarding).
         fn run(members: &str, extract_tags: &[&str]) -> Vec<Feature> {
+            run_with_base(members, extract_tags, &HashMap::new())
+        }
+
+        /// As [`run`], with the input feature's attributes to merge in, keyed by source URL.
+        fn run_with_base(
+            members: &str,
+            extract_tags: &[&str],
+            base_attributes: &HashMap<String, Attributes>,
+        ) -> Vec<Feature> {
             let xml = format!(
                 r#"<core:CityModel
                      xmlns:core="http://www.opengis.net/citygml/3.0"
@@ -387,6 +426,7 @@ mod build_next {
                 &srs_by_file,
                 &ns_registry,
                 &tags,
+                base_attributes,
                 None,
                 true,
                 &[],
@@ -502,6 +542,49 @@ mod build_next {
             }
             assert_single_polygon_surface(by_type(&features, "con:WallSurface"));
             assert_single_polygon_surface(by_type(&features, "con:RoofSurface"));
+        }
+
+        /// The input feature's attributes, keyed by the URL `run_with_base` parses from.
+        fn base_for_test_gml() -> HashMap<String, Attributes> {
+            let mut attrs = Attributes::new();
+            attrs.insert(
+                Attribute::new("package"),
+                AttributeValue::String("tran".into()),
+            );
+            HashMap::from([("file:///test.gml".to_string(), attrs)])
+        }
+
+        #[test]
+        fn base_attributes_merge_into_top_level_features() {
+            let members = format!(
+                "<core:cityObjectMember><bldg:Building gml:id=\"b_base\">\
+                   <core:lod0MultiSurface><gml:MultiSurface><gml:surfaceMember>{TA}</gml:surfaceMember></gml:MultiSurface></core:lod0MultiSurface>\
+                 </bldg:Building></core:cityObjectMember>"
+            );
+            let features = run_with_base(&members, &[], &base_for_test_gml());
+            assert_eq!(features.len(), 1);
+            assert_eq!(
+                features[0].get("package"),
+                Some(&AttributeValue::String("tran".into()))
+            );
+        }
+
+        #[test]
+        fn base_attributes_merge_into_hoisted_features() {
+            let members = format!(
+                "<core:cityObjectMember><bldg:Building gml:id=\"b_base2\">\
+                   <core:boundary><con:WallSurface gml:id=\"wall2\"><core:lod2MultiSurface><gml:MultiSurface><gml:surfaceMember>{TA}</gml:surfaceMember></gml:MultiSurface></core:lod2MultiSurface></con:WallSurface></core:boundary>\
+                 </bldg:Building></core:cityObjectMember>"
+            );
+            let features =
+                run_with_base(&members, &["Building", "WallSurface"], &base_for_test_gml());
+            assert_eq!(features.len(), 2);
+            for feature in &features {
+                assert_eq!(
+                    feature.get("package"),
+                    Some(&AttributeValue::String("tran".into()))
+                );
+            }
         }
     }
 }

--- a/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
+++ b/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
@@ -41,10 +41,10 @@ enum DestinationFrame {
     #[serde(rename_all = "camelCase")]
     Crs {
         /// # EPSG Code
-        /// EPSG code of the destination coordinate reference system.
-        // u16 is the width `EpsgCode` itself holds, so the generated schema states the real
-        // bound rather than a looser one that `build` would then have to re-check.
-        epsg_code: u16,
+        /// Expression evaluating to the EPSG code of the destination coordinate
+        /// reference system. Resolved once when the node is built, so only
+        /// `variables` is in scope.
+        epsg_code: Code<{ CodeType::FlowExpr as u32 }>,
     },
     /// # Euclidean
     /// Convert to a non-georeferenced Euclidean frame. This is the frame the
@@ -138,7 +138,7 @@ impl ProcessorFactory for CoordinateFrameReprojectorFactory {
 
     fn build(
         &self,
-        _ctx: NodeContext,
+        ctx: NodeContext,
         _event_hub: EventHub,
         _action: String,
         with: Option<HashMap<String, Value>>,
@@ -164,7 +164,29 @@ impl ProcessorFactory for CoordinateFrameReprojectorFactory {
         // `epsgCode` rides inside the `crs` variant, so the schema cannot express a
         // CRS destination without one — no runtime check needed (§3.2).
         let target = match params.destination_frame {
-            DestinationFrame::Crs { epsg_code } => CoordinateFrame::Crs(EpsgCode::new(epsg_code)),
+            DestinationFrame::Crs { epsg_code } => {
+                let compiled = epsg_code.compile().map_err(|e| {
+                    GeometryProcessorError::CoordinateFrameReprojectorFactory(format!(
+                        "Failed to compile `epsgCode` expression: {e:?}"
+                    ))
+                })?;
+                let value = compiled
+                    .eval_variables_only(ctx.variables.clone())
+                    .map_err(|e| {
+                        GeometryProcessorError::CoordinateFrameReprojectorFactory(format!(
+                            "Failed to evaluate `epsgCode` expression: {e}"
+                        ))
+                    })?;
+                let code = value
+                    .as_i64()
+                    .and_then(|v| u16::try_from(v).ok())
+                    .ok_or_else(|| {
+                        GeometryProcessorError::CoordinateFrameReprojectorFactory(format!(
+                            "`epsgCode` expression did not evaluate to an EPSG code: {value:?}"
+                        ))
+                    })?;
+                CoordinateFrame::Crs(EpsgCode::new(code))
+            }
             DestinationFrame::Euclidean => CoordinateFrame::Euclidean,
         };
 
@@ -437,7 +459,10 @@ mod tests {
     #[test]
     fn value_mode_carries_its_base_point() {
         let params = parse(json!({
-            "destinationFrame": { "type": "crs", "epsgCode": 6677 },
+            "destinationFrame": {
+                "type": "crs",
+                "epsgCode": { "type": "flowExpr", "value": "6677" },
+            },
             "basePointSource": {
                 "type": "value",
                 "basePoint": { "type": "flowExpr", "value": "[1, 2, 3]" },
@@ -481,11 +506,14 @@ mod tests {
     #[test]
     fn crs_destination_carries_its_epsg_code() {
         let params = parse(json!({
-            "destinationFrame": { "type": "crs", "epsgCode": 6677 },
+            "destinationFrame": {
+                "type": "crs",
+                "epsgCode": { "type": "flowExpr", "value": "variables[\"prcs\"]" },
+            },
         }));
         assert!(matches!(
             params.destination_frame,
-            DestinationFrame::Crs { epsg_code: 6677 }
+            DestinationFrame::Crs { .. }
         ));
     }
 

--- a/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
@@ -40,6 +40,7 @@ use reearth_flow_types::{Geometry, GeometryValue};
 use reearth_flow_geometry::{
     coordinate::CoordinateFrame,
     line_string::LineString2D,
+    overlay::snap_positions,
     point::Point2D,
     predicates::kernel::{segment_intersection, SegmentIntersection},
     predicates::view::{flatten_2d, Leaf2D},
@@ -1017,6 +1018,16 @@ fn overlay_entries(
     lss_per_feature: &[Vec<Polyline>],
     tolerance: f64,
 ) -> OverlayResult {
+    // The intersection kernel below is exact, so two copies of a shared edge
+    // differing in their last bits read as a crossing at an arbitrary point
+    // along them instead of as a collinear overlap. Snapping the vertices onto
+    // one position first restores the coincidence.
+    let snapped = snap_group_vertices(lss_per_feature, tolerance);
+    let (entries, lss_per_feature) = match &snapped {
+        Some(snapped) => (rebuilt_aabbs(entries, snapped), snapped.as_slice()),
+        None => (entries, lss_per_feature),
+    };
+
     let rtree: RTree<AabbEntry> = RTree::bulk_load(entries);
     let rtree_items: Vec<&AabbEntry> = rtree.iter().collect();
 
@@ -1245,6 +1256,51 @@ fn coords_match(a: &[[f64; 2]], b: &[[f64; 2]], tolerance: f64) -> bool {
         .rev()
         .zip(b.iter())
         .all(|(&c1, &c2)| dist(c1, c2) < tolerance)
+}
+
+/// The group's polylines with their vertices closer together than `tolerance`
+/// pulled onto one shared position, or `None` when nothing snaps.
+#[cfg(feature = "new-geometry")]
+fn snap_group_vertices(
+    lss_per_feature: &[Vec<Polyline>],
+    tolerance: f64,
+) -> Option<Vec<Vec<Polyline>>> {
+    let points: Vec<[f64; 2]> = lss_per_feature
+        .iter()
+        .flat_map(|lss| lss.iter().flat_map(|pl| pl.coords.iter().copied()))
+        .collect();
+    let snapped = snap_positions(&points, tolerance)?;
+
+    let mut read = 0;
+    let mut out = Vec::with_capacity(lss_per_feature.len());
+    for lss in lss_per_feature {
+        let mut lines = Vec::with_capacity(lss.len());
+        for pl in lss {
+            let end = read + pl.coords.len();
+            lines.push(Polyline {
+                frame: pl.frame.clone(),
+                coords: snapped[read..end].to_vec(),
+            });
+            read = end;
+        }
+        out.push(lines);
+    }
+    Some(out)
+}
+
+/// The entries with each bounding box recomputed from the polyline it stands
+/// for; snapping may have moved a vertex out of the box taken at intake.
+#[cfg(feature = "new-geometry")]
+fn rebuilt_aabbs(entries: Vec<AabbEntry>, lss_per_feature: &[Vec<Polyline>]) -> Vec<AabbEntry> {
+    entries
+        .into_iter()
+        .map(|entry| AabbEntry {
+            aabb: aabb_to_rstar(polyline_bbox(
+                &lss_per_feature[entry.feature_idx][entry.ls_local_idx].coords,
+            )),
+            ..entry
+        })
+        .collect()
 }
 
 /// Every pairwise segment intersection of two polylines, appended to `out`:
@@ -1831,6 +1887,46 @@ mod tests {
         overlay_counts.sort();
         assert_eq!(overlay_counts, vec![1, 2, 2, 3]);
         assert_eq!(result.split_coords.len(), 3);
+    }
+
+    #[test]
+    fn a_shared_edge_whose_copies_differ_in_their_last_bits_stays_one_overlap() {
+        // Two triangles meeting along [0, 0]-[1, 0], the second one's copy of
+        // that edge off by a fraction of a nanometre.
+        let drift = 1e-10;
+        let result = overlay_lines(
+            vec![
+                vec![[0.0, 0.0], [1.0, 0.0], [0.4, 0.6], [0.0, 0.0]],
+                vec![
+                    [1.0 + drift, -drift],
+                    [-drift, drift],
+                    [0.4, -0.6],
+                    [1.0 + drift, -drift],
+                ],
+            ],
+            0.01,
+        );
+
+        // The shared edge, plus the remaining two vertices of each triangle.
+        assert_eq!(result.line_strings_with_metadata.len(), 3);
+        let shared: Vec<_> = result
+            .line_strings_with_metadata
+            .iter()
+            .filter(|meta| meta.source_feature_idxs.len() == 2)
+            .collect();
+        assert_eq!(shared.len(), 1);
+        let mut endpoints = shared[0].line_string.coords.clone();
+        endpoints.sort_by(|a, b| a[0].total_cmp(&b[0]));
+        assert_eq!(endpoints, vec![[0.0, 0.0], [1.0, 0.0]]);
+        // Nothing crosses anything: the edge is cut only where it begins and
+        // ends, never part-way along.
+        for point in &result.split_coords {
+            assert!(
+                dist(point.coord, [0.0, 0.0]) < 0.01 || dist(point.coord, [1.0, 0.0]) < 0.01,
+                "split part-way along the shared edge at {:?}",
+                point.coord
+            );
+        }
     }
 
     #[test]

--- a/engine/runtime/examples/fixture/graphs/lod_splitter_next.yml
+++ b/engine/runtime/examples/fixture/graphs/lod_splitter_next.yml
@@ -1,0 +1,204 @@
+# New-geometry counterpart of `lod_splitter_with_dm.yml`, kept as a separate
+# graph because the legacy one's string `lod` filter and single-level split do
+# not fit the new `Geometry Splitter`, and old-world tile-comparison tests
+# depend on it as it stands.
+#
+# Emits one feature per face, with `lod` promoted from the reader's per-member
+# geometry attributes.
+id: bf2ceaf8-f2b0-49ca-b05e-fd1469f15eb0
+name: LodSplitterNext
+nodes:
+  - id: c0b6fef5-38e5-49e6-9746-307814da02c9
+    name: InputRouter
+    type: action
+    action: Input Router
+    with:
+      routingPort: features
+
+  - id: 7d41915b-e078-4216-a661-fc7796b83d08
+    name: DmGeometricAttributeFilter
+    type: action
+    action: Feature Filter
+    with:
+      conditions:
+        - expr:
+            type: flowExpr
+            value: attributes.get("dm_feature_type") == "DmGeometricAttribute"
+          outputPort: DmGeometricAttribute
+
+  - id: a6421580-d816-47fa-b197-e042e5f757d4
+    name: GeometryFilter
+    type: action
+    action: Geometry Filter
+    with:
+      filterType: none
+
+  - id: e0293925-1a3e-4b44-aa5a-832dff6750b9
+    name: FeatureFilterByExceptSplit
+    type: action
+    action: Feature Filter
+    with:
+      conditions:
+        - expr:
+            type: flowExpr
+            value: variables.get("exceptSplit", false)
+          outputPort: exceptSplit
+
+  # A split descends one container level and passes a non-container through
+  # untouched, so the deepest case sets the stage count: per-LOD collection ->
+  # `gml:MultiSurface` -> `gml:CompositeSurface` mesh.
+  - id: 6449b421-7945-466b-972c-d035fb0bdfca
+    name: GeometrySplitterByLod
+    type: action
+    action: Geometry Splitter
+
+  - id: 033780b6-5ffc-4f45-9b66-c50b2cc71fd8
+    name: GeometrySplitterByMember
+    type: action
+    action: Geometry Splitter
+
+  - id: 89659aed-7a89-4735-a393-9d85497a1583
+    name: GeometrySplitterByFace
+    type: action
+    action: Geometry Splitter
+
+  - id: 927a6653-643f-47f6-9b42-61979467069f
+    name: FeatureFilterByLod
+    type: action
+    action: Feature Filter
+    with:
+      conditions:
+        - expr:
+            type: flowExpr
+            value: attributes.get("lod") == 0
+          outputPort: lod0
+        - expr:
+            type: flowExpr
+            value: attributes.get("lod") == 1
+          outputPort: lod1
+        - expr:
+            type: flowExpr
+            value: attributes.get("lod") == 2
+          outputPort: lod2
+        - expr:
+            type: flowExpr
+            value: attributes.get("lod") == 3
+          outputPort: lod3
+        - expr:
+            type: flowExpr
+            value: attributes.get("lod") == 4
+          outputPort: lod4
+
+  - id: fad22518-83b8-42a1-b8dc-0daeae225e68
+    name: DmGeometricAttributeRouter
+    type: action
+    action: Output Router
+    with:
+      routingPort: DmGeometricAttribute
+
+  - id: 05d74816-5bca-4e99-b4fb-ee276981ec2c
+    name: Lod0Router
+    type: action
+    action: Output Router
+    with:
+      routingPort: lod0
+
+  - id: ed8957ee-df5e-404c-84ed-d2e1bf02b791
+    name: Lod1Router
+    type: action
+    action: Output Router
+    with:
+      routingPort: lod1
+
+  - id: 1516f5af-899f-438a-8439-58d09305105e
+    name: Lod2Router
+    type: action
+    action: Output Router
+    with:
+      routingPort: lod2
+
+  - id: 50b479ff-9ac8-400f-b267-103beb277d7d
+    name: Lod3Router
+    type: action
+    action: Output Router
+    with:
+      routingPort: lod3
+
+  - id: 4e92069d-be86-41f2-ad86-a7972f2093dc
+    name: Lod4Router
+    type: action
+    action: Output Router
+    with:
+      routingPort: lod4
+
+edges:
+  - id: 5d1a5940-bb5c-437b-a865-e1f1b07a49c7
+    from: c0b6fef5-38e5-49e6-9746-307814da02c9
+    to: 7d41915b-e078-4216-a661-fc7796b83d08
+    fromPort: features
+    toPort: features
+  - id: 74a884bc-f6e7-455a-aff1-131a2a5d0bc0
+    from: 7d41915b-e078-4216-a661-fc7796b83d08
+    to: a6421580-d816-47fa-b197-e042e5f757d4
+    fromPort: unfiltered
+    toPort: features
+  - id: 27e59c82-dfaa-4b2f-aac1-45859b635226
+    from: 7d41915b-e078-4216-a661-fc7796b83d08
+    to: fad22518-83b8-42a1-b8dc-0daeae225e68
+    fromPort: DmGeometricAttribute
+    toPort: features
+  - id: 5433c1ee-8d76-4128-bc8b-1db3d262620a
+    from: a6421580-d816-47fa-b197-e042e5f757d4
+    to: e0293925-1a3e-4b44-aa5a-832dff6750b9
+    fromPort: unfiltered
+    toPort: features
+  - id: 652502f4-49c4-452a-b921-8127836cfdee
+    from: e0293925-1a3e-4b44-aa5a-832dff6750b9
+    to: 6449b421-7945-466b-972c-d035fb0bdfca
+    fromPort: unfiltered
+    toPort: features
+  - id: 0438ccc2-9aec-498f-843b-56b1ad426386
+    from: 6449b421-7945-466b-972c-d035fb0bdfca
+    to: 033780b6-5ffc-4f45-9b66-c50b2cc71fd8
+    fromPort: features
+    toPort: features
+  - id: 2db63f87-c8f0-4afe-9d75-e56a48c8ede3
+    from: 033780b6-5ffc-4f45-9b66-c50b2cc71fd8
+    to: 89659aed-7a89-4735-a393-9d85497a1583
+    fromPort: features
+    toPort: features
+  - id: 46748dfa-3bb5-439e-810e-7feed369a708
+    from: 89659aed-7a89-4735-a393-9d85497a1583
+    to: 927a6653-643f-47f6-9b42-61979467069f
+    fromPort: features
+    toPort: features
+  - id: c1aa46df-68ed-4fef-b29b-359e766c7698
+    from: e0293925-1a3e-4b44-aa5a-832dff6750b9
+    to: 927a6653-643f-47f6-9b42-61979467069f
+    fromPort: exceptSplit
+    toPort: features
+  - id: f55ae466-928b-462f-9989-631fd697c388
+    from: 927a6653-643f-47f6-9b42-61979467069f
+    to: 05d74816-5bca-4e99-b4fb-ee276981ec2c
+    fromPort: lod0
+    toPort: features
+  - id: 06901452-9184-4ba0-b256-b11440cb2d69
+    from: 927a6653-643f-47f6-9b42-61979467069f
+    to: ed8957ee-df5e-404c-84ed-d2e1bf02b791
+    fromPort: lod1
+    toPort: features
+  - id: f8495fd7-0bec-4d39-8ee9-006a9e9d84be
+    from: 927a6653-643f-47f6-9b42-61979467069f
+    to: 1516f5af-899f-438a-8439-58d09305105e
+    fromPort: lod2
+    toPort: features
+  - id: e44d6f20-6bbc-4f64-bec2-4caee971f5ec
+    from: 927a6653-643f-47f6-9b42-61979467069f
+    to: 50b479ff-9ac8-400f-b267-103beb277d7d
+    fromPort: lod3
+    toPort: features
+  - id: 68c13633-dd4a-4274-8891-14e160670788
+    from: 927a6653-643f-47f6-9b42-61979467069f
+    to: 4e92069d-be86-41f2-ad86-a7972f2093dc
+    fromPort: lod4
+    toPort: features

--- a/engine/runtime/examples/fixture/graphs/surface_validator_next.yml
+++ b/engine/runtime/examples/fixture/graphs/surface_validator_next.yml
@@ -1,0 +1,184 @@
+# New-geometry counterpart of `surface_validator.yml`. The legacy graph's
+# per-check actions have no new-world equivalent; `Geometry Validator` runs the
+# whole matrix and reports every failure on one `validationResult` attribute, so
+# checks are selected by filtering that attribute rather than by wiring a node
+# per check.
+#
+# Two validators, because a 3D face has no absolute winding: the 3D one only
+# compares each hole against the exterior ring, and the exterior ring's own
+# winding — the "incorrect orientation" error — is defined only once the face is
+# flattened by `Two Dimension Forcer`.
+#
+# Deliberate differences from the legacy graph: ring intersections are decided
+# exactly instead of with a proximity tolerance, and an interior ring crossing
+# the exterior is no longer told apart from one crossing another interior ring.
+#
+# Expects one feature per face, already reprojected to a linear-unit CRS: the
+# planarity check does not run on angular (geographic) coordinates.
+id: 51454aa9-c17c-43ca-a377-4c7b4622682b
+name: SurfaceValidatorNext
+nodes:
+  - id: 05bfb591-97fa-4cca-b528-4de949418504
+    name: InputRouter
+    type: action
+    action: Input Router
+    with:
+      routingPort: features
+
+  - id: 43b33bb0-200f-4cfe-be7c-05f61f3ff13f
+    name: Noop
+    type: action
+    action: Noop Processor
+
+  - id: fcbe7688-7434-4845-8ef2-2eb430c90163
+    name: SurfaceRouter
+    type: action
+    action: Output Router
+    with:
+      routingPort: features
+
+  ## Invalid surface
+  # Every failing check lands here, as in the legacy graph, whose 0.03 m
+  # absolute planarity bound carries over.
+  #
+  # `duplicateTolerance` is deliberately unset, so duplicate points are found by
+  # exact equality: the tolerant path builds a k-d tree whose bucket overflows —
+  # aborting the process — on rings that real road surfaces produce.
+  - id: 45840964-7c81-473d-abc3-d8f9b767445a
+    name: GeometryValidator3D
+    type: action
+    action: Geometry Validator
+    with:
+      planarityThreshold:
+        maxHeight: 0.03
+
+  - id: 6df74ac6-b2c2-474e-9673-e230394c42e4
+    name: AttributeManagerSurfaceIssue
+    type: action
+    action: Attribute Manager
+    with:
+      operations:
+        - attribute: issue
+          method: create
+          value:
+            type: flowExpr
+            value: attributes["validationResult"]["checks"].keys()[0]
+
+  - id: c1405582-1ad9-4ee8-a8af-a7474b41dd72
+    name: InvalidSurfaceRouter
+    type: action
+    action: Output Router
+    with:
+      routingPort: invalidSurface
+
+  ## Incorrect orientation
+  - id: af8289ff-34cf-45f5-a6a7-c7c12a5ec43e
+    name: TwoDimensionForcer
+    type: action
+    action: Two Dimension Forcer
+
+  # Runs the whole matrix again, but only its `Orientation` verdict is read
+  # below. The planarity threshold is inert on a flattened face and is set
+  # only because the action takes no empty parameter block.
+  - id: ca0a5de6-c6b6-422e-8748-c13d3debf33d
+    name: GeometryValidator2D
+    type: action
+    action: Geometry Validator
+    with:
+      planarityThreshold:
+        maxHeight: 0.03
+
+  # Only the winding matters here; every other check on the flattened face
+  # repeats what GeometryValidator3D already reported on the same feature.
+  - id: 3db5a2b9-b2e3-4509-8e11-2b2f95417d7d
+    name: FeatureFilterByOrientation
+    type: action
+    action: Feature Filter
+    with:
+      conditions:
+        - expr:
+            type: flowExpr
+            value: attributes["validationResult"]["checks"].get("Orientation", 0) > 0
+          outputPort: inCorrectOrientation
+
+  - id: 07d49e5a-2839-4911-847e-282021bfd991
+    name: InCorrectOrientationRouter
+    type: action
+    action: Output Router
+    with:
+      routingPort: inCorrectOrientation
+
+  # Features whose geometry could not be flattened or validated at all. Routed
+  # out rather than dropped so a caller can see them.
+  - id: 81220ae1-2143-478d-b861-e5672cb00e95
+    name: RejectedRouter
+    type: action
+    action: Output Router
+    with:
+      routingPort: rejected
+
+edges:
+  - id: 1cae1ad8-cf80-444e-8e2e-7017d5a8c1e4
+    from: 05bfb591-97fa-4cca-b528-4de949418504
+    to: 43b33bb0-200f-4cfe-be7c-05f61f3ff13f
+    fromPort: features
+    toPort: features
+  - id: 91c47787-ed49-4c3f-a1a2-0310f53a880e
+    from: 43b33bb0-200f-4cfe-be7c-05f61f3ff13f
+    to: fcbe7688-7434-4845-8ef2-2eb430c90163
+    fromPort: features
+    toPort: features
+
+  ## Invalid surface
+  - id: 4be2cd01-5896-498e-a326-68aaa9c5b12f
+    from: 43b33bb0-200f-4cfe-be7c-05f61f3ff13f
+    to: 45840964-7c81-473d-abc3-d8f9b767445a
+    fromPort: features
+    toPort: features
+  - id: d9e463cb-04dd-4509-a18a-be0561e3742c
+    from: 45840964-7c81-473d-abc3-d8f9b767445a
+    to: 6df74ac6-b2c2-474e-9673-e230394c42e4
+    fromPort: failed
+    toPort: features
+  - id: 1d6089d7-b630-4fa3-b370-2af967619de9
+    from: 6df74ac6-b2c2-474e-9673-e230394c42e4
+    to: c1405582-1ad9-4ee8-a8af-a7474b41dd72
+    fromPort: features
+    toPort: features
+  - id: 7ff59f95-2dd6-4b42-8fc6-1579acb9899f
+    from: 45840964-7c81-473d-abc3-d8f9b767445a
+    to: 81220ae1-2143-478d-b861-e5672cb00e95
+    fromPort: rejected
+    toPort: features
+
+  ## Incorrect orientation
+  - id: c7f6b35b-b6a6-4055-8b91-934e8e24d341
+    from: 43b33bb0-200f-4cfe-be7c-05f61f3ff13f
+    to: af8289ff-34cf-45f5-a6a7-c7c12a5ec43e
+    fromPort: features
+    toPort: features
+  - id: 5cdfc415-da9d-45d4-899e-8dc3820f4d2c
+    from: af8289ff-34cf-45f5-a6a7-c7c12a5ec43e
+    to: ca0a5de6-c6b6-422e-8748-c13d3debf33d
+    fromPort: features
+    toPort: features
+  - id: 6092a398-493e-4517-a0d9-27f0a1eb5054
+    from: af8289ff-34cf-45f5-a6a7-c7c12a5ec43e
+    to: 81220ae1-2143-478d-b861-e5672cb00e95
+    fromPort: rejected
+    toPort: features
+  - id: faa94c90-1ad6-4c81-8ed5-cc1ad74e40c6
+    from: ca0a5de6-c6b6-422e-8748-c13d3debf33d
+    to: 3db5a2b9-b2e3-4509-8e11-2b2f95417d7d
+    fromPort: failed
+    toPort: features
+  - id: 807d866e-6275-420d-9e75-b58a30a028ba
+    from: ca0a5de6-c6b6-422e-8748-c13d3debf33d
+    to: 81220ae1-2143-478d-b861-e5672cb00e95
+    fromPort: rejected
+    toPort: features
+  - id: bb3d3273-1dc9-4c3f-adc2-a80c98826da8
+    from: 3db5a2b9-b2e3-4509-8e11-2b2f95417d7d
+    to: 07d49e5a-2839-4911-847e-282021bfd991
+    fromPort: inCorrectOrientation
+    toPort: features

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau6/01-bldg/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau6/01-bldg/workflow.yml
@@ -108,6 +108,17 @@ graphs:
               value:
                 type: string
                 value: feature_type
+            # The reader copies the input feature's attributes onto every
+            # parsed city object; drop them so local paths do not end up as
+            # tile properties, as the plateau4 workflows do here too.
+            - attribute: city_gml_path
+              method: remove
+            - attribute: path
+              method: remove
+            - attribute: name
+              method: remove
+            - attribute: extension
+              method: remove
 
       - id: 9f2a7c4e-3b5d-4c8f-a1e0-6d9b2f5a8c31
         name: AttributeConversionTableForWardName

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau6/02-tran-rwy-trk-squr-wwy/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau6/02-tran-rwy-trk-squr-wwy/workflow.yml
@@ -112,6 +112,17 @@ graphs:
               value:
                 type: string
                 value: feature_type
+            # The reader copies the input feature's attributes onto every
+            # parsed city object; drop them so local paths do not end up as
+            # tile properties, as the plateau4 workflows do here too.
+            - attribute: city_gml_path
+              method: remove
+            - attribute: path
+              method: remove
+            - attribute: name
+              method: remove
+            - attribute: extension
+              method: remove
             - attribute: gml_id
               method: create
               value:

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
@@ -17,16 +17,16 @@ with:
   - squr
   - wwy
 graphs:
-- id: 7e98d856-1438-4148-bdcb-91747ef2e405
-  name: PLATEAU3.LodSplitterWithDM
+- id: bf2ceaf8-f2b0-49ca-b05e-fd1469f15eb0
+  name: LodSplitterNext
   nodes:
-  - id: 5848465e-828f-4646-874e-e2f182b73714
+  - id: c0b6fef5-38e5-49e6-9746-307814da02c9
     name: InputRouter
     type: action
     action: Input Router
     with:
       routingPort: features
-  - id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  - id: 7d41915b-e078-4216-a661-fc7796b83d08
     name: DmGeometricAttributeFilter
     type: action
     action: Feature Filter
@@ -36,13 +36,13 @@ graphs:
           type: flowExpr
           value: attributes.get("dm_feature_type") == "DmGeometricAttribute"
         outputPort: DmGeometricAttribute
-  - id: 278ab965-ce22-473d-98c6-c7b381c38679
+  - id: a6421580-d816-47fa-b197-e042e5f757d4
     name: GeometryFilter
     type: action
     action: Geometry Filter
     with:
       filterType: none
-  - id: 1787b15c-19b5-4386-a0ff-f0e58f477d07
+  - id: e0293925-1a3e-4b44-aa5a-832dff6750b9
     name: FeatureFilterByExceptSplit
     type: action
     action: Feature Filter
@@ -52,11 +52,19 @@ graphs:
           type: flowExpr
           value: variables.get("exceptSplit", false)
         outputPort: exceptSplit
-  - id: 8fe1a102-e3f3-40dd-b235-66e9c148830f
-    name: GeometrySplitter
+  - id: 6449b421-7945-466b-972c-d035fb0bdfca
+    name: GeometrySplitterByLod
     type: action
     action: Geometry Splitter
-  - id: 7c843a02-3b1f-40c1-8214-562e72bfb9a6
+  - id: 033780b6-5ffc-4f45-9b66-c50b2cc71fd8
+    name: GeometrySplitterByMember
+    type: action
+    action: Geometry Splitter
+  - id: 89659aed-7a89-4735-a393-9d85497a1583
+    name: GeometrySplitterByFace
+    type: action
+    action: Geometry Splitter
+  - id: 927a6653-643f-47f6-9b42-61979467069f
     name: FeatureFilterByLod
     type: action
     action: Feature Filter
@@ -64,155 +72,186 @@ graphs:
       conditions:
       - expr:
           type: flowExpr
-          value: attributes["lod"] == "0"
+          value: attributes.get("lod") == 0
         outputPort: lod0
       - expr:
           type: flowExpr
-          value: attributes["lod"] == "1"
+          value: attributes.get("lod") == 1
         outputPort: lod1
       - expr:
           type: flowExpr
-          value: attributes["lod"] == "2"
+          value: attributes.get("lod") == 2
         outputPort: lod2
       - expr:
           type: flowExpr
-          value: attributes["lod"] == "3"
+          value: attributes.get("lod") == 3
         outputPort: lod3
       - expr:
           type: flowExpr
-          value: attributes["lod"] == "4"
+          value: attributes.get("lod") == 4
         outputPort: lod4
-  - id: b1c2d3e4-f5a6-7890-bcde-f12345678901
+  - id: fad22518-83b8-42a1-b8dc-0daeae225e68
     name: DmGeometricAttributeRouter
     type: action
     action: Output Router
     with:
       routingPort: DmGeometricAttribute
-  - id: dab9d3b6-594e-40cc-9f6b-c605005e3320
+  - id: 05d74816-5bca-4e99-b4fb-ee276981ec2c
     name: Lod0Router
     type: action
     action: Output Router
     with:
       routingPort: lod0
-  - id: dab9d3b6-594e-40cc-9f6b-c605005e3321
+  - id: ed8957ee-df5e-404c-84ed-d2e1bf02b791
     name: Lod1Router
     type: action
     action: Output Router
     with:
       routingPort: lod1
-  - id: dab9d3b6-594e-40cc-9f6b-c605005e3322
+  - id: 1516f5af-899f-438a-8439-58d09305105e
     name: Lod2Router
     type: action
     action: Output Router
     with:
       routingPort: lod2
-  - id: dab9d3b6-594e-40cc-9f6b-c605005e3323
+  - id: 50b479ff-9ac8-400f-b267-103beb277d7d
     name: Lod3Router
     type: action
     action: Output Router
     with:
       routingPort: lod3
-  - id: dab9d3b6-594e-40cc-9f6b-c605005e3324
+  - id: 4e92069d-be86-41f2-ad86-a7972f2093dc
     name: Lod4Router
     type: action
     action: Output Router
     with:
       routingPort: lod4
   edges:
-  - id: fcc0d596-9169-4289-9f35-07c8cbec6f10
-    from: 5848465e-828f-4646-874e-e2f182b73714
-    to: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  - id: 5d1a5940-bb5c-437b-a865-e1f1b07a49c7
+    from: c0b6fef5-38e5-49e6-9746-307814da02c9
+    to: 7d41915b-e078-4216-a661-fc7796b83d08
     fromPort: features
     toPort: features
-  - id: c1d2e3f4-a5b6-7c8d-9e0f-1a2b3c4d5e6f
-    from: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-    to: 278ab965-ce22-473d-98c6-c7b381c38679
+  - id: 74a884bc-f6e7-455a-aff1-131a2a5d0bc0
+    from: 7d41915b-e078-4216-a661-fc7796b83d08
+    to: a6421580-d816-47fa-b197-e042e5f757d4
     fromPort: unfiltered
     toPort: features
-  - id: d2e3f4a5-b6c7-8d9e-0f1a-2b3c4d5e6f7a
-    from: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-    to: b1c2d3e4-f5a6-7890-bcde-f12345678901
+  - id: 27e59c82-dfaa-4b2f-aac1-45859b635226
+    from: 7d41915b-e078-4216-a661-fc7796b83d08
+    to: fad22518-83b8-42a1-b8dc-0daeae225e68
     fromPort: DmGeometricAttribute
     toPort: features
-  - id: 1386a662-cf02-4475-a5d2-3668a50a56b7
-    from: 278ab965-ce22-473d-98c6-c7b381c38679
-    to: 1787b15c-19b5-4386-a0ff-f0e58f477d07
+  - id: 5433c1ee-8d76-4128-bc8b-1db3d262620a
+    from: a6421580-d816-47fa-b197-e042e5f757d4
+    to: e0293925-1a3e-4b44-aa5a-832dff6750b9
     fromPort: unfiltered
     toPort: features
-  - id: ef2f1484-6173-4f34-85bc-58bc45e31bff
-    from: 1787b15c-19b5-4386-a0ff-f0e58f477d07
-    to: 8fe1a102-e3f3-40dd-b235-66e9c148830f
+  - id: 652502f4-49c4-452a-b921-8127836cfdee
+    from: e0293925-1a3e-4b44-aa5a-832dff6750b9
+    to: 6449b421-7945-466b-972c-d035fb0bdfca
     fromPort: unfiltered
     toPort: features
-  - id: 111cc70e-e1ad-44f4-b4c8-82f7b1cf1309
-    from: 8fe1a102-e3f3-40dd-b235-66e9c148830f
-    to: 7c843a02-3b1f-40c1-8214-562e72bfb9a6
+  - id: 0438ccc2-9aec-498f-843b-56b1ad426386
+    from: 6449b421-7945-466b-972c-d035fb0bdfca
+    to: 033780b6-5ffc-4f45-9b66-c50b2cc71fd8
     fromPort: features
     toPort: features
-  - id: 5857909b-7fc0-4d3e-adfa-65a5669a6646
-    from: 1787b15c-19b5-4386-a0ff-f0e58f477d07
-    to: 7c843a02-3b1f-40c1-8214-562e72bfb9a6
+  - id: 2db63f87-c8f0-4afe-9d75-e56a48c8ede3
+    from: 033780b6-5ffc-4f45-9b66-c50b2cc71fd8
+    to: 89659aed-7a89-4735-a393-9d85497a1583
+    fromPort: features
+    toPort: features
+  - id: 46748dfa-3bb5-439e-810e-7feed369a708
+    from: 89659aed-7a89-4735-a393-9d85497a1583
+    to: 927a6653-643f-47f6-9b42-61979467069f
+    fromPort: features
+    toPort: features
+  - id: c1aa46df-68ed-4fef-b29b-359e766c7698
+    from: e0293925-1a3e-4b44-aa5a-832dff6750b9
+    to: 927a6653-643f-47f6-9b42-61979467069f
     fromPort: exceptSplit
     toPort: features
-  - id: 1a802e2e-c876-42e3-b3ae-639af1bc7780
-    from: 7c843a02-3b1f-40c1-8214-562e72bfb9a6
-    to: dab9d3b6-594e-40cc-9f6b-c605005e3320
+  - id: f55ae466-928b-462f-9989-631fd697c388
+    from: 927a6653-643f-47f6-9b42-61979467069f
+    to: 05d74816-5bca-4e99-b4fb-ee276981ec2c
     fromPort: lod0
     toPort: features
-  - id: 1a802e2e-c876-42e3-b3ae-639af1bc7781
-    from: 7c843a02-3b1f-40c1-8214-562e72bfb9a6
-    to: dab9d3b6-594e-40cc-9f6b-c605005e3321
+  - id: 06901452-9184-4ba0-b256-b11440cb2d69
+    from: 927a6653-643f-47f6-9b42-61979467069f
+    to: ed8957ee-df5e-404c-84ed-d2e1bf02b791
     fromPort: lod1
     toPort: features
-  - id: 1a802e2e-c876-42e3-b3ae-639af1bc7782
-    from: 7c843a02-3b1f-40c1-8214-562e72bfb9a6
-    to: dab9d3b6-594e-40cc-9f6b-c605005e3322
+  - id: f8495fd7-0bec-4d39-8ee9-006a9e9d84be
+    from: 927a6653-643f-47f6-9b42-61979467069f
+    to: 1516f5af-899f-438a-8439-58d09305105e
     fromPort: lod2
     toPort: features
-  - id: 1a802e2e-c876-42e3-b3ae-639af1bc7783
-    from: 7c843a02-3b1f-40c1-8214-562e72bfb9a6
-    to: dab9d3b6-594e-40cc-9f6b-c605005e3323
+  - id: e44d6f20-6bbc-4f64-bec2-4caee971f5ec
+    from: 927a6653-643f-47f6-9b42-61979467069f
+    to: 50b479ff-9ac8-400f-b267-103beb277d7d
     fromPort: lod3
     toPort: features
-  - id: 1a802e2e-c876-42e3-b3ae-639af1bc7784
-    from: 7c843a02-3b1f-40c1-8214-562e72bfb9a6
-    to: dab9d3b6-594e-40cc-9f6b-c605005e3324
+  - id: 68c13633-dd4a-4274-8891-14e160670788
+    from: 927a6653-643f-47f6-9b42-61979467069f
+    to: 4e92069d-be86-41f2-ad86-a7972f2093dc
     fromPort: lod4
     toPort: features
-- id: 8a5b1c9d-2e4f-4a3b-9c5d-1e6f8a2b4c7d
-  name: PLATEAU3.SurfaceValidator3D
+- id: 51454aa9-c17c-43ca-a377-4c7b4622682b
+  name: SurfaceValidatorNext
   nodes:
-  - id: 2f8a4b1c-5e9d-4c2a-8b6e-3f7a9b2c5d8e
+  - id: 05bfb591-97fa-4cca-b528-4de949418504
     name: InputRouter
     type: action
     action: Input Router
     with:
       routingPort: features
-  - id: 4c7a2b5e-8f1d-4a6c-9e2b-7a4c8e1b3f6d
+  - id: 43b33bb0-200f-4cfe-be7c-05f61f3ff13f
     name: Noop
     type: action
     action: Noop Processor
-  - id: 6e3b8a1c-f4d7-4b9e-a2c5-8f1b4e6a9c3d
+  - id: fcbe7688-7434-4845-8ef2-2eb430c90163
     name: SurfaceRouter
     type: action
     action: Output Router
     with:
       routingPort: features
-  - id: 1a9c4e7b-2f5d-4e8a-b3c6-9f2a5e8b1c4d
-    name: GeometryPartExtractor
+  - id: 45840964-7c81-473d-abc3-d8f9b767445a
+    name: GeometryValidator3D
     type: action
-    action: Geometry Part Extractor
-  - id: 3d6f9a2c-5b8e-4a1d-c7f4-2e5a8c3b6f9d
+    action: Geometry Validator
+    with:
+      planarityThreshold:
+        maxHeight: 0.03
+  - id: 6df74ac6-b2c2-474e-9673-e230394c42e4
+    name: AttributeManagerSurfaceIssue
+    type: action
+    action: Attribute Manager
+    with:
+      operations:
+      - attribute: issue
+        method: create
+        value:
+          type: flowExpr
+          value: attributes["validationResult"]["checks"].keys()[0]
+  - id: c1405582-1ad9-4ee8-a8af-a7474b41dd72
+    name: InvalidSurfaceRouter
+    type: action
+    action: Output Router
+    with:
+      routingPort: invalidSurface
+  - id: af8289ff-34cf-45f5-a6a7-c7c12a5ec43e
     name: TwoDimensionForcer
     type: action
     action: Two Dimension Forcer
-  - id: 5c2a7f4b-8e1d-4f9c-a6e3-4b7f2a5c8e1d
-    name: OrientationExtractor
+  - id: ca0a5de6-c6b6-422e-8748-c13d3debf33d
+    name: GeometryValidator2D
     type: action
-    action: Orientation Extractor
+    action: Geometry Validator
     with:
-      outputAttribute: outerOrientation
-  - id: 7f4a1c6e-b9d2-4c5a-e8f1-6a3c7f4b9e2d
+      planarityThreshold:
+        maxHeight: 0.03
+  - id: 3db5a2b9-b2e3-4509-8e11-2b2f95417d7d
     name: FeatureFilterByOrientation
     type: action
     action: Feature Filter
@@ -220,478 +259,80 @@ graphs:
       conditions:
       - expr:
           type: flowExpr
-          value: attributes["outerOrientation"] != "counter_clockwise"
+          value: attributes["validationResult"]["checks"].get("Orientation", 0) > 0
         outputPort: inCorrectOrientation
-  - id: 9e2b5f8a-1c4d-4a7e-f2b5-8a1e4b7c2f5d
-    name: GeometryReplacer
-    type: action
-    action: Geometry Replacer
-    with:
-      sourceAttribute: dumpGeometry
-  - id: 2a5c8f1b-4e7d-4b2c-a9f6-1c4e7a2b5f8d
+  - id: 07d49e5a-2839-4911-847e-282021bfd991
     name: InCorrectOrientationRouter
     type: action
     action: Output Router
     with:
       routingPort: inCorrectOrientation
-  - id: 4f8b3e6a-7d1c-4e5a-c2f9-3a6f9b4e7c1d
-    name: GeometryValidator
-    type: action
-    action: Geometry Validator
-    with:
-      validationTypes:
-      - corruptGeometry: 0.01
-  - id: 6a1d4f7c-9e2b-4c8a-f5e1-7c2a6f9d4e1b
-    name: PlanarityFilter
-    type: action
-    action: Planarity Filter
-    with:
-      filterType: height
-      threshold:
-        type: flowExpr
-        value: '0.03'
-  - id: a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d
-    name: Rotator3D
-    type: action
-    action: Rotator 3D
-    with:
-      rotation:
-        type: fromToVectors
-        fromX:
-          type: flowExpr
-          value: attributes["surfaceNormalX"]
-        fromY:
-          type: flowExpr
-          value: attributes["surfaceNormalY"]
-        fromZ:
-          type: flowExpr
-          value: attributes["surfaceNormalZ"]
-        toX:
-          type: flowExpr
-          value: '0.0'
-        toY:
-          type: flowExpr
-          value: '0.0'
-        toZ:
-          type: flowExpr
-          value: '1.0'
-  - id: 8c5f2a9d-1b4e-4f7c-a3d8-5e2c8f1b4a7d
-    name: FeatureCounter
-    type: action
-    action: Feature Counter
-    with:
-      countStart: 0
-      outputAttribute: surfaceId
-  - id: 1e7a4c9b-3f6d-4a2e-c8b5-9d2a5e8c1b4f
-    name: HoleCounter
-    type: action
-    action: Hole Counter
-    with:
-      outputAttribute: holeCount
-  - id: 3b9f6a2d-5c8e-4d1a-f7c4-2e5b8a3f6d9c
-    name: FeatureFilterByHole
-    type: action
-    action: Feature Filter
-    with:
-      conditions:
-      - expr:
-          type: flowExpr
-          value: 'true'
-        outputPort: features
-      - expr:
-          type: flowExpr
-          value: attributes["holeCount"] > 0
-        outputPort: hole
-  - id: 5d2c7f4a-8b1e-4c6d-a9f2-4a7d2c5f8b1e
-    name: GeometryValidatorSelfIntersection
-    type: action
-    action: Geometry Validator
-    with:
-      validationTypes:
-      - duplicateConsecutivePoints: 0.0099
-      - selfIntersection: 0.0099
-  - id: 6b2e9a4f-1c5d-4b8e-a3f7-2e5b8c1d4a7f
-    name: AttributeManagerSelfIntersection
-    type: action
-    action: Attribute Manager
-    with:
-      operations:
-      - attribute: issue
-        method: create
-        value:
-          type: flowExpr
-          value: |
-            vr = attributes["validationResult"];
-            vr["details"][0][0]
-  - id: 7f5a8c3b-1d4e-4a9f-c2b7-6e3a7f5c8b1d
-    name: GeometryCoercerRingNotClosed
-    type: action
-    action: Geometry Coercer
-    with:
-      targetType: lineString
-  - id: 9c1e4a7b-6f2d-4e5c-a8b1-3f6c9e1a4b7d
-    name: ClosedCurveFilter
-    type: action
-    action: Closed Curve Filter
-  - id: 2d8a5f3c-4b7e-4c1d-f9a6-8c2d5a8f3b6e
-    name: HoleExtractor
-    type: action
-    action: Hole Extractor
-  - id: 4a6c9f2d-7e3b-4d8a-c5f2-1a4c7e9f2d5b
-    name: OrientationExtractorOuterShell
-    type: action
-    action: Orientation Extractor
-    with:
-      outputAttribute: outerOrientation
-  - id: 6f3b1a8e-9c4d-4a7f-e2c9-3b6f1a8e4c7d
-    name: ElevationExtractorHole
-    type: action
-    action: Elevation Extractor
-    with:
-      outputAttribute: elevation
-  - id: 8e7c4a1f-2d5b-4f8e-a6c3-7f4e1c8a5b2d
-    name: GeometryCoercerOutershell
-    type: action
-    action: Geometry Coercer
-    with:
-      targetType: lineString
-  - id: 1c4f7a2e-5b8d-4a3c-f9e6-4c1f8a7e2b5d
-    name: GeometryCoercerHole
-    type: action
-    action: Geometry Coercer
-    with:
-      targetType: lineString
-  - id: 3f5a8c1d-7e4b-4c9f-a2e7-6f3a8c1d4e7b
-    name: FeatureCounterHole
-    type: action
-    action: Feature Counter
-    with:
-      countStart: 1
-      groupBy:
-      - surfaceId
-      outputAttribute: holeId
-  - id: 5b8d1f4a-9c6e-4f2b-c8d5-1f4b8d5a9c2e
-    name: FeatureMergerIntersectionbetweenInteriorAndExterior
-    type: action
-    action: Feature Merger
-    with:
-      requestorAttribute:
-      - surfaceId
-      supplierAttribute:
-      - surfaceId
-      completeGrouped: true
-  - id: 7d4e9a2c-1f5b-4d8a-e7c4-9a2d7e4c1f5b
-    name: LineOnLineOverlayer
-    type: action
-    action: Line On Line Overlayer
-    with:
-      groupBy:
-      - surfaceId
-      - holeId
-      tolerance: 0.01
-      outputAttribute: overlap
-  - id: 9a6c3f8b-4e1d-4a7c-f5b9-3f8a6c9b4e1d
-    name: Bufferer
-    type: action
-    action: Bufferer
-    with:
-      bufferType: area2d
-      distance: 0.005
-      interpolationAngle: 22.5
-  - id: 2c7f4a9e-8b1d-4f6c-a3e8-7f2c4a9e1b8d
-    name: AreaOnAreaOverlayerInteriorAndInterior
-    type: action
-    action: Area On Area Overlayer
-    with:
-      groupBy:
-      - surfaceId
-      accumulationMode: useAttributesFromOneFeature
-      outputAttribute: overlap
-      tolerance: 0.1
-  - id: 4e1b7c5a-6f9d-4c2e-b8a5-1c4e7b5a6f9d
-    name: FeatureFilterByAreaOnAreaOverlap
-    type: action
-    action: Feature Filter
-    with:
-      conditions:
-      - expr:
-          type: flowExpr
-          value: attributes["overlap"] > 1
-        outputPort: intersectionInterior
-  - id: 5a3b7e9c-2f4d-4a6e-b8c1-3e7a5b9c2f4d
-    name: AttributeManagerIntersectionInterior
-    type: action
-    action: Attribute Manager
-    with:
-      operations:
-      - attribute: issue
-        method: create
-        value:
-          type: string
-          value: IntersectionBetweenInteriorAndInterior
-  - id: 6b5d8a3f-1c4e-4b7d-a9c2-5d6b8a3f1c4e
-    name: OrientationExtractorIncorrectInterior
-    type: action
-    action: Orientation Extractor
-    with:
-      outputAttribute: innerOrientation
-  - id: 8f2a5c7d-3e6b-4a9f-c1d4-2a8f5c7d3e6b
-    name: FeatureMergerIncorrectInterior
-    type: action
-    action: Feature Merger
-    with:
-      requestorAttribute:
-      - surfaceId
-      supplierAttribute:
-      - surfaceId
-      completeGrouped: true
-  - id: 1a4d7c2f-9e5b-4d8a-f6c3-4d1a7c2f9e5b
-    name: FeatureFilterByIncorrectInteriorOrientation
-    type: action
-    action: Feature Filter
-    with:
-      conditions:
-      - expr:
-          type: flowExpr
-          value: attributes["innerOrientation"] == attributes["outerOrientation"]
-        outputPort: incorrectInterior
-  - id: 4b8e2a7d-3f6c-4a1e-b9d5-7a4b8e2d3f6c
-    name: AttributeManagerIncorrectInteriorOrientation
-    type: action
-    action: Attribute Manager
-    with:
-      operations:
-      - attribute: issue
-        method: create
-        value:
-          type: string
-          value: IncorrectInteriorOrientation
-  - id: 3c6f9a1e-8d4b-4f3c-a7e2-6f3c9a1e8d4b
-    name: InvalidSurfaceRouter
+  - id: 81220ae1-2143-478d-b861-e5672cb00e95
+    name: RejectedRouter
     type: action
     action: Output Router
     with:
-      routingPort: invalidSurface
+      routingPort: rejected
   edges:
-  - id: 5e8b2a7f-1c4d-4e9b-a6f3-8b5e2a7f1c4d
-    from: 2f8a4b1c-5e9d-4c2a-8b6e-3f7a9b2c5d8e
-    to: 4c7a2b5e-8f1d-4a6c-9e2b-7a4c8e1b3f6d
+  - id: 1cae1ad8-cf80-444e-8e2e-7017d5a8c1e4
+    from: 05bfb591-97fa-4cca-b528-4de949418504
+    to: 43b33bb0-200f-4cfe-be7c-05f61f3ff13f
     fromPort: features
     toPort: features
-  - id: 7f3a6c9e-4d1b-4c7f-e2a5-3f7a6c9e4d1b
-    from: 4c7a2b5e-8f1d-4a6c-9e2b-7a4c8e1b3f6d
-    to: 6e3b8a1c-f4d7-4b9e-a2c5-8f1b4e6a9c3d
+  - id: 91c47787-ed49-4c3f-a1a2-0310f53a880e
+    from: 43b33bb0-200f-4cfe-be7c-05f61f3ff13f
+    to: fcbe7688-7434-4845-8ef2-2eb430c90163
     fromPort: features
     toPort: features
-  - id: 9d6a3f2c-8e5b-4a1d-c7f4-6a9d3f2c8e5b
-    from: 4c7a2b5e-8f1d-4a6c-9e2b-7a4c8e1b3f6d
-    to: 1a9c4e7b-2f5d-4e8a-b3c6-9f2a5e8b1c4d
+  - id: 4be2cd01-5896-498e-a326-68aaa9c5b12f
+    from: 43b33bb0-200f-4cfe-be7c-05f61f3ff13f
+    to: 45840964-7c81-473d-abc3-d8f9b767445a
     fromPort: features
     toPort: features
-  - id: 2c5f8a1d-6e9b-4c2f-a7e4-5c2f8a1d6e9b
-    from: 1a9c4e7b-2f5d-4e8a-b3c6-9f2a5e8b1c4d
-    to: 3d6f9a2c-5b8e-4a1d-c7f4-2e5a8c3b6f9d
-    fromPort: extracted
+  - id: d9e463cb-04dd-4509-a18a-be0561e3742c
+    from: 45840964-7c81-473d-abc3-d8f9b767445a
+    to: 6df74ac6-b2c2-474e-9673-e230394c42e4
+    fromPort: failed
     toPort: features
-  - id: 4a7e1c5b-9f2d-4a8e-c6f3-7e4a1c5b9f2d
-    from: 3d6f9a2c-5b8e-4a1d-c7f4-2e5a8c3b6f9d
-    to: 5c2a7f4b-8e1d-4f9c-a6e3-4b7f2a5c8e1d
+  - id: 1d6089d7-b630-4fa3-b370-2af967619de9
+    from: 6df74ac6-b2c2-474e-9673-e230394c42e4
+    to: c1405582-1ad9-4ee8-a8af-a7474b41dd72
     fromPort: features
     toPort: features
-  - id: 6f9c4a2e-1d5b-4f7c-e8a1-9c6f4a2e1d5b
-    from: 5c2a7f4b-8e1d-4f9c-a6e3-4b7f2a5c8e1d
-    to: 7f4a1c6e-b9d2-4c5a-e8f1-6a3c7f4b9e2d
+  - id: 7ff59f95-2dd6-4b42-8fc6-1579acb9899f
+    from: 45840964-7c81-473d-abc3-d8f9b767445a
+    to: 81220ae1-2143-478d-b861-e5672cb00e95
+    fromPort: rejected
+    toPort: features
+  - id: c7f6b35b-b6a6-4055-8b91-934e8e24d341
+    from: 43b33bb0-200f-4cfe-be7c-05f61f3ff13f
+    to: af8289ff-34cf-45f5-a6a7-c7c12a5ec43e
     fromPort: features
     toPort: features
-  - id: 8b1e6a3f-4c7d-4b8e-a2f5-1e8b6a3f4c7d
-    from: 7f4a1c6e-b9d2-4c5a-e8f1-6a3c7f4b9e2d
-    to: 9e2b5f8a-1c4d-4a7e-f2b5-8a1e4b7c2f5d
+  - id: 5cdfc415-da9d-45d4-899e-8dc3820f4d2c
+    from: af8289ff-34cf-45f5-a6a7-c7c12a5ec43e
+    to: ca0a5de6-c6b6-422e-8748-c13d3debf33d
+    fromPort: features
+    toPort: features
+  - id: 6092a398-493e-4517-a0d9-27f0a1eb5054
+    from: af8289ff-34cf-45f5-a6a7-c7c12a5ec43e
+    to: 81220ae1-2143-478d-b861-e5672cb00e95
+    fromPort: rejected
+    toPort: features
+  - id: faa94c90-1ad6-4c81-8ed5-cc1ad74e40c6
+    from: ca0a5de6-c6b6-422e-8748-c13d3debf33d
+    to: 3db5a2b9-b2e3-4509-8e11-2b2f95417d7d
+    fromPort: failed
+    toPort: features
+  - id: 807d866e-6275-420d-9e75-b58a30a028ba
+    from: ca0a5de6-c6b6-422e-8748-c13d3debf33d
+    to: 81220ae1-2143-478d-b861-e5672cb00e95
+    fromPort: rejected
+    toPort: features
+  - id: bb3d3273-1dc9-4c3f-adc2-a80c98826da8
+    from: 3db5a2b9-b2e3-4509-8e11-2b2f95417d7d
+    to: 07d49e5a-2839-4911-847e-282021bfd991
     fromPort: inCorrectOrientation
-    toPort: features
-  - id: 1d4a7c2e-8f5b-4d1a-c9f6-4a1d7c2e8f5b
-    from: 9e2b5f8a-1c4d-4a7e-f2b5-8a1e4b7c2f5d
-    to: 2a5c8f1b-4e7d-4b2c-a9f6-1c4e7a2b5f8d
-    fromPort: features
-    toPort: features
-  - id: 3f6c9a2d-7e4b-4f3c-a8e1-6c3f9a2d7e4b
-    from: 1a9c4e7b-2f5d-4e8a-b3c6-9f2a5e8b1c4d
-    to: 4f8b3e6a-7d1c-4e5a-c2f9-3a6f9b4e7c1d
-    fromPort: extracted
-    toPort: features
-  - id: 5c8a1f4d-9e2b-4c5a-f7d2-8c5a1f4d9e2b
-    from: 4f8b3e6a-7d1c-4e5a-c2f9-3a6f9b4e7c1d
-    to: 6a1d4f7c-9e2b-4c8a-f5e1-7c2a6f9d4e1b
-    fromPort: success
-    toPort: features
-  - id: 7e4b9f2a-1c6d-4e7b-a3f8-4b7e9f2a1c6d
-    from: 6a1d4f7c-9e2b-4c8a-f5e1-7c2a6f9d4e1b
-    to: 3c6f9a1e-8d4b-4f3c-a7e2-6f3c9a1e8d4b
-    fromPort: notplanarity
-    toPort: features
-  - id: 9a2f5c8d-6e1b-4a9f-c4d7-2a9f5c8d6e1b
-    from: 6a1d4f7c-9e2b-4c8a-f5e1-7c2a6f9d4e1b
-    to: a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d
-    fromPort: planarity
-    toPort: features
-  - id: b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e
-    from: a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d
-    to: 8c5f2a9d-1b4e-4f7c-a3d8-5e2c8f1b4a7d
-    fromPort: features
-    toPort: features
-  - id: 2d7a4c1f-5e8b-4d2a-f6c9-7a2d4c1f5e8b
-    from: 8c5f2a9d-1b4e-4f7c-a3d8-5e2c8f1b4a7d
-    to: 1e7a4c9b-3f6d-4a2e-c8b5-9d2a5e8c1b4f
-    fromPort: features
-    toPort: features
-  - id: 4b6d9a3c-8f1e-4b6d-a2c7-6b4d9a3c8f1e
-    from: 1e7a4c9b-3f6d-4a2e-c8b5-9d2a5e8c1b4f
-    to: 3b9f6a2d-5c8e-4d1a-f7c4-2e5b8a3f6d9c
-    fromPort: features
-    toPort: features
-  - id: 6f1c4a7e-9d2b-4f1c-e5a8-1f6c4a7e9d2b
-    from: 3b9f6a2d-5c8e-4d1a-f7c4-2e5b8a3f6d9c
-    to: 5d2c7f4a-8b1e-4c6d-a9f2-4a7d2c5f8b1e
-    fromPort: features
-    toPort: features
-  - id: 8c4e7a1d-2f5b-4c8e-a1d4-4e8c7a1d2f5b
-    from: 5d2c7f4a-8b1e-4c6d-a9f2-4a7d2c5f8b1e
-    to: 7f5a8c3b-1d4e-4a9f-c2b7-6e3a7f5c8b1d
-    fromPort: success
-    toPort: features
-  - id: 1a5e8c2d-6f9b-4a1e-c7d2-5a1e8c2d6f9b
-    from: 5d2c7f4a-8b1e-4c6d-a9f2-4a7d2c5f8b1e
-    to: 6b2e9a4f-1c5d-4b8e-a3f7-2e5b8c1d4a7f
-    fromPort: failed
-    toPort: features
-  - id: 7c1d4a8e-3f6b-4e9c-b2d5-8a1e4f7c3b6d
-    from: 6b2e9a4f-1c5d-4b8e-a3f7-2e5b8c1d4a7f
-    to: 3c6f9a1e-8d4b-4f3c-a7e2-6f3c9a1e8d4b
-    fromPort: features
-    toPort: features
-  - id: 3d8b5a2f-7c4e-4d8b-a6f1-8b3d5a2f7c4e
-    from: 7f5a8c3b-1d4e-4a9f-c2b7-6e3a7f5c8b1d
-    to: 9c1e4a7b-6f2d-4e5c-a8b1-3f6c9e1a4b7d
-    fromPort: features
-    toPort: features
-  - id: 5f2c8a6d-1e4b-4f2c-a9e4-2c5f8a6d1e4b
-    from: 9c1e4a7b-6f2d-4e5c-a8b1-3f6c9e1a4b7d
-    to: 3c6f9a1e-8d4b-4f3c-a7e2-6f3c9a1e8d4b
-    fromPort: open
-    toPort: features
-  - id: 7a6f3c9b-4e2d-4a7a-c1f6-6f7a3c9b4e2d
-    from: 3b9f6a2d-5c8e-4d1a-f7c4-2e5b8a3f6d9c
-    to: 2d8a5f3c-4b7e-4c1d-f9a6-8c2d5a8f3b6e
-    fromPort: hole
-    toPort: features
-  - id: 9c4a7f2e-8d1b-4c9a-f3e6-4a9c7f2e8d1b
-    from: 2d8a5f3c-4b7e-4c1d-f9a6-8c2d5a8f3b6e
-    to: 4a6c9f2d-7e3b-4d8a-c5f2-1a4c7e9f2d5b
-    fromPort: exterior
-    toPort: features
-  - id: 2e7b4a1c-6f9d-4e2b-a8c5-7b2e4a1c6f9d
-    from: 2d8a5f3c-4b7e-4c1d-f9a6-8c2d5a8f3b6e
-    to: 6f3b1a8e-9c4d-4a7f-e2c9-3b6f1a8e4c7d
-    fromPort: hole
-    toPort: features
-  - id: 4c8f5a3d-1e6b-4c8f-a2d5-8f4c5a3d1e6b
-    from: 4a6c9f2d-7e3b-4d8a-c5f2-1a4c7e9f2d5b
-    to: 8e7c4a1f-2d5b-4f8e-a6c3-7f4e1c8a5b2d
-    fromPort: features
-    toPort: features
-  - id: 6a1d7c4f-9e2b-4a1d-c8f5-1a6d7c4f9e2b
-    from: 6f3b1a8e-9c4d-4a7f-e2c9-3b6f1a8e4c7d
-    to: 1c4f7a2e-5b8d-4a3c-f9e6-4c1f8a7e2b5d
-    fromPort: features
-    toPort: features
-  - id: 8f4c1a6e-3d7b-4f8c-a5e2-4c8f1a6e3d7b
-    from: 1c4f7a2e-5b8d-4a3c-f9e6-4c1f8a7e2b5d
-    to: 3f5a8c1d-7e4b-4c9f-a2e7-6f3a8c1d4e7b
-    fromPort: features
-    toPort: features
-  - id: 1d7a4c2f-8e5b-4d1a-c6f9-7a1d4c2f8e5b
-    from: 8e7c4a1f-2d5b-4f8e-a6c3-7f4e1c8a5b2d
-    to: 5b8d1f4a-9c6e-4f2b-c8d5-1f4b8d5a9c2e
-    fromPort: features
-    toPort: requestor
-  - id: 3b6f9a4d-2c8e-4b3b-a7f2-6f3b9a4d2c8e
-    from: 3f5a8c1d-7e4b-4c9f-a2e7-6f3a8c1d4e7b
-    to: 5b8d1f4a-9c6e-4f2b-c8d5-1f4b8d5a9c2e
-    fromPort: features
-    toPort: supplier
-  - id: 5e2c8f1a-4d7b-4e5e-c9a6-2c5e8f1a4d7b
-    from: 5b8d1f4a-9c6e-4f2b-c8d5-1f4b8d5a9c2e
-    to: 7d4e9a2c-1f5b-4d8a-e7c4-9a2d7e4c1f5b
-    fromPort: merged
-    toPort: features
-  - id: 7a9d2c5f-6e8b-4a7a-f1d4-9d7a2c5f6e8b
-    from: 3f5a8c1d-7e4b-4c9f-a2e7-6f3a8c1d4e7b
-    to: 7d4e9a2c-1f5b-4d8a-e7c4-9a2d7e4c1f5b
-    fromPort: features
-    toPort: features
-  - id: 9c6a5f2d-8e1b-4c9c-a4f7-6a9c5f2d8e1b
-    from: 7d4e9a2c-1f5b-4d8a-e7c4-9a2d7e4c1f5b
-    to: 3c6f9a1e-8d4b-4f3c-a7e2-6f3c9a1e8d4b
-    fromPort: point
-    toPort: features
-  - id: 2f8a5c1d-7e4b-4f2f-a6c9-8a2f5c1d7e4b
-    from: 6f3b1a8e-9c4d-4a7f-e2c9-3b6f1a8e4c7d
-    to: 9a6c3f8b-4e1d-4a7c-f5b9-3f8a6c9b4e1d
-    fromPort: features
-    toPort: features
-  - id: 4d1c7a5e-9f2b-4d4d-c8a3-1c4d7a5e9f2b
-    from: 9a6c3f8b-4e1d-4a7c-f5b9-3f8a6c9b4e1d
-    to: 2c7f4a9e-8b1d-4f6c-a3e8-7f2c4a9e1b8d
-    fromPort: features
-    toPort: features
-  - id: 6e5b8a2f-1c4d-4e6e-b9f4-5b6e8a2f1c4d
-    from: 2c7f4a9e-8b1d-4f6c-a3e8-7f2c4a9e1b8d
-    to: 4e1b7c5a-6f9d-4c2e-b8a5-1c4e7b5a6f9d
-    fromPort: area
-    toPort: features
-  - id: 8a3f6c9d-4e7b-4a8a-f2c5-3f8a6c9d4e7b
-    from: 4e1b7c5a-6f9d-4c2e-b8a5-1c4e7b5a6f9d
-    to: 5a3b7e9c-2f4d-4a6e-b8c1-3e7a5b9c2f4d
-    fromPort: intersectionInterior
-    toPort: features
-  - id: 9b4c8e2a-6f7d-4b9c-e1a4-2e8b4c9a6f7d
-    from: 5a3b7e9c-2f4d-4a6e-b8c1-3e7a5b9c2f4d
-    to: 3c6f9a1e-8d4b-4f3c-a7e2-6f3c9a1e8d4b
-    fromPort: features
-    toPort: features
-  - id: 1c7d4a2e-9f5b-4c1c-d8e3-7d1c4a2e9f5b
-    from: 6f3b1a8e-9c4d-4a7f-e2c9-3b6f1a8e4c7d
-    to: 6b5d8a3f-1c4e-4b7d-a9c2-5d6b8a3f1c4e
-    fromPort: features
-    toPort: features
-  - id: 3e6a9c2f-8d1b-4e3e-a7c4-6a3e9c2f8d1b
-    from: 6b5d8a3f-1c4e-4b7d-a9c2-5d6b8a3f1c4e
-    to: 8f2a5c7d-3e6b-4a9f-c1d4-2a8f5c7d3e6b
-    fromPort: features
-    toPort: requestor
-  - id: 5b4f7c1a-2e9d-4b5b-c6a9-4f5b7c1a2e9d
-    from: 4a6c9f2d-7e3b-4d8a-c5f2-1a4c7e9f2d5b
-    to: 8f2a5c7d-3e6b-4a9f-c1d4-2a8f5c7d3e6b
-    fromPort: features
-    toPort: supplier
-  - id: 7d9c2a5f-6e8b-4d7d-c1f6-9c7d2a5f6e8b
-    from: 8f2a5c7d-3e6b-4a9f-c1d4-2a8f5c7d3e6b
-    to: 1a4d7c2f-9e5b-4d8a-f6c3-4d1a7c2f9e5b
-    fromPort: merged
-    toPort: features
-  - id: 9f2e5c8a-1d4b-4f9f-e4c7-2e9f5c8a1d4b
-    from: 1a4d7c2f-9e5b-4d8a-f6c3-4d1a7c2f9e5b
-    to: 4b8e2a7d-3f6c-4a1e-b9d5-7a4b8e2d3f6c
-    fromPort: incorrectInterior
-    toPort: features
-  - id: 7c3f1a6e-9d2b-4c8f-a5e1-3f7c1a6e9d2b
-    from: 4b8e2a7d-3f6c-4a1e-b9d5-7a4b8e2d3f6c
-    to: 3c6f9a1e-8d4b-4f3c-a7e2-6f3c9a1e8d4b
-    fromPort: features
-    toPort: features
-  - id: 2a5c8f1d-7e4b-4f2a-c9e6-5c2a8f1d7e4b
-    from: 4f8b3e6a-7d1c-4e5a-c2f9-3a6f9b4e7c1d
-    to: 3c6f9a1e-8d4b-4f3c-a7e2-6f3c9a1e8d4b
-    fromPort: failed
     toPort: features
 - id: 2c753ffc-cc90-4f4a-b5ee-f5d7853dbac6
   name: PLATEAU4.XMLValidator
@@ -2470,25 +2111,23 @@ graphs:
           value: not variables["targetPackages"] or attributes["package"] in variables["targetPackages"]
         outputPort: features
   - id: 242e339a-c7df-4be4-82f7-3223a6ed2145
-    name: FeatureCityGmlReader
+    name: FeatureCityGml2Reader
     type: action
-    action: Feature CityGML Reader
+    action: Feature CityGML 2 Reader
     with:
-      codelistsPath:
-        type: flowExpr
-        value: attributes["codelists"]
-      flatten: true
       dataset:
         type: flowExpr
         value: attributes["path"]
   - id: 10df06f3-cafa-4abd-ba94-04ac71dae467
-    name: HorizontalReprojector
+    name: CoordinateFrameReprojector
     type: action
-    action: Horizontal Reprojector
+    action: Coordinate Frame Reprojector
     with:
-      targetEpsgCode:
-        type: flowExpr
-        value: variables["prcs"]
+      destinationFrame:
+        type: crs
+        epsgCode:
+          type: flowExpr
+          value: variables["prcs"]
   - id: 6f556405-1fdb-4807-8e3b-f18da79fbe1a
     name: TransportationXlinkDetector
     type: action
@@ -2541,17 +2180,17 @@ graphs:
         type: string
         value: 03_交通_xlink参照エラー.csv
   - id: 51431704-ac14-41cd-988b-88141dc6e326
-    name: PLATEAU3.LodSplitterWithDM
+    name: LodSplitterNext
     type: subGraph
-    subGraphId: 7e98d856-1438-4148-bdcb-91747ef2e405
+    subGraphId: bf2ceaf8-f2b0-49ca-b05e-fd1469f15eb0
   - id: e28b5f31-4826-4775-a343-a12ecb7f90f9
-    name: PLATEAU3.SurfaceValidator2D
+    name: SurfaceValidatorLod12
     type: subGraph
-    subGraphId: 8a5b1c9d-2e4f-4a3b-9c5d-1e6f8a2b4c7d
+    subGraphId: 51454aa9-c17c-43ca-a377-4c7b4622682b
   - id: abf4b25e-6c1f-46fd-b5f8-07d43d137abf
-    name: PLATEAU3.SurfaceValidator3D
+    name: SurfaceValidatorLod3
     type: subGraph
-    subGraphId: 8a5b1c9d-2e4f-4a3b-9c5d-1e6f8a2b4c7d
+    subGraphId: 51454aa9-c17c-43ca-a377-4c7b4622682b
   - id: d44341fa-7de4-41f5-abfd-7e0a3b1d9be8
     name: SurfaceValidationAttributeMapper
     type: action
@@ -2573,7 +2212,7 @@ graphs:
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes.get("featureType", "")
+          value: attributes.get("__citygml_geometry_feature_type", "")
       - attribute: LOD
         expr:
           type: flowExpr
@@ -2581,35 +2220,22 @@ graphs:
       - attribute: gml:id
         expr:
           type: flowExpr
-          value: attributes.get("featureId", "")
+          value: attributes.get("__citygml_geometry_gml_id", "")
       - attribute: issue
         expr:
           type: flowExpr
-          value: |
-            vr = attributes.get("validationResult");
-            if vr != null and "details" in vr {
-              vr["details"][0][0]
-            } else if "issue" in attributes {
-              attributes["issue"]
-            } else {
-              "UnknownError"
-            }
+          value: attributes.get("issue", "UnknownError")
   - id: d60f93c1-c55e-49ee-9332-657f4408ba05
-    name: OrientationExtractor
+    name: AttributeManagerRejected
     type: action
-    action: Orientation Extractor
+    action: Attribute Manager
     with:
-      outputAttribute: orientation
-  - id: 1c385359-698d-40df-aed8-e8b9b0eaac67
-    name: FilterIncorrectOrientation
-    type: action
-    action: Feature Filter
-    with:
-      conditions:
-      - expr:
-          type: flowExpr
-          value: attributes["orientation"] == "clockwise"
-        outputPort: incorrectOrientation
+      operations:
+      - attribute: issue
+        method: create
+        value:
+          type: string
+          value: GeometryRejected
   - id: 0740c8ce-3c27-416f-9a13-5b2086090426
     name: AttributeMapper
     type: action
@@ -2631,7 +2257,7 @@ graphs:
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes.get("featureType", "")
+          value: attributes.get("__citygml_geometry_feature_type", "")
       - attribute: LOD
         expr:
           type: flowExpr
@@ -2639,7 +2265,7 @@ graphs:
       - attribute: gml:id
         expr:
           type: flowExpr
-          value: attributes.get("featureId", "")
+          value: attributes.get("__citygml_geometry_gml_id", "")
       - attribute: エラー数
         expr:
           type: flowExpr
@@ -2683,7 +2309,7 @@ graphs:
       groupBy:
       - lod
       - fileIndex
-      - gmlId
+      - __citygml_gml_id
       - package
       tolerance: 0.01
   - id: 0c979585-82b2-41aa-909c-00d9b8d017d0
@@ -2714,11 +2340,11 @@ graphs:
       conditions:
       - expr:
           type: flowExpr
-          value: attributes["lod"] == "1"
+          value: attributes.get("lod") == 1
         outputPort: lod1
       - expr:
           type: flowExpr
-          value: attributes["lod"] == "2" or attributes["lod"] == "3"
+          value: attributes.get("lod") == 2 or attributes.get("lod") == 3
         outputPort: lod23
   - id: b684d916-5efe-4dfa-be20-fed9b101239d
     name: LineOnLineOverlayerLOD1
@@ -2767,7 +2393,7 @@ graphs:
     action: Attribute Duplicate Filter
     with:
       filterBy:
-      - gmlId
+      - __citygml_gml_id
   - id: 2261a5c9-46a4-45ce-a292-d277a3dc0ebc
     name: GeometryReplacer
     type: action
@@ -2808,7 +2434,7 @@ graphs:
     action: List Concatenator
     with:
       list: areaOverlapList
-      elementAttribute: gmlId
+      elementAttribute: __citygml_gml_id
       separator: ','
       outputAttribute: concatenatedGmlIds
   - id: 518572d2-8561-4b60-ab28-fcd66d90afa2
@@ -2845,7 +2471,7 @@ graphs:
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes.get("featureType", "")
+          value: attributes.get("__citygml_feature_type", "")
       - attribute: LOD
         expr:
           type: flowExpr
@@ -2853,7 +2479,7 @@ graphs:
       - attribute: gml:id
         expr:
           type: flowExpr
-          value: attributes.get("gmlId", "")
+          value: attributes.get("__citygml_gml_id", "")
       - attribute: 隣接ID
         expr:
           type: flowExpr
@@ -2990,6 +2616,14 @@ graphs:
         expr:
           type: flowExpr
           value: attributes.get("L-TRAN-03 xlink参照エラー", 0)
+      - newAttribute: L-TRAN-02 隣接面重複
+        expr:
+          type: flowExpr
+          value: attributes.get("L-TRAN-02 隣接面重複", 0)
+      - newAttribute: 面の向き不正
+        expr:
+          type: flowExpr
+          value: attributes.get("面の向き不正", 0)
       - newAttribute: 面のエラー
         expr:
           type: flowExpr
@@ -3117,6 +2751,11 @@ graphs:
     to: 51431704-ac14-41cd-988b-88141dc6e326
     fromPort: features
     toPort: features
+  - id: 5e267610-bc90-4bb1-a31e-38d5c874268a
+    from: 10df06f3-cafa-4abd-ba94-04ac71dae467
+    to: d60f93c1-c55e-49ee-9332-657f4408ba05
+    fromPort: rejected
+    toPort: features
   - id: 30d1bde3-8025-47aa-983e-1f5429069aa4
     from: a1554a74-3caa-4880-a4a3-6dc4ab526a13
     to: 6f556405-1fdb-4807-8e3b-f18da79fbe1a
@@ -3157,25 +2796,30 @@ graphs:
     to: d44341fa-7de4-41f5-abfd-7e0a3b1d9be8
     fromPort: invalidSurface
     toPort: features
+  - id: 05a6d315-61a1-4021-acaa-606cb1a7435a
+    from: e28b5f31-4826-4775-a343-a12ecb7f90f9
+    to: d60f93c1-c55e-49ee-9332-657f4408ba05
+    fromPort: rejected
+    toPort: features
+  - id: cf5b54cd-a548-4694-a7db-35a4d682852c
+    from: abf4b25e-6c1f-46fd-b5f8-07d43d137abf
+    to: d60f93c1-c55e-49ee-9332-657f4408ba05
+    fromPort: rejected
+    toPort: features
+  - id: bbd0c116-cf6c-4f5f-b7c1-3c6011c013d3
+    from: d60f93c1-c55e-49ee-9332-657f4408ba05
+    to: d44341fa-7de4-41f5-abfd-7e0a3b1d9be8
+    fromPort: features
+    toPort: features
   - id: f57856b7-7b32-4a0d-88a4-2bfadaf2f9a3
     from: e28b5f31-4826-4775-a343-a12ecb7f90f9
     to: 0740c8ce-3c27-416f-9a13-5b2086090426
     fromPort: inCorrectOrientation
     toPort: features
-  - id: cf5b54cd-a548-4694-a7db-35a4d682852c
+  - id: 8a1dd667-081d-460e-9f22-86ea6ee30b6e
     from: abf4b25e-6c1f-46fd-b5f8-07d43d137abf
-    to: d60f93c1-c55e-49ee-9332-657f4408ba05
-    fromPort: inCorrectOrientation
-    toPort: features
-  - id: 05a6d315-61a1-4021-acaa-606cb1a7435a
-    from: d60f93c1-c55e-49ee-9332-657f4408ba05
-    to: 1c385359-698d-40df-aed8-e8b9b0eaac67
-    fromPort: features
-    toPort: features
-  - id: bbd0c116-cf6c-4f5f-b7c1-3c6011c013d3
-    from: 1c385359-698d-40df-aed8-e8b9b0eaac67
     to: 0740c8ce-3c27-416f-9a13-5b2086090426
-    fromPort: incorrectOrientation
+    fromPort: inCorrectOrientation
     toPort: features
   - id: 298fa998-d16c-4d64-bfa0-05d73b250a22
     from: 0740c8ce-3c27-416f-9a13-5b2086090426
@@ -3207,12 +2851,17 @@ graphs:
     to: c93837eb-e050-46f3-9c97-66d7273fe1e5
     fromPort: features
     toPort: features
+  - id: f86e6ef2-018a-4c34-a8d3-6da80a1d2665
+    from: b4d2d577-28a0-43a3-8a23-0ae562be1d04
+    to: d60f93c1-c55e-49ee-9332-657f4408ba05
+    fromPort: rejected
+    toPort: features
   - id: c472919a-4b86-462f-8570-34a149f69382
     from: c93837eb-e050-46f3-9c97-66d7273fe1e5
     to: 0c979585-82b2-41aa-909c-00d9b8d017d0
     fromPort: features
     toPort: features
-  - id: c472919a-4b86-462f-8570-34a149f69382
+  - id: 9eaa4869-aec6-45f7-86e7-6b5ea4f7616f
     from: 0c979585-82b2-41aa-909c-00d9b8d017d0
     to: 37e634aa-67c0-4f70-8fdc-939854a3cc21
     fromPort: features
@@ -3271,6 +2920,11 @@ graphs:
     from: e85ef1d5-a8fb-49e8-895a-b0a055c7b4c0
     to: b0568e70-1c73-4ee0-8bae-8db3687e3d7d
     fromPort: area
+    toPort: features
+  - id: 0ba2fc44-95d1-4c95-a185-fdd98a8cbd83
+    from: e85ef1d5-a8fb-49e8-895a-b0a055c7b4c0
+    to: d60f93c1-c55e-49ee-9332-657f4408ba05
+    fromPort: rejected
     toPort: features
   - id: a6f198a7-b3dd-4460-8169-6ae6679dfa5f
     from: b0568e70-1c73-4ee0-8bae-8db3687e3d7d

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
@@ -18,8 +18,10 @@ with:
     - squr
     - wwy
 graphs:
-  - !include ../../../../graphs/lod_splitter_with_dm.yml
-  - !include ../../../../graphs/surface_validator.yml
+  # New-geometry graphs: the legacy `lod_splitter_with_dm.yml` and
+  # `surface_validator.yml` build on actions that the new geometry world dropped.
+  - !include ../../../../graphs/lod_splitter_next.yml
+  - !include ../../../../graphs/surface_validator_next.yml
   # Common quality check graphs
   - !include ../../../../graphs/plateau4/xml_validator.yml
   - !include ../../../../graphs/plateau4/domain_of_definition_validator.yml
@@ -120,25 +122,31 @@ graphs:
             outputPort: features
 
       - id: 242e339a-c7df-4be4-82f7-3223a6ed2145
-        name: FeatureCityGmlReader
+        name: FeatureCityGml2Reader
         type: action
-        action: Feature CityGML Reader
+        action: Feature CityGML 2 Reader
         with:
-          codelistsPath:
-            type: flowExpr
-            value: attributes["codelists"]
-          flatten: true
           dataset:
             type: flowExpr
             value: attributes["path"]
+          # `extractTags` is left empty on purpose: one feature per top-level
+          # city object, so a road's traffic areas stay inside the road feature
+          # and the adjacent-surface check groups its surfaces together. Each
+          # surface still names its own city object through the
+          # `__citygml_geometry_*` attributes.
+
+      # Reprojects to the plane-rectangular CRS the checks run in: the planarity
+      # check needs a linear unit, and the 2D overlays need one common frame.
       - id: 10df06f3-cafa-4abd-ba94-04ac71dae467
-        name: HorizontalReprojector
+        name: CoordinateFrameReprojector
         type: action
-        action: Horizontal Reprojector
+        action: Coordinate Frame Reprojector
         with:
-          targetEpsgCode:
-            type: flowExpr
-            value: variables["prcs"]
+          destinationFrame:
+            type: crs
+            epsgCode:
+              type: flowExpr
+              value: variables["prcs"]
 
       # Unreferenced XLink detection for L-TRAN-03
       - id: 6f556405-1fdb-4807-8e3b-f18da79fbe1a
@@ -198,21 +206,21 @@ graphs:
             value: 03_交通_xlink参照エラー.csv
 
       - id: 51431704-ac14-41cd-988b-88141dc6e326
-        name: PLATEAU3.LodSplitterWithDM
+        name: LodSplitterNext
         type: subGraph
-        subGraphId: 7e98d856-1438-4148-bdcb-91747ef2e405
+        subGraphId: bf2ceaf8-f2b0-49ca-b05e-fd1469f15eb0
 
-      # Surface validator 2D for LOD1 and LOD2
+      # Surface validator for LOD1 and LOD2
       - id: e28b5f31-4826-4775-a343-a12ecb7f90f9
-        name: PLATEAU3.SurfaceValidator2D
+        name: SurfaceValidatorLod12
         type: subGraph
-        subGraphId: 8a5b1c9d-2e4f-4a3b-9c5d-1e6f8a2b4c7d
+        subGraphId: 51454aa9-c17c-43ca-a377-4c7b4622682b
 
-      # Surface validator 3D for LOD3
+      # Surface validator for LOD3
       - id: abf4b25e-6c1f-46fd-b5f8-07d43d137abf
-        name: PLATEAU3.SurfaceValidator3D
+        name: SurfaceValidatorLod3
         type: subGraph
-        subGraphId: 8a5b1c9d-2e4f-4a3b-9c5d-1e6f8a2b4c7d
+        subGraphId: 51454aa9-c17c-43ca-a377-4c7b4622682b
 
       # Attribute Mapper for surface validation errors
       - id: d44341fa-7de4-41f5-abfd-7e0a3b1d9be8
@@ -236,7 +244,7 @@ graphs:
             - attribute: FeatureType
               expr:
                 type: flowExpr
-                value: attributes.get("featureType", "")
+                value: attributes.get("__citygml_geometry_feature_type", "")
             - attribute: LOD
               expr:
                 type: flowExpr
@@ -244,39 +252,26 @@ graphs:
             - attribute: "gml:id"
               expr:
                 type: flowExpr
-                value: attributes.get("featureId", "")
+                value: attributes.get("__citygml_geometry_gml_id", "")
             - attribute: issue
               expr:
                 type: flowExpr
-                value: |
-                  vr = attributes.get("validationResult");
-                  if vr != null and "details" in vr {
-                    vr["details"][0][0]
-                  } else if "issue" in attributes {
-                    attributes["issue"]
-                  } else {
-                    "UnknownError"
-                  }
+                value: attributes.get("issue", "UnknownError")
 
-      # Extract surface orientation
+      # Geometry no check could run on, from the `rejected` port of the
+      # reprojector, the validators and the overlays. Reported as surface errors
+      # so it cannot vanish between the reader and the CSV.
       - id: d60f93c1-c55e-49ee-9332-657f4408ba05
-        name: OrientationExtractor
+        name: AttributeManagerRejected
         type: action
-        action: Orientation Extractor
+        action: Attribute Manager
         with:
-          outputAttribute: orientation
-
-      # Filter for incorrect orientation (clockwise/right_hand_rule)
-      - id: 1c385359-698d-40df-aed8-e8b9b0eaac67
-        name: FilterIncorrectOrientation
-        type: action
-        action: Feature Filter
-        with:
-          conditions:
-            - expr:
-                type: flowExpr
-                value: attributes["orientation"] == "clockwise"
-              outputPort: incorrectOrientation
+          operations:
+            - attribute: issue
+              method: create
+              value:
+                type: string
+                value: GeometryRejected
 
       # Map attributes for CSV output
       - id: 0740c8ce-3c27-416f-9a13-5b2086090426
@@ -300,7 +295,7 @@ graphs:
             - attribute: FeatureType
               expr:
                 type: flowExpr
-                value: attributes.get("featureType", "")
+                value: attributes.get("__citygml_geometry_feature_type", "")
             - attribute: LOD
               expr:
                 type: flowExpr
@@ -308,7 +303,7 @@ graphs:
             - attribute: "gml:id"
               expr:
                 type: flowExpr
-                value: attributes.get("featureId", "")
+                value: attributes.get("__citygml_geometry_gml_id", "")
 
             # The error count is always 1
             - attribute: "エラー数"
@@ -364,7 +359,7 @@ graphs:
           groupBy:
             - lod
             - fileIndex
-            - gmlId
+            - __citygml_gml_id
             - package
           tolerance: 0.01
 
@@ -402,11 +397,11 @@ graphs:
           conditions:
             - expr:
                 type: flowExpr
-                value: attributes["lod"] == "1"
+                value: attributes.get("lod") == 1
               outputPort: lod1
             - expr:
                 type: flowExpr
-                value: attributes["lod"] == "2" or attributes["lod"] == "3"
+                value: attributes.get("lod") == 2 or attributes.get("lod") == 3
               outputPort: lod23
 
       # Detect overlaps between different Road instances for LOD1
@@ -460,13 +455,13 @@ graphs:
         with:
           sourceAttribute: overlaidLists
 
-      # DuplicateFilter to remove duplicates based on gmlId
+      # DuplicateFilter to remove duplicates based on gml:id
       - id: f94ccdb2-2133-4b0d-886d-9c933c0d645f
         name: DuplicateFilterLineOverlaps
         type: action
         action: Attribute Duplicate Filter
         with:
-          filterBy: ["gmlId"]
+          filterBy: ["__citygml_gml_id"]
 
       # Replace geometry from attribute
       - id: 2261a5c9-46a4-45ce-a292-d277a3dc0ebc
@@ -510,18 +505,18 @@ graphs:
           countStart: 0
           outputAttribute: areaOverlapIndex
 
-      # Concatenate gmlId from each element in areaOverlapList
+      # Concatenate gml:id from each element in areaOverlapList
       - id: 8d7f5e2a-1b3c-4f9e-a7d8-3e9b6c4a2f1d
         name: ListConcatenator
         type: action
         action: List Concatenator
         with:
           list: areaOverlapList
-          elementAttribute: gmlId
+          elementAttribute: __citygml_gml_id
           separator: ","
           outputAttribute: concatenatedGmlIds
 
-      # DuplicateFilter to remove duplicates based on gmlId
+      # DuplicateFilter to remove duplicates based on the concatenated gml:ids
       - id: 518572d2-8561-4b60-ab28-fcd66d90afa2
         name: DuplicateFilter
         type: action
@@ -559,7 +554,7 @@ graphs:
             - attribute: FeatureType
               expr:
                 type: flowExpr
-                value: attributes.get("featureType", "")
+                value: attributes.get("__citygml_feature_type", "")
             - attribute: LOD
               expr:
                 type: flowExpr
@@ -567,7 +562,7 @@ graphs:
             - attribute: "gml:id"
               expr:
                 type: flowExpr
-                value: attributes.get("gmlId", "")
+                value: attributes.get("__citygml_gml_id", "")
             - attribute: 隣接ID
               expr:
                 type: flowExpr
@@ -725,11 +720,21 @@ graphs:
         action: Statistics Calculator
         with:
           calculations:
-            # Domain-specific error columns
+            # Domain-specific error columns. Adjacent-surface overlap and
+            # incorrect orientation are reported but, per the FME original, do
+            # not count towards `totalErrorCount`.
             - newAttribute: "L-TRAN-03 xlink参照エラー"
               expr:
                 type: flowExpr
                 value: attributes.get("L-TRAN-03 xlink参照エラー", 0)
+            - newAttribute: "L-TRAN-02 隣接面重複"
+              expr:
+                type: flowExpr
+                value: attributes.get("L-TRAN-02 隣接面重複", 0)
+            - newAttribute: "面の向き不正"
+              expr:
+                type: flowExpr
+                value: attributes.get("面の向き不正", 0)
             - newAttribute: "面のエラー"
               expr:
                 type: flowExpr
@@ -873,6 +878,12 @@ graphs:
         to: 51431704-ac14-41cd-988b-88141dc6e326
         fromPort: features
         toPort: features
+      # Geometry that could not be reprojected still has to be accounted for
+      - id: 5e267610-bc90-4bb1-a31e-38d5c874268a
+        from: 10df06f3-cafa-4abd-ba94-04ac71dae467
+        to: d60f93c1-c55e-49ee-9332-657f4408ba05
+        fromPort: rejected
+        toPort: features
 
       # XLink detection flow
       - id: 30d1bde3-8025-47aa-983e-1f5429069aa4
@@ -892,7 +903,7 @@ graphs:
         toPort: features
 
       # Connect LOD splitter to surface validators
-      # LOD1 and LOD2 go to SurfaceValidator2D
+      # LOD1 and LOD2 go to SurfaceValidatorLod12
       - id: e23edb68-8299-4a9f-a722-f82b73c82d88
         from: 51431704-ac14-41cd-988b-88141dc6e326
         to: e28b5f31-4826-4775-a343-a12ecb7f90f9
@@ -904,53 +915,54 @@ graphs:
         fromPort: lod2
         toPort: features
 
-      # LOD3 goes to SurfaceValidator3D
+      # LOD3 goes to SurfaceValidatorLod3
       - id: e44eff90-4ce0-4dc2-8c66-78e553ef4560
         from: 51431704-ac14-41cd-988b-88141dc6e326
         to: abf4b25e-6c1f-46fd-b5f8-07d43d137abf
         fromPort: lod3
         toPort: features
 
-      # Connect SurfaceValidator2D invalidSurface to SurfaceValidationAttributeMapper
+      # Connect SurfaceValidatorLod12 invalidSurface to SurfaceValidationAttributeMapper
       - id: bf52a96b-2a23-4866-9646-1a8a7e17ade3
         from: e28b5f31-4826-4775-a343-a12ecb7f90f9
         to: d44341fa-7de4-41f5-abfd-7e0a3b1d9be8
         fromPort: invalidSurface
         toPort: features
 
-      # Connect SurfaceValidator3D invalidSurface to SurfaceValidationAttributeMapper
+      # Connect SurfaceValidatorLod3 invalidSurface to SurfaceValidationAttributeMapper
       - id: 06d601c8-0bf2-4be0-b4ef-c942e2336373
         from: abf4b25e-6c1f-46fd-b5f8-07d43d137abf
         to: d44341fa-7de4-41f5-abfd-7e0a3b1d9be8
         fromPort: invalidSurface
         toPort: features
 
-      # Connect SurfaceValidator2D incorrectOrientation to AttributeMapper (for LOD1/2)
+      # Rejected geometry from either validator is reported as a surface error
+      - id: 05a6d315-61a1-4021-acaa-606cb1a7435a
+        from: e28b5f31-4826-4775-a343-a12ecb7f90f9
+        to: d60f93c1-c55e-49ee-9332-657f4408ba05
+        fromPort: rejected
+        toPort: features
+      - id: cf5b54cd-a548-4694-a7db-35a4d682852c
+        from: abf4b25e-6c1f-46fd-b5f8-07d43d137abf
+        to: d60f93c1-c55e-49ee-9332-657f4408ba05
+        fromPort: rejected
+        toPort: features
+      - id: bbd0c116-cf6c-4f5f-b7c1-3c6011c013d3
+        from: d60f93c1-c55e-49ee-9332-657f4408ba05
+        to: d44341fa-7de4-41f5-abfd-7e0a3b1d9be8
+        fromPort: features
+        toPort: features
+
+      # Connect both validators' inCorrectOrientation to AttributeMapper
       - id: f57856b7-7b32-4a0d-88a4-2bfadaf2f9a3
         from: e28b5f31-4826-4775-a343-a12ecb7f90f9
         to: 0740c8ce-3c27-416f-9a13-5b2086090426
         fromPort: inCorrectOrientation
         toPort: features
-
-      # Connect SurfaceValidator3D to OrientationExtractor (for LOD3)
-      - id: cf5b54cd-a548-4694-a7db-35a4d682852c
+      - id: 8a1dd667-081d-460e-9f22-86ea6ee30b6e
         from: abf4b25e-6c1f-46fd-b5f8-07d43d137abf
-        to: d60f93c1-c55e-49ee-9332-657f4408ba05
-        fromPort: inCorrectOrientation
-        toPort: features
-
-      # OrientationExtractor to Filter
-      - id: 05a6d315-61a1-4021-acaa-606cb1a7435a
-        from: d60f93c1-c55e-49ee-9332-657f4408ba05
-        to: 1c385359-698d-40df-aed8-e8b9b0eaac67
-        fromPort: features
-        toPort: features
-
-      # Filter to AttributeMapper
-      - id: bbd0c116-cf6c-4f5f-b7c1-3c6011c013d3
-        from: 1c385359-698d-40df-aed8-e8b9b0eaac67
         to: 0740c8ce-3c27-416f-9a13-5b2086090426
-        fromPort: incorrectOrientation
+        fromPort: inCorrectOrientation
         toPort: features
 
       # AttributeMapper to FeatureWriter
@@ -991,6 +1003,12 @@ graphs:
         to: c93837eb-e050-46f3-9c97-66d7273fe1e5
         fromPort: features
         toPort: features
+      # Geometry that could not be flattened still has to be accounted for
+      - id: f86e6ef2-018a-4c34-a8d3-6da80a1d2665
+        from: b4d2d577-28a0-43a3-8a23-0ae562be1d04
+        to: d60f93c1-c55e-49ee-9332-657f4408ba05
+        fromPort: rejected
+        toPort: features
 
       # Dissolver to FeatureSorter
       - id: c472919a-4b86-462f-8570-34a149f69382
@@ -1000,7 +1018,7 @@ graphs:
         toPort: features
 
       # FeatureSorter to GeometryExtractor
-      - id: c472919a-4b86-462f-8570-34a149f69382
+      - id: 9eaa4869-aec6-45f7-86e7-6b5ea4f7616f
         from: 0c979585-82b2-41aa-909c-00d9b8d017d0
         to: 37e634aa-67c0-4f70-8fdc-939854a3cc21
         fromPort: features
@@ -1080,6 +1098,12 @@ graphs:
         from: e85ef1d5-a8fb-49e8-895a-b0a055c7b4c0
         to: b0568e70-1c73-4ee0-8bae-8db3687e3d7d
         fromPort: area
+        toPort: features
+      # Geometry the overlay could not take still has to be accounted for
+      - id: 0ba2fc44-95d1-4c95-a185-fdd98a8cbd83
+        from: e85ef1d5-a8fb-49e8-895a-b0a055c7b4c0
+        to: d60f93c1-c55e-49ee-9332-657f4408ba05
+        fromPort: rejected
         toPort: features
 
       # FilterAreaOverlaps to AreaOverlapCounter

--- a/engine/runtime/geometry/src/overlay/mod.rs
+++ b/engine/runtime/geometry/src/overlay/mod.rs
@@ -150,6 +150,18 @@ pub fn overlay_2d(
     overlay_leaves(&a_leaves, &b_leaves, op)
 }
 
+/// The position each of `points` snaps to, or `None` when there is nothing to
+/// snap. Scanning in index order, a point not yet claimed becomes an anchor and
+/// claims every later unclaimed point within `tolerance` of it, so no point
+/// moves further than the tolerance and anchors keep their exact coordinates. A
+/// non-positive tolerance snaps nothing.
+pub fn snap_positions(points: &[[f64; 2]], tolerance: f64) -> Option<Vec<[f64; 2]>> {
+    if tolerance <= 0.0 {
+        return None;
+    }
+    snap::snapped_positions(points, tolerance)
+}
+
 /// The union of one areal operand's own leaves, as disjoint polygons in their
 /// common frame (empty when they enclose no area). Taking leaves lets several
 /// geometries dissolve as one operand. Vertices closer together than

--- a/engine/runtime/geometry/src/overlay/snap.rs
+++ b/engine/runtime/geometry/src/overlay/snap.rs
@@ -46,7 +46,7 @@ pub(super) fn snap_shapes(shapes: &mut [Shape], tolerance: f64) {
 /// The position each of `points` snaps to, or `None` when there is nothing to
 /// snap. Scanning in index order, a point not yet claimed becomes an anchor and
 /// claims every later unclaimed point within `tolerance` of it.
-fn snapped_positions(points: &[[f64; 2]], tolerance: f64) -> Option<Vec<[f64; 2]>> {
+pub(super) fn snapped_positions(points: &[[f64; 2]], tolerance: f64) -> Option<Vec<[f64; 2]>> {
     let n = points.len();
     if n <= 1 {
         return None;

--- a/engine/testing/data/testcases/quality-check/plateau4/03-tran/L-TRAN-02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/03-tran/L-TRAN-02/workflow_test.json
@@ -1,7 +1,5 @@
 {
   "description": "Test for plateau4 L-TRAN-02 inspection.",
-  "skip": true,
-  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/03-tran/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/03-tran/L-TRAN-03/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/03-tran/L-TRAN-03/workflow_test.json
@@ -1,6 +1,5 @@
 {
   "description": "Test for plateau4 L-TRAN-03 inspection.",
-  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/03-tran/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/03-tran/Z-TRAN-01-surface-orientation/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/03-tran/Z-TRAN-01-surface-orientation/workflow_test.json
@@ -1,6 +1,5 @@
 {
   "description": "Test for checking transportation objects' surface orientation errors.",
-  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/03-tran/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/03-tran/Z-tran-00_no-error/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/03-tran/Z-tran-00_no-error/workflow_test.json
@@ -1,6 +1,5 @@
 {
   "description": "Verify output files: no errors, empty CityGML",
-  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/03-tran/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/03-tran/common/C01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/03-tran/common/C01/workflow_test.json
@@ -1,6 +1,5 @@
 {
   "description": "Test quality check for C01. L-TRAN-02 隣接面重複 is excluded from the summary because the input files are duplicates (with different names).",
-  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/03-tran/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/03-tran/common/C05/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/03-tran/common/C05/workflow_test.json
@@ -1,6 +1,5 @@
 {
   "description": "Test quality check for C05",
-  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/03-tran/workflow.yml",
   "workflowVariables": [
     {


### PR DESCRIPTION
# Overview

Ports the plateau4 03-tran (transportation) quality-check workflow to the new geometry world.

## What I've done

- Added new-geometry counterparts of the LOD splitter and surface validator subgraphs, and rewired 03-tran onto them.
- Made the CityGML 2 reader carry each geometry member's owning city object (`gml:id` and feature type) and merge the input feature's attributes.
- Let `Coordinate Frame Reprojector` take `epsgCode` as an expression, so the workflow can pass `variables["prcs"]`.
- Snap vertices in `Line On Line Overlayer` before the exact intersection kernel.

## What I haven't done

- `flatten_single_child_objects` is still unhandled in the new-geometry reader path.

## How I tested

`cargo test -p workflow-tests --features new-geometry test_quality_check_plateau4_03_tran`

## Which point I want you to review particularly

- 03-tran reads with an empty `extractTags` on purpose: a road keeps its traffic areas so the adjacent-surface check can group them, and each surface names its own city object via the `__citygml_geometry_*` member attributes instead.

## Memo

- Geometry rejected anywhere in the chain is now emitted as a `GeometryRejected` surface error rather than dropped, so nothing disappears silently between the reader and the CSV.
- The overlayer's snap is required because the exact kernel reads two copies of a shared edge differing in their last bits as a crossing part-way along it, not as a collinear overlap.