### PR TITLE
feat(engine): run plateau4 qc(tran) on new geometry

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.146"
+version = "0.2.147"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "Inflector",
  "approx",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5024,7 +5024,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "bytes",
  "clap",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-diagnostics"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5163,7 +5163,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5180,7 +5180,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "approx",
  "bvh",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5256,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5265,7 +5265,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5297,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5351,7 +5351,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5365,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "bytes",
  "futures",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "bytes",
  "futures",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5415,7 +5415,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5453,7 +5453,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "ahash",
  "bytes",
@@ -5489,7 +5489,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.523"
+version = "0.0.524"
 dependencies = [
  "async-trait",
  "axum",
@@ -8257,7 +8257,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.336"
+version = "0.1.337"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.523"
+version = "0.0.524"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/action-processor/src/citygml_parser/geometry_next.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/geometry_next.rs
@@ -21,29 +21,41 @@ use super::resolver::{FaceIds, GeomNode, GmlGeometryType, LeafIds, Role, Unresol
 use super::utils::{frame_for, local_name, GML_NS_311_ID, GML_NS_ID};
 
 /// A geometry carved from a feature, tagged with the LOD of the property it came
-/// from (`None` for `tin`) and the `gml:id`s of its enclosing elements (nearest
-/// first), used to attach it to the right feature when `flatten` hoists children.
+/// from (`None` for `tin`) and its enclosing `gml:id`-bearing elements (nearest
+/// first), used to attach it to the right feature when `flatten` hoists children
+/// and to name the object a surface belongs to.
 pub(super) struct PendingGeom {
     pub(super) lod: Option<u8>,
     pub(super) node: GeomNode,
-    pub(super) owner_ids: Vec<String>,
+    pub(super) owners: Vec<GeomOwner>,
 }
 
-/// A `gml:id`-bearing ancestor, chained on the stack so the enclosing-id list is
-/// materialized only where a geometry is actually found.
+/// An element that encloses a geometry and carries a `gml:id`.
+pub(super) struct GeomOwner {
+    pub(super) gml_id: String,
+    /// The qualified element name, e.g. `tran:AuxiliaryTrafficArea`.
+    pub(super) feature_type: String,
+}
+
+/// A `gml:id`-bearing ancestor, chained on the stack so the enclosing-owner list
+/// is materialized only where a geometry is actually found.
 struct Owner<'a> {
     id: &'a str,
+    name: &'a str,
     parent: Option<&'a Owner<'a>>,
 }
 
-/// The enclosing `gml:id`s, nearest first.
-fn owner_chain(mut owner: Option<&Owner>) -> Vec<String> {
-    let mut ids = Vec::new();
+/// The enclosing `gml:id`-bearing elements, nearest first.
+fn owner_chain(mut owner: Option<&Owner>) -> Vec<GeomOwner> {
+    let mut owners = Vec::new();
     while let Some(o) = owner {
-        ids.push(o.id.to_string());
+        owners.push(GeomOwner {
+            gml_id: o.id.to_string(),
+            feature_type: o.name.to_string(),
+        });
         owner = o.parent;
     }
-    ids
+    owners
 }
 
 impl Parser {
@@ -61,14 +73,18 @@ impl Parser {
 
     /// Recursively rebuild `node` without its geometry-property children, collecting
     /// the parsed geometries into `geoms`. `owner` is the chain of enclosing
-    /// `gml:id`s above `node`.
+    /// `gml:id`-bearing elements above `node`.
     fn strip(
         &mut self,
         node: &Arc<RawNode>,
         owner: Option<&Owner>,
         geoms: &mut Vec<PendingGeom>,
     ) -> Arc<RawNode> {
-        let here = gml_id_ref(node).map(|id| Owner { id, parent: owner });
+        let here = gml_id_ref(node).map(|id| Owner {
+            id,
+            name: node.name.0.as_str(),
+            parent: owner,
+        });
         let owner = here.as_ref().or(owner);
         let mut new_children: Option<Vec<RawChild>> = None;
 
@@ -93,7 +109,7 @@ impl Parser {
 
             if let Some(lod) = lod {
                 if let Some(gnode) = self.property_geometry(e) {
-                    let owner_ids = if self.track_owners {
+                    let owners = if self.track_owners {
                         owner_chain(owner)
                     } else {
                         Vec::new()
@@ -101,7 +117,7 @@ impl Parser {
                     geoms.push(PendingGeom {
                         lod,
                         node: gnode,
-                        owner_ids,
+                        owners,
                     });
                 }
                 if new_children.is_none() {
@@ -646,7 +662,7 @@ mod tests {
     }
 
     #[test]
-    fn geometry_tagged_with_enclosing_gml_ids() {
+    fn geometry_tagged_with_enclosing_owners() {
         // The wrapping feature is `b1`; a nested WallSurface `wall1` owns the geometry.
         let (geoms, _) = parse_one(&format!(
             r#"<core:boundary><con:WallSurface gml:id="wall1">
@@ -654,9 +670,14 @@ mod tests {
                </con:WallSurface></core:boundary>"#
         ));
         assert_eq!(geoms.len(), 1);
+        let owners: Vec<(&str, &str)> = geoms[0]
+            .owners
+            .iter()
+            .map(|o| (o.gml_id.as_str(), o.feature_type.as_str()))
+            .collect();
         assert_eq!(
-            geoms[0].owner_ids,
-            vec!["wall1".to_string(), "b1".to_string()]
+            owners,
+            vec![("wall1", "con:WallSurface"), ("b1", "bldg:Building")]
         );
     }
 

--- a/engine/runtime/action-processor/src/citygml_parser/pipeline.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/pipeline.rs
@@ -20,6 +20,13 @@ use super::{
 /// `GeometryCollection` member's source LOD (absent for a `tin`, which has none).
 pub const MEMBER_LOD_KEY: &str = "lod";
 
+/// Per-member attribute keys naming the innermost enclosing element that carries a
+/// `gml:id` — the object the geometry belongs to. One feature can hold the geometry
+/// of several nested objects, so the feature's own `gml:id` and type do not identify
+/// a single member's owner.
+pub const MEMBER_GEOMETRY_GML_ID_KEY: &str = "__citygml_geometry_gml_id";
+pub const MEMBER_GEOMETRY_FEATURE_TYPE_KEY: &str = "__citygml_geometry_feature_type";
+
 /// Resolves the parsed document (xlink + codespace) and returns one feature per top-level city
 /// object, or — when `extract_tags` is non-empty — one feature per matching flattened node.
 /// `base_attributes` maps a source file URL to the input feature's attributes (e.g. `package`),
@@ -167,7 +174,7 @@ mod build_next {
         CITYGML_ROOT_GML_ID_KEY,
     };
 
-    use super::MEMBER_LOD_KEY;
+    use super::{MEMBER_GEOMETRY_FEATURE_TYPE_KEY, MEMBER_GEOMETRY_GML_ID_KEY, MEMBER_LOD_KEY};
 
     use crate::citygml_parser::{
         appearance::{self, AppearanceIndex},
@@ -272,11 +279,11 @@ mod build_next {
                 let mut by_owner: HashMap<&str, Vec<&geometry::PendingGeom>> = HashMap::new();
                 for g in &geoms {
                     if let Some(target) = g
-                        .owner_ids
+                        .owners
                         .iter()
-                        .find(|id| emitted_ids.contains(id.as_str()))
+                        .find(|o| emitted_ids.contains(o.gml_id.as_str()))
                     {
-                        by_owner.entry(target.as_str()).or_default().push(g);
+                        by_owner.entry(target.gml_id.as_str()).or_default().push(g);
                     }
                 }
                 for (node, parent_id) in &extracted {
@@ -326,7 +333,8 @@ mod build_next {
         srs_by_file: &HashMap<String, EpsgCode>,
     ) {
         // Each member records its source LOD (a `tin` has none) so downstream
-        // sinks can select a single LOD; gml:id is still TODO.
+        // sinks can select a single LOD, and the object it belongs to so a
+        // per-surface report can name it.
         let mut members: Vec<Geometry> = Vec::new();
         let mut attrs: Vec<Attributes> = Vec::new();
         for pending in geoms {
@@ -341,6 +349,16 @@ mod build_next {
                 member_attrs.insert(
                     Attribute::new(MEMBER_LOD_KEY),
                     AttributeValue::Number(lod.into()),
+                );
+            }
+            if let Some(owner) = pending.owners.first() {
+                member_attrs.insert(
+                    Attribute::new(MEMBER_GEOMETRY_GML_ID_KEY),
+                    AttributeValue::String(owner.gml_id.clone()),
+                );
+                member_attrs.insert(
+                    Attribute::new(MEMBER_GEOMETRY_FEATURE_TYPE_KEY),
+                    AttributeValue::String(owner.feature_type.clone()),
                 );
             }
             members.push(member);
@@ -372,6 +390,7 @@ mod build_next {
                      xmlns:core="http://www.opengis.net/citygml/3.0"
                      xmlns:bldg="http://www.opengis.net/citygml/building/3.0"
                      xmlns:con="http://www.opengis.net/citygml/construction/3.0"
+                     xmlns:tran="http://www.opengis.net/citygml/transportation/3.0"
                      xmlns:gml="http://www.opengis.net/gml/3.2"
                      xmlns:xlink="http://www.w3.org/1999/xlink">{members}</core:CityModel>"#
             );
@@ -513,6 +532,59 @@ mod build_next {
             }
             assert_single_polygon_surface(by_type(&features, "con:WallSurface"));
             assert_single_polygon_surface(by_type(&features, "con:RoofSurface"));
+        }
+
+        #[test]
+        fn case13_each_member_names_the_object_it_belongs_to() {
+            // Without `extract_tags` the nested TrafficArea stays inside the Road
+            // feature, so only the per-member attributes tell the two apart.
+            let members = format!(
+                "<core:cityObjectMember><tran:Road gml:id=\"road1\">\
+                   <core:lod1MultiSurface><gml:MultiSurface><gml:surfaceMember>{TA}</gml:surfaceMember></gml:MultiSurface></core:lod1MultiSurface>\
+                   <tran:trafficArea><tran:TrafficArea gml:id=\"ta1\">\
+                     <core:lod3MultiSurface><gml:MultiSurface><gml:surfaceMember>{TB}</gml:surfaceMember></gml:MultiSurface></core:lod3MultiSurface>\
+                   </tran:TrafficArea></tran:trafficArea>\
+                 </tran:Road></core:cityObjectMember>"
+            );
+            let features = run(&members, &[]);
+            assert_eq!(features.len(), 1);
+            let Geometry::GeometryCollection(gc) = &*features[0].geometry else {
+                panic!(
+                    "expected GeometryCollection, got {:?}",
+                    features[0].geometry
+                );
+            };
+            let owners: Vec<(
+                Option<&AttributeValue>,
+                Option<&AttributeValue>,
+                Option<&AttributeValue>,
+            )> = gc
+                .member_attributes()
+                .iter()
+                .map(|a| {
+                    (
+                        a.get(&Attribute::new(MEMBER_LOD_KEY)),
+                        a.get(&Attribute::new(MEMBER_GEOMETRY_GML_ID_KEY)),
+                        a.get(&Attribute::new(MEMBER_GEOMETRY_FEATURE_TYPE_KEY)),
+                    )
+                })
+                .collect();
+            let expected = |lod: u64, id: &str, ty: &str| {
+                (
+                    AttributeValue::Number(lod.into()),
+                    AttributeValue::String(id.to_string()),
+                    AttributeValue::String(ty.to_string()),
+                )
+            };
+            let lod1 = expected(1, "road1", "tran:Road");
+            let lod3 = expected(3, "ta1", "tran:TrafficArea");
+            assert_eq!(
+                owners,
+                vec![
+                    (Some(&lod1.0), Some(&lod1.1), Some(&lod1.2)),
+                    (Some(&lod3.0), Some(&lod3.1), Some(&lod3.2)),
+                ]
+            );
         }
     }
 }

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
@@ -17,46 +17,26 @@ with:
   - squr
   - wwy
 graphs:
-- id: 7e98d856-1438-4148-bdcb-91747ef2e405
-  name: PLATEAU3.LodSplitterWithDM
+- id: b1000000-0000-4000-8000-000000000000
+  name: LodSplitter
   nodes:
-  - id: 5848465e-828f-4646-874e-e2f182b73714
+  - id: b1000000-0000-4000-8000-000000000001
     name: InputRouter
     type: action
     action: Input Router
     with:
       routingPort: features
-  - id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-    name: DmGeometricAttributeFilter
-    type: action
-    action: Feature Filter
-    with:
-      conditions:
-      - expr:
-          type: flowExpr
-          value: attributes.get("dm_feature_type") == "DmGeometricAttribute"
-        outputPort: DmGeometricAttribute
-  - id: 278ab965-ce22-473d-98c6-c7b381c38679
+  - id: b1000000-0000-4000-8000-000000000002
     name: GeometryFilter
     type: action
     action: Geometry Filter
     with:
       filterType: none
-  - id: 1787b15c-19b5-4386-a0ff-f0e58f477d07
-    name: FeatureFilterByExceptSplit
-    type: action
-    action: Feature Filter
-    with:
-      conditions:
-      - expr:
-          type: flowExpr
-          value: variables.get("exceptSplit", false)
-        outputPort: exceptSplit
-  - id: 8fe1a102-e3f3-40dd-b235-66e9c148830f
+  - id: b1000000-0000-4000-8000-000000000003
     name: GeometrySplitter
     type: action
     action: Geometry Splitter
-  - id: 7c843a02-3b1f-40c1-8214-562e72bfb9a6
+  - id: b1000000-0000-4000-8000-000000000004
     name: FeatureFilterByLod
     type: action
     action: Feature Filter
@@ -64,155 +44,168 @@ graphs:
       conditions:
       - expr:
           type: flowExpr
-          value: attributes["lod"] == "0"
+          value: attributes.get("lod") == 0
         outputPort: lod0
       - expr:
           type: flowExpr
-          value: attributes["lod"] == "1"
+          value: attributes.get("lod") == 1
         outputPort: lod1
       - expr:
           type: flowExpr
-          value: attributes["lod"] == "2"
+          value: attributes.get("lod") == 2
         outputPort: lod2
       - expr:
           type: flowExpr
-          value: attributes["lod"] == "3"
+          value: attributes.get("lod") == 3
         outputPort: lod3
       - expr:
           type: flowExpr
-          value: attributes["lod"] == "4"
+          value: attributes.get("lod") == 4
         outputPort: lod4
-  - id: b1c2d3e4-f5a6-7890-bcde-f12345678901
-    name: DmGeometricAttributeRouter
-    type: action
-    action: Output Router
-    with:
-      routingPort: DmGeometricAttribute
-  - id: dab9d3b6-594e-40cc-9f6b-c605005e3320
+  - id: b1000000-0000-4000-8000-000000000010
     name: Lod0Router
     type: action
     action: Output Router
     with:
       routingPort: lod0
-  - id: dab9d3b6-594e-40cc-9f6b-c605005e3321
+  - id: b1000000-0000-4000-8000-000000000011
     name: Lod1Router
     type: action
     action: Output Router
     with:
       routingPort: lod1
-  - id: dab9d3b6-594e-40cc-9f6b-c605005e3322
+  - id: b1000000-0000-4000-8000-000000000012
     name: Lod2Router
     type: action
     action: Output Router
     with:
       routingPort: lod2
-  - id: dab9d3b6-594e-40cc-9f6b-c605005e3323
+  - id: b1000000-0000-4000-8000-000000000013
     name: Lod3Router
     type: action
     action: Output Router
     with:
       routingPort: lod3
-  - id: dab9d3b6-594e-40cc-9f6b-c605005e3324
+  - id: b1000000-0000-4000-8000-000000000014
     name: Lod4Router
     type: action
     action: Output Router
     with:
       routingPort: lod4
   edges:
-  - id: fcc0d596-9169-4289-9f35-07c8cbec6f10
-    from: 5848465e-828f-4646-874e-e2f182b73714
-    to: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  - id: b1000000-0000-4000-8000-000000000101
+    from: b1000000-0000-4000-8000-000000000001
+    to: b1000000-0000-4000-8000-000000000002
     fromPort: features
     toPort: features
-  - id: c1d2e3f4-a5b6-7c8d-9e0f-1a2b3c4d5e6f
-    from: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-    to: 278ab965-ce22-473d-98c6-c7b381c38679
+  - id: b1000000-0000-4000-8000-000000000102
+    from: b1000000-0000-4000-8000-000000000002
+    to: b1000000-0000-4000-8000-000000000003
     fromPort: unfiltered
     toPort: features
-  - id: d2e3f4a5-b6c7-8d9e-0f1a-2b3c4d5e6f7a
-    from: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-    to: b1c2d3e4-f5a6-7890-bcde-f12345678901
-    fromPort: DmGeometricAttribute
-    toPort: features
-  - id: 1386a662-cf02-4475-a5d2-3668a50a56b7
-    from: 278ab965-ce22-473d-98c6-c7b381c38679
-    to: 1787b15c-19b5-4386-a0ff-f0e58f477d07
-    fromPort: unfiltered
-    toPort: features
-  - id: ef2f1484-6173-4f34-85bc-58bc45e31bff
-    from: 1787b15c-19b5-4386-a0ff-f0e58f477d07
-    to: 8fe1a102-e3f3-40dd-b235-66e9c148830f
-    fromPort: unfiltered
-    toPort: features
-  - id: 111cc70e-e1ad-44f4-b4c8-82f7b1cf1309
-    from: 8fe1a102-e3f3-40dd-b235-66e9c148830f
-    to: 7c843a02-3b1f-40c1-8214-562e72bfb9a6
+  - id: b1000000-0000-4000-8000-000000000103
+    from: b1000000-0000-4000-8000-000000000003
+    to: b1000000-0000-4000-8000-000000000004
     fromPort: features
     toPort: features
-  - id: 5857909b-7fc0-4d3e-adfa-65a5669a6646
-    from: 1787b15c-19b5-4386-a0ff-f0e58f477d07
-    to: 7c843a02-3b1f-40c1-8214-562e72bfb9a6
-    fromPort: exceptSplit
-    toPort: features
-  - id: 1a802e2e-c876-42e3-b3ae-639af1bc7780
-    from: 7c843a02-3b1f-40c1-8214-562e72bfb9a6
-    to: dab9d3b6-594e-40cc-9f6b-c605005e3320
+  - id: b1000000-0000-4000-8000-000000000110
+    from: b1000000-0000-4000-8000-000000000004
+    to: b1000000-0000-4000-8000-000000000010
     fromPort: lod0
     toPort: features
-  - id: 1a802e2e-c876-42e3-b3ae-639af1bc7781
-    from: 7c843a02-3b1f-40c1-8214-562e72bfb9a6
-    to: dab9d3b6-594e-40cc-9f6b-c605005e3321
+  - id: b1000000-0000-4000-8000-000000000111
+    from: b1000000-0000-4000-8000-000000000004
+    to: b1000000-0000-4000-8000-000000000011
     fromPort: lod1
     toPort: features
-  - id: 1a802e2e-c876-42e3-b3ae-639af1bc7782
-    from: 7c843a02-3b1f-40c1-8214-562e72bfb9a6
-    to: dab9d3b6-594e-40cc-9f6b-c605005e3322
+  - id: b1000000-0000-4000-8000-000000000112
+    from: b1000000-0000-4000-8000-000000000004
+    to: b1000000-0000-4000-8000-000000000012
     fromPort: lod2
     toPort: features
-  - id: 1a802e2e-c876-42e3-b3ae-639af1bc7783
-    from: 7c843a02-3b1f-40c1-8214-562e72bfb9a6
-    to: dab9d3b6-594e-40cc-9f6b-c605005e3323
+  - id: b1000000-0000-4000-8000-000000000113
+    from: b1000000-0000-4000-8000-000000000004
+    to: b1000000-0000-4000-8000-000000000013
     fromPort: lod3
     toPort: features
-  - id: 1a802e2e-c876-42e3-b3ae-639af1bc7784
-    from: 7c843a02-3b1f-40c1-8214-562e72bfb9a6
-    to: dab9d3b6-594e-40cc-9f6b-c605005e3324
+  - id: b1000000-0000-4000-8000-000000000114
+    from: b1000000-0000-4000-8000-000000000004
+    to: b1000000-0000-4000-8000-000000000014
     fromPort: lod4
     toPort: features
-- id: 8a5b1c9d-2e4f-4a3b-9c5d-1e6f8a2b4c7d
-  name: PLATEAU3.SurfaceValidator3D
+- id: c3000000-0000-4000-8000-000000000000
+  name: TranSurfaceChecks
   nodes:
-  - id: 2f8a4b1c-5e9d-4c2a-8b6e-3f7a9b2c5d8e
+  - id: c3000000-0000-4000-8000-000000000001
     name: InputRouter
     type: action
     action: Input Router
     with:
       routingPort: features
-  - id: 4c7a2b5e-8f1d-4a6c-9e2b-7a4c8e1b3f6d
-    name: Noop
+  - id: c3000000-0000-4000-8000-000000000002
+    name: GeometryCoercerFaces
     type: action
-    action: Noop Processor
-  - id: 6e3b8a1c-f4d7-4b9e-a2c5-8f1b4e6a9c3d
-    name: SurfaceRouter
+    action: Geometry Coercer
+    with:
+      targetType: polygon
+  - id: c3000000-0000-4000-8000-000000000003
+    name: GeometrySplitterMembers
+    type: action
+    action: Geometry Splitter
+  - id: c3000000-0000-4000-8000-000000000004
+    name: GeometrySplitterFaces
+    type: action
+    action: Geometry Splitter
+  - id: c3000000-0000-4000-8000-000000000005
+    name: GeometryValidatorFace
+    type: action
+    action: Geometry Validator
+    with:
+      planarityThreshold:
+        maxHeight: 0.03
+  - id: c3000000-0000-4000-8000-000000000006
+    name: AttributeManagerIssues
+    type: action
+    action: Attribute Manager
+    with:
+      operations:
+      - attribute: _issues
+        method: create
+        value:
+          type: flowExpr
+          value: |
+            names = {
+              "DuplicatePoints": "DuplicateConsecutivePoints",
+              "InteriorRingContainment": "InteriorRingNotContainedInExteriorRing",
+              "Planarity": "NonPlanarSurface",
+              "Orientation": "IncorrectInteriorOrientation",
+              "UnclosedRing": "RingNotClosed",
+              "Degenerate": "DegenerateSurface",
+              "Finite": "NonFiniteCoordinate",
+            };
+            checks = attributes["validationResult"]["checks"];
+            itertools.map(itertools.sorted(checks.keys()), fn(k) { {"issue": names.get(k, k)} })
+  - id: c3000000-0000-4000-8000-000000000007
+    name: ListExploderIssues
+    type: action
+    action: List Exploder
+    with:
+      sourceAttribute: _issues
+  - id: c3000000-0000-4000-8000-000000000008
+    name: InvalidSurfaceRouter
     type: action
     action: Output Router
     with:
-      routingPort: features
-  - id: 1a9c4e7b-2f5d-4e8a-b3c6-9f2a5e8b1c4d
-    name: GeometryPartExtractor
-    type: action
-    action: Geometry Part Extractor
-  - id: 3d6f9a2c-5b8e-4a1d-c7f4-2e5a8c3b6f9d
+      routingPort: invalidSurface
+  - id: c3000000-0000-4000-8000-000000000009
     name: TwoDimensionForcer
     type: action
     action: Two Dimension Forcer
-  - id: 5c2a7f4b-8e1d-4f9c-a6e3-4b7f2a5c8e1d
-    name: OrientationExtractor
+  - id: c3000000-0000-4000-8000-00000000000a
+    name: GeometryValidatorOutline
     type: action
-    action: Orientation Extractor
-    with:
-      outputAttribute: outerOrientation
-  - id: 7f4a1c6e-b9d2-4c5a-e8f1-6a3c7f4b9e2d
+    action: Geometry Validator
+  - id: c3000000-0000-4000-8000-00000000000b
     name: FeatureFilterByOrientation
     type: action
     action: Feature Filter
@@ -220,206 +213,16 @@ graphs:
       conditions:
       - expr:
           type: flowExpr
-          value: attributes["outerOrientation"] != "counter_clockwise"
+          value: attributes["validationResult"]["checks"].get("Orientation", 0) > 0
         outputPort: inCorrectOrientation
-  - id: 9e2b5f8a-1c4d-4a7e-f2b5-8a1e4b7c2f5d
-    name: GeometryReplacer
-    type: action
-    action: Geometry Replacer
-    with:
-      sourceAttribute: dumpGeometry
-  - id: 2a5c8f1b-4e7d-4b2c-a9f6-1c4e7a2b5f8d
+  - id: c3000000-0000-4000-8000-00000000000c
     name: InCorrectOrientationRouter
     type: action
     action: Output Router
     with:
       routingPort: inCorrectOrientation
-  - id: 4f8b3e6a-7d1c-4e5a-c2f9-3a6f9b4e7c1d
-    name: GeometryValidator
-    type: action
-    action: Geometry Validator
-    with:
-      validationTypes:
-      - corruptGeometry: 0.01
-  - id: 6a1d4f7c-9e2b-4c8a-f5e1-7c2a6f9d4e1b
-    name: PlanarityFilter
-    type: action
-    action: Planarity Filter
-    with:
-      filterType: height
-      threshold:
-        type: flowExpr
-        value: '0.03'
-  - id: a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d
-    name: Rotator3D
-    type: action
-    action: Rotator 3D
-    with:
-      rotation:
-        type: fromToVectors
-        fromX:
-          type: flowExpr
-          value: attributes["surfaceNormalX"]
-        fromY:
-          type: flowExpr
-          value: attributes["surfaceNormalY"]
-        fromZ:
-          type: flowExpr
-          value: attributes["surfaceNormalZ"]
-        toX:
-          type: flowExpr
-          value: '0.0'
-        toY:
-          type: flowExpr
-          value: '0.0'
-        toZ:
-          type: flowExpr
-          value: '1.0'
-  - id: 8c5f2a9d-1b4e-4f7c-a3d8-5e2c8f1b4a7d
-    name: FeatureCounter
-    type: action
-    action: Feature Counter
-    with:
-      countStart: 0
-      outputAttribute: surfaceId
-  - id: 1e7a4c9b-3f6d-4a2e-c8b5-9d2a5e8c1b4f
-    name: HoleCounter
-    type: action
-    action: Hole Counter
-    with:
-      outputAttribute: holeCount
-  - id: 3b9f6a2d-5c8e-4d1a-f7c4-2e5b8a3f6d9c
-    name: FeatureFilterByHole
-    type: action
-    action: Feature Filter
-    with:
-      conditions:
-      - expr:
-          type: flowExpr
-          value: 'true'
-        outputPort: features
-      - expr:
-          type: flowExpr
-          value: attributes["holeCount"] > 0
-        outputPort: hole
-  - id: 5d2c7f4a-8b1e-4c6d-a9f2-4a7d2c5f8b1e
-    name: GeometryValidatorSelfIntersection
-    type: action
-    action: Geometry Validator
-    with:
-      validationTypes:
-      - duplicateConsecutivePoints: 0.0099
-      - selfIntersection: 0.0099
-  - id: 6b2e9a4f-1c5d-4b8e-a3f7-2e5b8c1d4a7f
-    name: AttributeManagerSelfIntersection
-    type: action
-    action: Attribute Manager
-    with:
-      operations:
-      - attribute: issue
-        method: create
-        value:
-          type: flowExpr
-          value: |
-            vr = attributes["validationResult"];
-            vr["details"][0][0]
-  - id: 7f5a8c3b-1d4e-4a9f-c2b7-6e3a7f5c8b1d
-    name: GeometryCoercerRingNotClosed
-    type: action
-    action: Geometry Coercer
-    with:
-      targetType: lineString
-  - id: 9c1e4a7b-6f2d-4e5c-a8b1-3f6c9e1a4b7d
-    name: ClosedCurveFilter
-    type: action
-    action: Closed Curve Filter
-  - id: 2d8a5f3c-4b7e-4c1d-f9a6-8c2d5a8f3b6e
-    name: HoleExtractor
-    type: action
-    action: Hole Extractor
-  - id: 4a6c9f2d-7e3b-4d8a-c5f2-1a4c7e9f2d5b
-    name: OrientationExtractorOuterShell
-    type: action
-    action: Orientation Extractor
-    with:
-      outputAttribute: outerOrientation
-  - id: 6f3b1a8e-9c4d-4a7f-e2c9-3b6f1a8e4c7d
-    name: ElevationExtractorHole
-    type: action
-    action: Elevation Extractor
-    with:
-      outputAttribute: elevation
-  - id: 8e7c4a1f-2d5b-4f8e-a6c3-7f4e1c8a5b2d
-    name: GeometryCoercerOutershell
-    type: action
-    action: Geometry Coercer
-    with:
-      targetType: lineString
-  - id: 1c4f7a2e-5b8d-4a3c-f9e6-4c1f8a7e2b5d
-    name: GeometryCoercerHole
-    type: action
-    action: Geometry Coercer
-    with:
-      targetType: lineString
-  - id: 3f5a8c1d-7e4b-4c9f-a2e7-6f3a8c1d4e7b
-    name: FeatureCounterHole
-    type: action
-    action: Feature Counter
-    with:
-      countStart: 1
-      groupBy:
-      - surfaceId
-      outputAttribute: holeId
-  - id: 5b8d1f4a-9c6e-4f2b-c8d5-1f4b8d5a9c2e
-    name: FeatureMergerIntersectionbetweenInteriorAndExterior
-    type: action
-    action: Feature Merger
-    with:
-      requestorAttribute:
-      - surfaceId
-      supplierAttribute:
-      - surfaceId
-      completeGrouped: true
-  - id: 7d4e9a2c-1f5b-4d8a-e7c4-9a2d7e4c1f5b
-    name: LineOnLineOverlayer
-    type: action
-    action: Line On Line Overlayer
-    with:
-      groupBy:
-      - surfaceId
-      - holeId
-      tolerance: 0.01
-      outputAttribute: overlap
-  - id: 9a6c3f8b-4e1d-4a7c-f5b9-3f8a6c9b4e1d
-    name: Bufferer
-    type: action
-    action: Bufferer
-    with:
-      bufferType: area2d
-      distance: 0.005
-      interpolationAngle: 22.5
-  - id: 2c7f4a9e-8b1d-4f6c-a3e8-7f2c4a9e1b8d
-    name: AreaOnAreaOverlayerInteriorAndInterior
-    type: action
-    action: Area On Area Overlayer
-    with:
-      groupBy:
-      - surfaceId
-      attributeAccumulation: useOneFeature
-      outputAttribute: overlap
-      tolerance: 0.1
-  - id: 4e1b7c5a-6f9d-4c2e-b8a5-1c4e7b5a6f9d
-    name: FeatureFilterByAreaOnAreaOverlap
-    type: action
-    action: Feature Filter
-    with:
-      conditions:
-      - expr:
-          type: flowExpr
-          value: attributes["overlap"] > 1
-        outputPort: intersectionInterior
-  - id: 5a3b7e9c-2f4d-4a6e-b8c1-3e7a5b9c2f4d
-    name: AttributeManagerIntersectionInterior
+  - id: c3000000-0000-4000-8000-00000000000d
+    name: AttributeManagerRejected
     type: action
     action: Attribute Manager
     with:
@@ -428,271 +231,91 @@ graphs:
         method: create
         value:
           type: string
-          value: IntersectionBetweenInteriorAndInterior
-  - id: 6b5d8a3f-1c4e-4b7d-a9c2-5d6b8a3f1c4e
-    name: OrientationExtractorIncorrectInterior
-    type: action
-    action: Orientation Extractor
-    with:
-      outputAttribute: innerOrientation
-  - id: 8f2a5c7d-3e6b-4a9f-c1d4-2a8f5c7d3e6b
-    name: FeatureMergerIncorrectInterior
-    type: action
-    action: Feature Merger
-    with:
-      requestorAttribute:
-      - surfaceId
-      supplierAttribute:
-      - surfaceId
-      completeGrouped: true
-  - id: 1a4d7c2f-9e5b-4d8a-f6c3-4d1a7c2f9e5b
-    name: FeatureFilterByIncorrectInteriorOrientation
-    type: action
-    action: Feature Filter
-    with:
-      conditions:
-      - expr:
-          type: flowExpr
-          value: attributes["innerOrientation"] == attributes["outerOrientation"]
-        outputPort: incorrectInterior
-  - id: 4b8e2a7d-3f6c-4a1e-b9d5-7a4b8e2d3f6c
-    name: AttributeManagerIncorrectInteriorOrientation
-    type: action
-    action: Attribute Manager
-    with:
-      operations:
-      - attribute: issue
-        method: create
-        value:
-          type: string
-          value: IncorrectInteriorOrientation
-  - id: 3c6f9a1e-8d4b-4f3c-a7e2-6f3c9a1e8d4b
-    name: InvalidSurfaceRouter
-    type: action
-    action: Output Router
-    with:
-      routingPort: invalidSurface
+          value: GeometryRejected
   edges:
-  - id: 5e8b2a7f-1c4d-4e9b-a6f3-8b5e2a7f1c4d
-    from: 2f8a4b1c-5e9d-4c2a-8b6e-3f7a9b2c5d8e
-    to: 4c7a2b5e-8f1d-4a6c-9e2b-7a4c8e1b3f6d
+  - id: c3000000-0000-4000-8000-000000000101
+    from: c3000000-0000-4000-8000-000000000001
+    to: c3000000-0000-4000-8000-000000000002
     fromPort: features
     toPort: features
-  - id: 7f3a6c9e-4d1b-4c7f-e2a5-3f7a6c9e4d1b
-    from: 4c7a2b5e-8f1d-4a6c-9e2b-7a4c8e1b3f6d
-    to: 6e3b8a1c-f4d7-4b9e-a2c5-8f1b4e6a9c3d
+  - id: c3000000-0000-4000-8000-000000000102
+    from: c3000000-0000-4000-8000-000000000002
+    to: c3000000-0000-4000-8000-000000000003
     fromPort: features
     toPort: features
-  - id: 9d6a3f2c-8e5b-4a1d-c7f4-6a9d3f2c8e5b
-    from: 4c7a2b5e-8f1d-4a6c-9e2b-7a4c8e1b3f6d
-    to: 1a9c4e7b-2f5d-4e8a-b3c6-9f2a5e8b1c4d
+  - id: c3000000-0000-4000-8000-000000000103
+    from: c3000000-0000-4000-8000-000000000003
+    to: c3000000-0000-4000-8000-000000000004
     fromPort: features
     toPort: features
-  - id: 2c5f8a1d-6e9b-4c2f-a7e4-5c2f8a1d6e9b
-    from: 1a9c4e7b-2f5d-4e8a-b3c6-9f2a5e8b1c4d
-    to: 3d6f9a2c-5b8e-4a1d-c7f4-2e5a8c3b6f9d
-    fromPort: extracted
-    toPort: features
-  - id: 4a7e1c5b-9f2d-4a8e-c6f3-7e4a1c5b9f2d
-    from: 3d6f9a2c-5b8e-4a1d-c7f4-2e5a8c3b6f9d
-    to: 5c2a7f4b-8e1d-4f9c-a6e3-4b7f2a5c8e1d
+  - id: c3000000-0000-4000-8000-000000000104
+    from: c3000000-0000-4000-8000-000000000004
+    to: c3000000-0000-4000-8000-000000000005
     fromPort: features
     toPort: features
-  - id: 6f9c4a2e-1d5b-4f7c-e8a1-9c6f4a2e1d5b
-    from: 5c2a7f4b-8e1d-4f9c-a6e3-4b7f2a5c8e1d
-    to: 7f4a1c6e-b9d2-4c5a-e8f1-6a3c7f4b9e2d
+  - id: c3000000-0000-4000-8000-000000000105
+    from: c3000000-0000-4000-8000-000000000005
+    to: c3000000-0000-4000-8000-000000000006
+    fromPort: failed
+    toPort: features
+  - id: c3000000-0000-4000-8000-000000000106
+    from: c3000000-0000-4000-8000-000000000006
+    to: c3000000-0000-4000-8000-000000000007
     fromPort: features
     toPort: features
-  - id: 8b1e6a3f-4c7d-4b8e-a2f5-1e8b6a3f4c7d
-    from: 7f4a1c6e-b9d2-4c5a-e8f1-6a3c7f4b9e2d
-    to: 9e2b5f8a-1c4d-4a7e-f2b5-8a1e4b7c2f5d
+  - id: c3000000-0000-4000-8000-000000000107
+    from: c3000000-0000-4000-8000-000000000007
+    to: c3000000-0000-4000-8000-000000000008
+    fromPort: features
+    toPort: features
+  - id: c3000000-0000-4000-8000-000000000108
+    from: c3000000-0000-4000-8000-000000000004
+    to: c3000000-0000-4000-8000-000000000009
+    fromPort: features
+    toPort: features
+  - id: c3000000-0000-4000-8000-000000000109
+    from: c3000000-0000-4000-8000-000000000009
+    to: c3000000-0000-4000-8000-00000000000a
+    fromPort: features
+    toPort: features
+  - id: c3000000-0000-4000-8000-00000000010a
+    from: c3000000-0000-4000-8000-00000000000a
+    to: c3000000-0000-4000-8000-00000000000b
+    fromPort: failed
+    toPort: features
+  - id: c3000000-0000-4000-8000-00000000010b
+    from: c3000000-0000-4000-8000-00000000000b
+    to: c3000000-0000-4000-8000-00000000000c
     fromPort: inCorrectOrientation
     toPort: features
-  - id: 1d4a7c2e-8f5b-4d1a-c9f6-4a1d7c2e8f5b
-    from: 9e2b5f8a-1c4d-4a7e-f2b5-8a1e4b7c2f5d
-    to: 2a5c8f1b-4e7d-4b2c-a9f6-1c4e7a2b5f8d
+  - id: c3000000-0000-4000-8000-00000000010c
+    from: c3000000-0000-4000-8000-000000000005
+    to: c3000000-0000-4000-8000-00000000000d
+    fromPort: rejected
+    toPort: features
+  - id: c3000000-0000-4000-8000-00000000010d
+    from: c3000000-0000-4000-8000-000000000009
+    to: c3000000-0000-4000-8000-00000000000d
+    fromPort: rejected
+    toPort: features
+  - id: c3000000-0000-4000-8000-00000000010e
+    from: c3000000-0000-4000-8000-00000000000a
+    to: c3000000-0000-4000-8000-00000000000d
+    fromPort: rejected
+    toPort: features
+  - id: c3000000-0000-4000-8000-00000000010f
+    from: c3000000-0000-4000-8000-00000000000d
+    to: c3000000-0000-4000-8000-000000000008
     fromPort: features
     toPort: features
-  - id: 3f6c9a2d-7e4b-4f3c-a8e1-6c3f9a2d7e4b
-    from: 1a9c4e7b-2f5d-4e8a-b3c6-9f2a5e8b1c4d
-    to: 4f8b3e6a-7d1c-4e5a-c2f9-3a6f9b4e7c1d
-    fromPort: extracted
-    toPort: features
-  - id: 5c8a1f4d-9e2b-4c5a-f7d2-8c5a1f4d9e2b
-    from: 4f8b3e6a-7d1c-4e5a-c2f9-3a6f9b4e7c1d
-    to: 6a1d4f7c-9e2b-4c8a-f5e1-7c2a6f9d4e1b
-    fromPort: success
-    toPort: features
-  - id: 7e4b9f2a-1c6d-4e7b-a3f8-4b7e9f2a1c6d
-    from: 6a1d4f7c-9e2b-4c8a-f5e1-7c2a6f9d4e1b
-    to: 3c6f9a1e-8d4b-4f3c-a7e2-6f3c9a1e8d4b
-    fromPort: notplanarity
-    toPort: features
-  - id: 9a2f5c8d-6e1b-4a9f-c4d7-2a9f5c8d6e1b
-    from: 6a1d4f7c-9e2b-4c8a-f5e1-7c2a6f9d4e1b
-    to: a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d
-    fromPort: planarity
-    toPort: features
-  - id: b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e
-    from: a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d
-    to: 8c5f2a9d-1b4e-4f7c-a3d8-5e2c8f1b4a7d
-    fromPort: features
-    toPort: features
-  - id: 2d7a4c1f-5e8b-4d2a-f6c9-7a2d4c1f5e8b
-    from: 8c5f2a9d-1b4e-4f7c-a3d8-5e2c8f1b4a7d
-    to: 1e7a4c9b-3f6d-4a2e-c8b5-9d2a5e8c1b4f
-    fromPort: features
-    toPort: features
-  - id: 4b6d9a3c-8f1e-4b6d-a2c7-6b4d9a3c8f1e
-    from: 1e7a4c9b-3f6d-4a2e-c8b5-9d2a5e8c1b4f
-    to: 3b9f6a2d-5c8e-4d1a-f7c4-2e5b8a3f6d9c
-    fromPort: features
-    toPort: features
-  - id: 6f1c4a7e-9d2b-4f1c-e5a8-1f6c4a7e9d2b
-    from: 3b9f6a2d-5c8e-4d1a-f7c4-2e5b8a3f6d9c
-    to: 5d2c7f4a-8b1e-4c6d-a9f2-4a7d2c5f8b1e
-    fromPort: features
-    toPort: features
-  - id: 8c4e7a1d-2f5b-4c8e-a1d4-4e8c7a1d2f5b
-    from: 5d2c7f4a-8b1e-4c6d-a9f2-4a7d2c5f8b1e
-    to: 7f5a8c3b-1d4e-4a9f-c2b7-6e3a7f5c8b1d
-    fromPort: success
-    toPort: features
-  - id: 1a5e8c2d-6f9b-4a1e-c7d2-5a1e8c2d6f9b
-    from: 5d2c7f4a-8b1e-4c6d-a9f2-4a7d2c5f8b1e
-    to: 6b2e9a4f-1c5d-4b8e-a3f7-2e5b8c1d4a7f
-    fromPort: failed
-    toPort: features
-  - id: 7c1d4a8e-3f6b-4e9c-b2d5-8a1e4f7c3b6d
-    from: 6b2e9a4f-1c5d-4b8e-a3f7-2e5b8c1d4a7f
-    to: 3c6f9a1e-8d4b-4f3c-a7e2-6f3c9a1e8d4b
-    fromPort: features
-    toPort: features
-  - id: 3d8b5a2f-7c4e-4d8b-a6f1-8b3d5a2f7c4e
-    from: 7f5a8c3b-1d4e-4a9f-c2b7-6e3a7f5c8b1d
-    to: 9c1e4a7b-6f2d-4e5c-a8b1-3f6c9e1a4b7d
-    fromPort: features
-    toPort: features
-  - id: 5f2c8a6d-1e4b-4f2c-a9e4-2c5f8a6d1e4b
-    from: 9c1e4a7b-6f2d-4e5c-a8b1-3f6c9e1a4b7d
-    to: 3c6f9a1e-8d4b-4f3c-a7e2-6f3c9a1e8d4b
-    fromPort: open
-    toPort: features
-  - id: 7a6f3c9b-4e2d-4a7a-c1f6-6f7a3c9b4e2d
-    from: 3b9f6a2d-5c8e-4d1a-f7c4-2e5b8a3f6d9c
-    to: 2d8a5f3c-4b7e-4c1d-f9a6-8c2d5a8f3b6e
-    fromPort: hole
-    toPort: features
-  - id: 9c4a7f2e-8d1b-4c9a-f3e6-4a9c7f2e8d1b
-    from: 2d8a5f3c-4b7e-4c1d-f9a6-8c2d5a8f3b6e
-    to: 4a6c9f2d-7e3b-4d8a-c5f2-1a4c7e9f2d5b
-    fromPort: exterior
-    toPort: features
-  - id: 2e7b4a1c-6f9d-4e2b-a8c5-7b2e4a1c6f9d
-    from: 2d8a5f3c-4b7e-4c1d-f9a6-8c2d5a8f3b6e
-    to: 6f3b1a8e-9c4d-4a7f-e2c9-3b6f1a8e4c7d
-    fromPort: hole
-    toPort: features
-  - id: 4c8f5a3d-1e6b-4c8f-a2d5-8f4c5a3d1e6b
-    from: 4a6c9f2d-7e3b-4d8a-c5f2-1a4c7e9f2d5b
-    to: 8e7c4a1f-2d5b-4f8e-a6c3-7f4e1c8a5b2d
-    fromPort: features
-    toPort: features
-  - id: 6a1d7c4f-9e2b-4a1d-c8f5-1a6d7c4f9e2b
-    from: 6f3b1a8e-9c4d-4a7f-e2c9-3b6f1a8e4c7d
-    to: 1c4f7a2e-5b8d-4a3c-f9e6-4c1f8a7e2b5d
-    fromPort: features
-    toPort: features
-  - id: 8f4c1a6e-3d7b-4f8c-a5e2-4c8f1a6e3d7b
-    from: 1c4f7a2e-5b8d-4a3c-f9e6-4c1f8a7e2b5d
-    to: 3f5a8c1d-7e4b-4c9f-a2e7-6f3a8c1d4e7b
-    fromPort: features
-    toPort: features
-  - id: 1d7a4c2f-8e5b-4d1a-c6f9-7a1d4c2f8e5b
-    from: 8e7c4a1f-2d5b-4f8e-a6c3-7f4e1c8a5b2d
-    to: 5b8d1f4a-9c6e-4f2b-c8d5-1f4b8d5a9c2e
-    fromPort: features
-    toPort: requestor
-  - id: 3b6f9a4d-2c8e-4b3b-a7f2-6f3b9a4d2c8e
-    from: 3f5a8c1d-7e4b-4c9f-a2e7-6f3a8c1d4e7b
-    to: 5b8d1f4a-9c6e-4f2b-c8d5-1f4b8d5a9c2e
-    fromPort: features
-    toPort: supplier
-  - id: 5e2c8f1a-4d7b-4e5e-c9a6-2c5e8f1a4d7b
-    from: 5b8d1f4a-9c6e-4f2b-c8d5-1f4b8d5a9c2e
-    to: 7d4e9a2c-1f5b-4d8a-e7c4-9a2d7e4c1f5b
-    fromPort: merged
-    toPort: features
-  - id: 7a9d2c5f-6e8b-4a7a-f1d4-9d7a2c5f6e8b
-    from: 3f5a8c1d-7e4b-4c9f-a2e7-6f3a8c1d4e7b
-    to: 7d4e9a2c-1f5b-4d8a-e7c4-9a2d7e4c1f5b
-    fromPort: features
-    toPort: features
-  - id: 9c6a5f2d-8e1b-4c9c-a4f7-6a9c5f2d8e1b
-    from: 7d4e9a2c-1f5b-4d8a-e7c4-9a2d7e4c1f5b
-    to: 3c6f9a1e-8d4b-4f3c-a7e2-6f3c9a1e8d4b
-    fromPort: point
-    toPort: features
-  - id: 2f8a5c1d-7e4b-4f2f-a6c9-8a2f5c1d7e4b
-    from: 6f3b1a8e-9c4d-4a7f-e2c9-3b6f1a8e4c7d
-    to: 9a6c3f8b-4e1d-4a7c-f5b9-3f8a6c9b4e1d
-    fromPort: features
-    toPort: features
-  - id: 4d1c7a5e-9f2b-4d4d-c8a3-1c4d7a5e9f2b
-    from: 9a6c3f8b-4e1d-4a7c-f5b9-3f8a6c9b4e1d
-    to: 2c7f4a9e-8b1d-4f6c-a3e8-7f2c4a9e1b8d
-    fromPort: features
-    toPort: features
-  - id: 6e5b8a2f-1c4d-4e6e-b9f4-5b6e8a2f1c4d
-    from: 2c7f4a9e-8b1d-4f6c-a3e8-7f2c4a9e1b8d
-    to: 4e1b7c5a-6f9d-4c2e-b8a5-1c4e7b5a6f9d
-    fromPort: overlaps
-    toPort: features
-  - id: 8a3f6c9d-4e7b-4a8a-f2c5-3f8a6c9d4e7b
-    from: 4e1b7c5a-6f9d-4c2e-b8a5-1c4e7b5a6f9d
-    to: 5a3b7e9c-2f4d-4a6e-b8c1-3e7a5b9c2f4d
-    fromPort: intersectionInterior
-    toPort: features
-  - id: 9b4c8e2a-6f7d-4b9c-e1a4-2e8b4c9a6f7d
-    from: 5a3b7e9c-2f4d-4a6e-b8c1-3e7a5b9c2f4d
-    to: 3c6f9a1e-8d4b-4f3c-a7e2-6f3c9a1e8d4b
-    fromPort: features
-    toPort: features
-  - id: 1c7d4a2e-9f5b-4c1c-d8e3-7d1c4a2e9f5b
-    from: 6f3b1a8e-9c4d-4a7f-e2c9-3b6f1a8e4c7d
-    to: 6b5d8a3f-1c4e-4b7d-a9c2-5d6b8a3f1c4e
-    fromPort: features
-    toPort: features
-  - id: 3e6a9c2f-8d1b-4e3e-a7c4-6a3e9c2f8d1b
-    from: 6b5d8a3f-1c4e-4b7d-a9c2-5d6b8a3f1c4e
-    to: 8f2a5c7d-3e6b-4a9f-c1d4-2a8f5c7d3e6b
-    fromPort: features
-    toPort: requestor
-  - id: 5b4f7c1a-2e9d-4b5b-c6a9-4f5b7c1a2e9d
-    from: 4a6c9f2d-7e3b-4d8a-c5f2-1a4c7e9f2d5b
-    to: 8f2a5c7d-3e6b-4a9f-c1d4-2a8f5c7d3e6b
-    fromPort: features
-    toPort: supplier
-  - id: 7d9c2a5f-6e8b-4d7d-c1f6-9c7d2a5f6e8b
-    from: 8f2a5c7d-3e6b-4a9f-c1d4-2a8f5c7d3e6b
-    to: 1a4d7c2f-9e5b-4d8a-f6c3-4d1a7c2f9e5b
-    fromPort: merged
-    toPort: features
-  - id: 9f2e5c8a-1d4b-4f9f-e4c7-2e9f5c8a1d4b
-    from: 1a4d7c2f-9e5b-4d8a-f6c3-4d1a7c2f9e5b
-    to: 4b8e2a7d-3f6c-4a1e-b9d5-7a4b8e2d3f6c
-    fromPort: incorrectInterior
-    toPort: features
-  - id: 7c3f1a6e-9d2b-4c8f-a5e1-3f7c1a6e9d2b
-    from: 4b8e2a7d-3f6c-4a1e-b9d5-7a4b8e2d3f6c
-    to: 3c6f9a1e-8d4b-4f3c-a7e2-6f3c9a1e8d4b
-    fromPort: features
-    toPort: features
-  - id: 2a5c8f1d-7e4b-4f2a-c9e6-5c2a8f1d7e4b
-    from: 4f8b3e6a-7d1c-4e5a-c2f9-3a6f9b4e7c1d
-    to: 3c6f9a1e-8d4b-4f3c-a7e2-6f3c9a1e8d4b
-    fromPort: failed
-    toPort: features
+  ports:
+    outputs:
+    - id: invalidSurface
+      nodeId: c3000000-0000-4000-8000-000000000008
+      port: features
+    - id: inCorrectOrientation
+      nodeId: c3000000-0000-4000-8000-00000000000c
+      port: features
 - id: 2c753ffc-cc90-4f4a-b5ee-f5d7853dbac6
   name: PLATEAU4.XMLValidator
   nodes:
@@ -2472,23 +2095,20 @@ graphs:
   - id: 242e339a-c7df-4be4-82f7-3223a6ed2145
     name: FeatureCityGmlReader
     type: action
-    action: Feature CityGML Reader
+    action: Feature CityGML 2 Reader
     with:
-      codelistsPath:
-        type: flowExpr
-        value: attributes["codelists"]
-      flatten: true
       dataset:
         type: flowExpr
         value: attributes["path"]
   - id: 10df06f3-cafa-4abd-ba94-04ac71dae467
-    name: HorizontalReprojector
+    name: CoordinateFrameReprojector
     type: action
-    action: Horizontal Reprojector
+    action: Coordinate Frame Reprojector
     with:
-      targetEpsgCode:
-        type: flowExpr
-        value: variables["prcs"]
+      destinationFrame:
+        crs:
+          type: flowExpr
+          value: variables["prcs"]
   - id: 6f556405-1fdb-4807-8e3b-f18da79fbe1a
     name: TransportationXlinkDetector
     type: action
@@ -2541,17 +2161,24 @@ graphs:
         type: string
         value: 03_交通_xlink参照エラー.csv
   - id: 51431704-ac14-41cd-988b-88141dc6e326
-    name: PLATEAU3.LodSplitterWithDM
+    name: LodSplitter
     type: subGraph
-    subGraphId: 7e98d856-1438-4148-bdcb-91747ef2e405
-  - id: e28b5f31-4826-4775-a343-a12ecb7f90f9
-    name: PLATEAU3.SurfaceValidator2D
-    type: subGraph
-    subGraphId: 8a5b1c9d-2e4f-4a3b-9c5d-1e6f8a2b4c7d
+    subGraphId: b1000000-0000-4000-8000-000000000000
   - id: abf4b25e-6c1f-46fd-b5f8-07d43d137abf
-    name: PLATEAU3.SurfaceValidator3D
+    name: SurfaceChecks
     type: subGraph
-    subGraphId: 8a5b1c9d-2e4f-4a3b-9c5d-1e6f8a2b4c7d
+    subGraphId: c3000000-0000-4000-8000-000000000000
+  - id: c3100000-0000-4000-8000-000000000001
+    name: AttributeManagerReprojectionRejected
+    type: action
+    action: Attribute Manager
+    with:
+      operations:
+      - attribute: issue
+        method: create
+        value:
+          type: string
+          value: GeometryRejected
   - id: d44341fa-7de4-41f5-abfd-7e0a3b1d9be8
     name: SurfaceValidationAttributeMapper
     type: action
@@ -2573,7 +2200,7 @@ graphs:
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes.get("featureType", "")
+          value: attributes.get("__citygml_geometry_feature_type") or attributes.get("__citygml_feature_type", "")
       - attribute: LOD
         expr:
           type: flowExpr
@@ -2581,35 +2208,11 @@ graphs:
       - attribute: gml:id
         expr:
           type: flowExpr
-          value: attributes.get("featureId", "")
+          value: attributes.get("__citygml_geometry_gml_id") or attributes.get("__citygml_gml_id", "")
       - attribute: issue
         expr:
           type: flowExpr
-          value: |
-            vr = attributes.get("validationResult");
-            if vr != null and "details" in vr {
-              vr["details"][0][0]
-            } else if "issue" in attributes {
-              attributes["issue"]
-            } else {
-              "UnknownError"
-            }
-  - id: d60f93c1-c55e-49ee-9332-657f4408ba05
-    name: OrientationExtractor
-    type: action
-    action: Orientation Extractor
-    with:
-      outputAttribute: orientation
-  - id: 1c385359-698d-40df-aed8-e8b9b0eaac67
-    name: FilterIncorrectOrientation
-    type: action
-    action: Feature Filter
-    with:
-      conditions:
-      - expr:
-          type: flowExpr
-          value: attributes["orientation"] == "clockwise"
-        outputPort: incorrectOrientation
+          value: attributes.get("issue", "UnknownError")
   - id: 0740c8ce-3c27-416f-9a13-5b2086090426
     name: AttributeMapper
     type: action
@@ -2631,7 +2234,7 @@ graphs:
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes.get("featureType", "")
+          value: attributes.get("__citygml_geometry_feature_type", "")
       - attribute: LOD
         expr:
           type: flowExpr
@@ -2639,7 +2242,7 @@ graphs:
       - attribute: gml:id
         expr:
           type: flowExpr
-          value: attributes.get("featureId", "")
+          value: attributes.get("__citygml_geometry_gml_id", "")
       - attribute: エラー数
         expr:
           type: flowExpr
@@ -2683,7 +2286,7 @@ graphs:
       groupBy:
       - lod
       - fileIndex
-      - gmlId
+      - __citygml_gml_id
       - package
       tolerance: 0.01
   - id: 0c979585-82b2-41aa-909c-00d9b8d017d0
@@ -2714,11 +2317,11 @@ graphs:
       conditions:
       - expr:
           type: flowExpr
-          value: attributes["lod"] == "1"
+          value: attributes.get("lod") == 1
         outputPort: lod1
       - expr:
           type: flowExpr
-          value: attributes["lod"] == "2" or attributes["lod"] == "3"
+          value: attributes.get("lod") == 2 or attributes.get("lod") == 3
         outputPort: lod23
   - id: b684d916-5efe-4dfa-be20-fed9b101239d
     name: LineOnLineOverlayerLOD1
@@ -2769,7 +2372,7 @@ graphs:
     action: Attribute Duplicate Filter
     with:
       filterBy:
-      - gmlId
+      - __citygml_gml_id
   - id: 2261a5c9-46a4-45ce-a292-d277a3dc0ebc
     name: GeometryReplacer
     type: action
@@ -2810,7 +2413,7 @@ graphs:
     action: List Concatenator
     with:
       list: areaOverlapList
-      elementAttribute: gmlId
+      elementAttribute: __citygml_gml_id
       separator: ','
       outputAttribute: concatenatedGmlIds
   - id: 518572d2-8561-4b60-ab28-fcd66d90afa2
@@ -2847,7 +2450,7 @@ graphs:
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes.get("featureType", "")
+          value: attributes.get("__citygml_feature_type", "")
       - attribute: LOD
         expr:
           type: flowExpr
@@ -2855,7 +2458,7 @@ graphs:
       - attribute: gml:id
         expr:
           type: flowExpr
-          value: attributes.get("gmlId", "")
+          value: attributes.get("__citygml_gml_id", "")
       - attribute: 隣接ID
         expr:
           type: flowExpr
@@ -2869,6 +2472,10 @@ graphs:
       output:
         type: string
         value: 03_交通_隣接面重複.csv
+  - id: c3100000-0000-4000-8000-000000000002
+    name: UnusableForOverlapSink
+    type: action
+    action: Noop Sink
   - id: 41bd7fb9-6e5b-4ac6-985f-a9abb40fb1c1
     name: SurfaceValidationCsvWriter
     type: action
@@ -3134,14 +2741,24 @@ graphs:
     to: 737996be-8410-4447-9986-bba01fe9ce0c
     fromPort: features
     toPort: features
+  - id: c3100000-0000-4000-8000-000000000101
+    from: 10df06f3-cafa-4abd-ba94-04ac71dae467
+    to: c3100000-0000-4000-8000-000000000001
+    fromPort: rejected
+    toPort: features
+  - id: c3100000-0000-4000-8000-000000000102
+    from: c3100000-0000-4000-8000-000000000001
+    to: d44341fa-7de4-41f5-abfd-7e0a3b1d9be8
+    fromPort: features
+    toPort: features
   - id: e23edb68-8299-4a9f-a722-f82b73c82d88
     from: 51431704-ac14-41cd-988b-88141dc6e326
-    to: e28b5f31-4826-4775-a343-a12ecb7f90f9
+    to: abf4b25e-6c1f-46fd-b5f8-07d43d137abf
     fromPort: lod1
     toPort: features
   - id: 53ce90b4-72b4-4473-89ff-da0d0388ba85
     from: 51431704-ac14-41cd-988b-88141dc6e326
-    to: e28b5f31-4826-4775-a343-a12ecb7f90f9
+    to: abf4b25e-6c1f-46fd-b5f8-07d43d137abf
     fromPort: lod2
     toPort: features
   - id: e44eff90-4ce0-4dc2-8c66-78e553ef4560
@@ -3149,35 +2766,15 @@ graphs:
     to: abf4b25e-6c1f-46fd-b5f8-07d43d137abf
     fromPort: lod3
     toPort: features
-  - id: bf52a96b-2a23-4866-9646-1a8a7e17ade3
-    from: e28b5f31-4826-4775-a343-a12ecb7f90f9
-    to: d44341fa-7de4-41f5-abfd-7e0a3b1d9be8
-    fromPort: invalidSurface
-    toPort: features
   - id: 06d601c8-0bf2-4be0-b4ef-c942e2336373
     from: abf4b25e-6c1f-46fd-b5f8-07d43d137abf
     to: d44341fa-7de4-41f5-abfd-7e0a3b1d9be8
     fromPort: invalidSurface
     toPort: features
   - id: f57856b7-7b32-4a0d-88a4-2bfadaf2f9a3
-    from: e28b5f31-4826-4775-a343-a12ecb7f90f9
-    to: 0740c8ce-3c27-416f-9a13-5b2086090426
-    fromPort: inCorrectOrientation
-    toPort: features
-  - id: cf5b54cd-a548-4694-a7db-35a4d682852c
     from: abf4b25e-6c1f-46fd-b5f8-07d43d137abf
-    to: d60f93c1-c55e-49ee-9332-657f4408ba05
-    fromPort: inCorrectOrientation
-    toPort: features
-  - id: 05a6d315-61a1-4021-acaa-606cb1a7435a
-    from: d60f93c1-c55e-49ee-9332-657f4408ba05
-    to: 1c385359-698d-40df-aed8-e8b9b0eaac67
-    fromPort: features
-    toPort: features
-  - id: bbd0c116-cf6c-4f5f-b7c1-3c6011c013d3
-    from: 1c385359-698d-40df-aed8-e8b9b0eaac67
     to: 0740c8ce-3c27-416f-9a13-5b2086090426
-    fromPort: incorrectOrientation
+    fromPort: inCorrectOrientation
     toPort: features
   - id: 298fa998-d16c-4d64-bfa0-05d73b250a22
     from: 0740c8ce-3c27-416f-9a13-5b2086090426
@@ -3298,6 +2895,31 @@ graphs:
     from: 2ccf00f0-202b-4bf5-b2a1-0c27a0e82a37
     to: 787f4304-c435-4d76-bd66-1fe3fb4ffc80
     fromPort: features
+    toPort: features
+  - id: c3100000-0000-4000-8000-000000000201
+    from: b4d2d577-28a0-43a3-8a23-0ae562be1d04
+    to: c3100000-0000-4000-8000-000000000002
+    fromPort: rejected
+    toPort: features
+  - id: c3100000-0000-4000-8000-000000000202
+    from: c93837eb-e050-46f3-9c97-66d7273fe1e5
+    to: c3100000-0000-4000-8000-000000000002
+    fromPort: rejected
+    toPort: features
+  - id: c3100000-0000-4000-8000-000000000203
+    from: b684d916-5efe-4dfa-be20-fed9b101239d
+    to: c3100000-0000-4000-8000-000000000002
+    fromPort: rejected
+    toPort: features
+  - id: c3100000-0000-4000-8000-000000000204
+    from: 5dab814a-c4c6-47e0-8688-1c5667c775fb
+    to: c3100000-0000-4000-8000-000000000002
+    fromPort: rejected
+    toPort: features
+  - id: c3100000-0000-4000-8000-000000000205
+    from: e85ef1d5-a8fb-49e8-895a-b0a055c7b4c0
+    to: c3100000-0000-4000-8000-000000000002
+    fromPort: rejected
     toPort: features
   - id: 3ca83706-219c-4855-99ed-48219d3829bb
     from: 787f4304-c435-4d76-bd66-1fe3fb4ffc80

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
@@ -161,6 +161,7 @@ graphs:
     type: action
     action: Geometry Validator
     with:
+      duplicateTolerance: 0.01
       planarityThreshold:
         maxHeight: 0.03
   - id: c3000000-0000-4000-8000-000000000006

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/surface_checks.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/surface_checks.yml
@@ -1,0 +1,217 @@
+id: c3000000-0000-4000-8000-000000000000
+name: TranSurfaceChecks
+# Validates every face of the incoming geometry. Emits one feature per failed
+# check per face on `invalidSurface` with the check name in `issue`, and every
+# face whose 2D outline is wound against the coordinate frame on
+# `inCorrectOrientation`. Geometry no step could handle also leaves via
+# `invalidSurface`, so nothing is dropped silently.
+nodes:
+  - id: c3000000-0000-4000-8000-000000000001
+    name: InputRouter
+    type: action
+    action: Input Router
+    with:
+      routingPort: features
+
+  - id: c3000000-0000-4000-8000-000000000002
+    name: GeometryCoercerFaces
+    type: action
+    action: Geometry Coercer
+    with:
+      targetType: polygon
+
+  - id: c3000000-0000-4000-8000-000000000003
+    name: GeometrySplitterMembers
+    type: action
+    action: Geometry Splitter
+
+  # A welded CompositeSurface coerces into a collection nested inside its
+  # MultiSurface, so reaching the faces takes a second split. A face that is
+  # already alone passes through unchanged.
+  - id: c3000000-0000-4000-8000-000000000004
+    name: GeometrySplitterFaces
+    type: action
+    action: Geometry Splitter
+
+  # No `duplicateTolerance`: the tolerant path indexes a k-d tree that overflows
+  # on the many axis-aligned vertices of a reprojected road surface.
+  - id: c3000000-0000-4000-8000-000000000005
+    name: GeometryValidatorFace
+    type: action
+    action: Geometry Validator
+    with:
+      planarityThreshold:
+        maxHeight: 0.03
+
+  - id: c3000000-0000-4000-8000-000000000006
+    name: AttributeManagerIssues
+    type: action
+    action: Attribute Manager
+    with:
+      operations:
+        - attribute: _issues
+          method: create
+          value:
+            type: flowExpr
+            value: |
+              names = {
+                "DuplicatePoints": "DuplicateConsecutivePoints",
+                "InteriorRingContainment": "InteriorRingNotContainedInExteriorRing",
+                "Planarity": "NonPlanarSurface",
+                "Orientation": "IncorrectInteriorOrientation",
+                "UnclosedRing": "RingNotClosed",
+                "Degenerate": "DegenerateSurface",
+                "Finite": "NonFiniteCoordinate",
+              };
+              checks = attributes["validationResult"]["checks"];
+              itertools.map(itertools.sorted(checks.keys()), fn(k) { {"issue": names.get(k, k)} })
+
+  - id: c3000000-0000-4000-8000-000000000007
+    name: ListExploderIssues
+    type: action
+    action: List Exploder
+    with:
+      sourceAttribute: _issues
+
+  - id: c3000000-0000-4000-8000-000000000008
+    name: InvalidSurfaceRouter
+    type: action
+    action: Output Router
+    with:
+      routingPort: invalidSurface
+
+  # The absolute winding of a face's outline is a 2D property, so the face is
+  # flattened before the orientation check reads it.
+  - id: c3000000-0000-4000-8000-000000000009
+    name: TwoDimensionForcer
+    type: action
+    action: Two Dimension Forcer
+
+  # Only its `Orientation` result is read; the 3D pass above owns every other
+  # check, so this one needs no thresholds of its own.
+  - id: c3000000-0000-4000-8000-00000000000a
+    name: GeometryValidatorOutline
+    type: action
+    action: Geometry Validator
+
+  - id: c3000000-0000-4000-8000-00000000000b
+    name: FeatureFilterByOrientation
+    type: action
+    action: Feature Filter
+    with:
+      conditions:
+        - expr:
+            type: flowExpr
+            value: attributes["validationResult"]["checks"].get("Orientation", 0) > 0
+          outputPort: inCorrectOrientation
+
+  - id: c3000000-0000-4000-8000-00000000000c
+    name: InCorrectOrientationRouter
+    type: action
+    action: Output Router
+    with:
+      routingPort: inCorrectOrientation
+
+  - id: c3000000-0000-4000-8000-00000000000d
+    name: AttributeManagerRejected
+    type: action
+    action: Attribute Manager
+    with:
+      operations:
+        - attribute: issue
+          method: create
+          value:
+            type: string
+            value: GeometryRejected
+
+edges:
+  - id: c3000000-0000-4000-8000-000000000101
+    from: c3000000-0000-4000-8000-000000000001
+    to: c3000000-0000-4000-8000-000000000002
+    fromPort: features
+    toPort: features
+  - id: c3000000-0000-4000-8000-000000000102
+    from: c3000000-0000-4000-8000-000000000002
+    to: c3000000-0000-4000-8000-000000000003
+    fromPort: features
+    toPort: features
+  - id: c3000000-0000-4000-8000-000000000103
+    from: c3000000-0000-4000-8000-000000000003
+    to: c3000000-0000-4000-8000-000000000004
+    fromPort: features
+    toPort: features
+
+  ## Surface errors
+  - id: c3000000-0000-4000-8000-000000000104
+    from: c3000000-0000-4000-8000-000000000004
+    to: c3000000-0000-4000-8000-000000000005
+    fromPort: features
+    toPort: features
+  - id: c3000000-0000-4000-8000-000000000105
+    from: c3000000-0000-4000-8000-000000000005
+    to: c3000000-0000-4000-8000-000000000006
+    fromPort: failed
+    toPort: features
+  - id: c3000000-0000-4000-8000-000000000106
+    from: c3000000-0000-4000-8000-000000000006
+    to: c3000000-0000-4000-8000-000000000007
+    fromPort: features
+    toPort: features
+  - id: c3000000-0000-4000-8000-000000000107
+    from: c3000000-0000-4000-8000-000000000007
+    to: c3000000-0000-4000-8000-000000000008
+    fromPort: features
+    toPort: features
+
+  ## Incorrect orientation
+  - id: c3000000-0000-4000-8000-000000000108
+    from: c3000000-0000-4000-8000-000000000004
+    to: c3000000-0000-4000-8000-000000000009
+    fromPort: features
+    toPort: features
+  - id: c3000000-0000-4000-8000-000000000109
+    from: c3000000-0000-4000-8000-000000000009
+    to: c3000000-0000-4000-8000-00000000000a
+    fromPort: features
+    toPort: features
+  - id: c3000000-0000-4000-8000-00000000010a
+    from: c3000000-0000-4000-8000-00000000000a
+    to: c3000000-0000-4000-8000-00000000000b
+    fromPort: failed
+    toPort: features
+  - id: c3000000-0000-4000-8000-00000000010b
+    from: c3000000-0000-4000-8000-00000000000b
+    to: c3000000-0000-4000-8000-00000000000c
+    fromPort: inCorrectOrientation
+    toPort: features
+
+  ## Geometry no step could handle is reported rather than dropped
+  - id: c3000000-0000-4000-8000-00000000010c
+    from: c3000000-0000-4000-8000-000000000005
+    to: c3000000-0000-4000-8000-00000000000d
+    fromPort: rejected
+    toPort: features
+  - id: c3000000-0000-4000-8000-00000000010d
+    from: c3000000-0000-4000-8000-000000000009
+    to: c3000000-0000-4000-8000-00000000000d
+    fromPort: rejected
+    toPort: features
+  - id: c3000000-0000-4000-8000-00000000010e
+    from: c3000000-0000-4000-8000-00000000000a
+    to: c3000000-0000-4000-8000-00000000000d
+    fromPort: rejected
+    toPort: features
+  - id: c3000000-0000-4000-8000-00000000010f
+    from: c3000000-0000-4000-8000-00000000000d
+    to: c3000000-0000-4000-8000-000000000008
+    fromPort: features
+    toPort: features
+
+ports:
+  outputs:
+    - id: invalidSurface
+      nodeId: c3000000-0000-4000-8000-000000000008
+      port: features
+    - id: inCorrectOrientation
+      nodeId: c3000000-0000-4000-8000-00000000000c
+      port: features

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/surface_checks.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/surface_checks.yml
@@ -33,13 +33,14 @@ nodes:
     type: action
     action: Geometry Splitter
 
-  # No `duplicateTolerance`: the tolerant path indexes a k-d tree that overflows
-  # on the many axis-aligned vertices of a reprojected road surface.
+  # Vertices within `duplicateTolerance` of each other count as one point: a
+  # reprojected surface does not preserve exact coordinate equality.
   - id: c3000000-0000-4000-8000-000000000005
     name: GeometryValidatorFace
     type: action
     action: Geometry Validator
     with:
+      duplicateTolerance: 0.01
       planarityThreshold:
         maxHeight: 0.03
 

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
@@ -18,8 +18,8 @@ with:
     - squr
     - wwy
 graphs:
-  - !include ../../../../graphs/lod_splitter_with_dm.yml
-  - !include ../../../../graphs/surface_validator.yml
+  - !include ../../../../graphs/lod_splitter.yml
+  - !include surface_checks.yml
   # Common quality check graphs
   - !include ../../../../graphs/plateau4/xml_validator.yml
   - !include ../../../../graphs/plateau4/domain_of_definition_validator.yml
@@ -119,26 +119,29 @@ graphs:
               value: not variables["targetPackages"] or attributes["package"] in variables["targetPackages"]
             outputPort: features
 
+      # `extractTags` stays empty: one feature per top-level city object, with each
+      # geometry naming the object it belongs to. Hoisting the traffic areas out
+      # would break the per-road grouping the overlap check depends on.
       - id: 242e339a-c7df-4be4-82f7-3223a6ed2145
         name: FeatureCityGmlReader
         type: action
-        action: Feature CityGML Reader
+        action: Feature CityGML 2 Reader
         with:
-          codelistsPath:
-            type: flowExpr
-            value: attributes["codelists"]
-          flatten: true
           dataset:
             type: flowExpr
             value: attributes["path"]
+
+      # Reprojected before any check: planarity and the absolute winding of a face
+      # are only defined in a linear-unit frame.
       - id: 10df06f3-cafa-4abd-ba94-04ac71dae467
-        name: HorizontalReprojector
+        name: CoordinateFrameReprojector
         type: action
-        action: Horizontal Reprojector
+        action: Coordinate Frame Reprojector
         with:
-          targetEpsgCode:
-            type: flowExpr
-            value: variables["prcs"]
+          destinationFrame:
+            crs:
+              type: flowExpr
+              value: variables["prcs"]
 
       # Unreferenced XLink detection for L-TRAN-03
       - id: 6f556405-1fdb-4807-8e3b-f18da79fbe1a
@@ -198,21 +201,29 @@ graphs:
             value: 03_交通_xlink参照エラー.csv
 
       - id: 51431704-ac14-41cd-988b-88141dc6e326
-        name: PLATEAU3.LodSplitterWithDM
+        name: LodSplitter
         type: subGraph
-        subGraphId: 7e98d856-1438-4148-bdcb-91747ef2e405
+        subGraphId: b1000000-0000-4000-8000-000000000000
 
-      # Surface validator 2D for LOD1 and LOD2
-      - id: e28b5f31-4826-4775-a343-a12ecb7f90f9
-        name: PLATEAU3.SurfaceValidator2D
-        type: subGraph
-        subGraphId: 8a5b1c9d-2e4f-4a3b-9c5d-1e6f8a2b4c7d
-
-      # Surface validator 3D for LOD3
+      # Surface errors and incorrect orientation, for every LOD
       - id: abf4b25e-6c1f-46fd-b5f8-07d43d137abf
-        name: PLATEAU3.SurfaceValidator3D
+        name: SurfaceChecks
         type: subGraph
-        subGraphId: 8a5b1c9d-2e4f-4a3b-9c5d-1e6f8a2b4c7d
+        subGraphId: c3000000-0000-4000-8000-000000000000
+
+      # A city object the reprojection could not convert takes part in no check at
+      # all, so it is reported as a surface error rather than dropped.
+      - id: c3100000-0000-4000-8000-000000000001
+        name: AttributeManagerReprojectionRejected
+        type: action
+        action: Attribute Manager
+        with:
+          operations:
+            - attribute: issue
+              method: create
+              value:
+                type: string
+                value: GeometryRejected
 
       # Attribute Mapper for surface validation errors
       - id: d44341fa-7de4-41f5-abfd-7e0a3b1d9be8
@@ -233,10 +244,12 @@ graphs:
               expr:
                 type: flowExpr
                 value: attributes.get("name", "")
+            # A face belongs to the innermost city object that encloses it, which
+            # is not the feature the reader emitted it on.
             - attribute: FeatureType
               expr:
                 type: flowExpr
-                value: attributes.get("featureType", "")
+                value: attributes.get("__citygml_geometry_feature_type") or attributes.get("__citygml_feature_type", "")
             - attribute: LOD
               expr:
                 type: flowExpr
@@ -244,39 +257,11 @@ graphs:
             - attribute: "gml:id"
               expr:
                 type: flowExpr
-                value: attributes.get("featureId", "")
+                value: attributes.get("__citygml_geometry_gml_id") or attributes.get("__citygml_gml_id", "")
             - attribute: issue
               expr:
                 type: flowExpr
-                value: |
-                  vr = attributes.get("validationResult");
-                  if vr != null and "details" in vr {
-                    vr["details"][0][0]
-                  } else if "issue" in attributes {
-                    attributes["issue"]
-                  } else {
-                    "UnknownError"
-                  }
-
-      # Extract surface orientation
-      - id: d60f93c1-c55e-49ee-9332-657f4408ba05
-        name: OrientationExtractor
-        type: action
-        action: Orientation Extractor
-        with:
-          outputAttribute: orientation
-
-      # Filter for incorrect orientation (clockwise/right_hand_rule)
-      - id: 1c385359-698d-40df-aed8-e8b9b0eaac67
-        name: FilterIncorrectOrientation
-        type: action
-        action: Feature Filter
-        with:
-          conditions:
-            - expr:
-                type: flowExpr
-                value: attributes["orientation"] == "clockwise"
-              outputPort: incorrectOrientation
+                value: attributes.get("issue", "UnknownError")
 
       # Map attributes for CSV output
       - id: 0740c8ce-3c27-416f-9a13-5b2086090426
@@ -300,7 +285,7 @@ graphs:
             - attribute: FeatureType
               expr:
                 type: flowExpr
-                value: attributes.get("featureType", "")
+                value: attributes.get("__citygml_geometry_feature_type", "")
             - attribute: LOD
               expr:
                 type: flowExpr
@@ -308,7 +293,7 @@ graphs:
             - attribute: "gml:id"
               expr:
                 type: flowExpr
-                value: attributes.get("featureId", "")
+                value: attributes.get("__citygml_geometry_gml_id", "")
 
             # The error count is always 1
             - attribute: "エラー数"
@@ -364,7 +349,7 @@ graphs:
           groupBy:
             - lod
             - fileIndex
-            - gmlId
+            - __citygml_gml_id
             - package
           tolerance: 0.01
 
@@ -402,11 +387,11 @@ graphs:
           conditions:
             - expr:
                 type: flowExpr
-                value: attributes["lod"] == "1"
+                value: attributes.get("lod") == 1
               outputPort: lod1
             - expr:
                 type: flowExpr
-                value: attributes["lod"] == "2" or attributes["lod"] == "3"
+                value: attributes.get("lod") == 2 or attributes.get("lod") == 3
               outputPort: lod23
 
       # Detect overlaps between different Road instances for LOD1
@@ -462,13 +447,13 @@ graphs:
         with:
           sourceAttribute: overlaidLists
 
-      # DuplicateFilter to remove duplicates based on gmlId
+      # DuplicateFilter to remove duplicates based on the road's gml:id
       - id: f94ccdb2-2133-4b0d-886d-9c933c0d645f
         name: DuplicateFilterLineOverlaps
         type: action
         action: Attribute Duplicate Filter
         with:
-          filterBy: ["gmlId"]
+          filterBy: ["__citygml_gml_id"]
 
       # Replace geometry from attribute
       - id: 2261a5c9-46a4-45ce-a292-d277a3dc0ebc
@@ -512,14 +497,14 @@ graphs:
           countStart: 0
           outputAttribute: areaOverlapIndex
 
-      # Concatenate gmlId from each element in areaOverlapList
+      # Concatenate the road gml:id of each element in areaOverlapList
       - id: 8d7f5e2a-1b3c-4f9e-a7d8-3e9b6c4a2f1d
         name: ListConcatenator
         type: action
         action: List Concatenator
         with:
           list: areaOverlapList
-          elementAttribute: gmlId
+          elementAttribute: __citygml_gml_id
           separator: ","
           outputAttribute: concatenatedGmlIds
 
@@ -561,7 +546,7 @@ graphs:
             - attribute: FeatureType
               expr:
                 type: flowExpr
-                value: attributes.get("featureType", "")
+                value: attributes.get("__citygml_feature_type", "")
             - attribute: LOD
               expr:
                 type: flowExpr
@@ -569,7 +554,7 @@ graphs:
             - attribute: "gml:id"
               expr:
                 type: flowExpr
-                value: attributes.get("gmlId", "")
+                value: attributes.get("__citygml_gml_id", "")
             - attribute: 隣接ID
               expr:
                 type: flowExpr
@@ -585,6 +570,16 @@ graphs:
           output:
             type: string
             value: 03_交通_隣接面重複.csv
+
+      # Geometry that cannot take part in overlap detection — not an area, or not
+      # in the group's coordinate frame. It is not a surface error: the surface
+      # checks see the same geometry on their own branch, so counting it here
+      # would double-report. Collected rather than left unwired so it is not
+      # dropped silently.
+      - id: c3100000-0000-4000-8000-000000000002
+        name: UnusableForOverlapSink
+        type: action
+        action: Noop Sink
 
       # Write surface validation errors to CSV
       - id: 41bd7fb9-6e5b-4ac6-985f-a9abb40fb1c1
@@ -893,66 +888,47 @@ graphs:
         fromPort: features
         toPort: features
 
-      # Connect LOD splitter to surface validators
-      # LOD1 and LOD2 go to SurfaceValidator2D
+      # Reprojection rejects are reported as surface errors
+      - id: c3100000-0000-4000-8000-000000000101
+        from: 10df06f3-cafa-4abd-ba94-04ac71dae467
+        to: c3100000-0000-4000-8000-000000000001
+        fromPort: rejected
+        toPort: features
+      - id: c3100000-0000-4000-8000-000000000102
+        from: c3100000-0000-4000-8000-000000000001
+        to: d44341fa-7de4-41f5-abfd-7e0a3b1d9be8
+        fromPort: features
+        toPort: features
+
+      # Connect LOD splitter to the surface checks
       - id: e23edb68-8299-4a9f-a722-f82b73c82d88
         from: 51431704-ac14-41cd-988b-88141dc6e326
-        to: e28b5f31-4826-4775-a343-a12ecb7f90f9
+        to: abf4b25e-6c1f-46fd-b5f8-07d43d137abf
         fromPort: lod1
         toPort: features
       - id: 53ce90b4-72b4-4473-89ff-da0d0388ba85
         from: 51431704-ac14-41cd-988b-88141dc6e326
-        to: e28b5f31-4826-4775-a343-a12ecb7f90f9
+        to: abf4b25e-6c1f-46fd-b5f8-07d43d137abf
         fromPort: lod2
         toPort: features
-
-      # LOD3 goes to SurfaceValidator3D
       - id: e44eff90-4ce0-4dc2-8c66-78e553ef4560
         from: 51431704-ac14-41cd-988b-88141dc6e326
         to: abf4b25e-6c1f-46fd-b5f8-07d43d137abf
         fromPort: lod3
         toPort: features
 
-      # Connect SurfaceValidator2D invalidSurface to SurfaceValidationAttributeMapper
-      - id: bf52a96b-2a23-4866-9646-1a8a7e17ade3
-        from: e28b5f31-4826-4775-a343-a12ecb7f90f9
-        to: d44341fa-7de4-41f5-abfd-7e0a3b1d9be8
-        fromPort: invalidSurface
-        toPort: features
-
-      # Connect SurfaceValidator3D invalidSurface to SurfaceValidationAttributeMapper
+      # Connect SurfaceChecks invalidSurface to SurfaceValidationAttributeMapper
       - id: 06d601c8-0bf2-4be0-b4ef-c942e2336373
         from: abf4b25e-6c1f-46fd-b5f8-07d43d137abf
         to: d44341fa-7de4-41f5-abfd-7e0a3b1d9be8
         fromPort: invalidSurface
         toPort: features
 
-      # Connect SurfaceValidator2D incorrectOrientation to AttributeMapper (for LOD1/2)
+      # Connect SurfaceChecks inCorrectOrientation to AttributeMapper
       - id: f57856b7-7b32-4a0d-88a4-2bfadaf2f9a3
-        from: e28b5f31-4826-4775-a343-a12ecb7f90f9
-        to: 0740c8ce-3c27-416f-9a13-5b2086090426
-        fromPort: inCorrectOrientation
-        toPort: features
-
-      # Connect SurfaceValidator3D to OrientationExtractor (for LOD3)
-      - id: cf5b54cd-a548-4694-a7db-35a4d682852c
         from: abf4b25e-6c1f-46fd-b5f8-07d43d137abf
-        to: d60f93c1-c55e-49ee-9332-657f4408ba05
-        fromPort: inCorrectOrientation
-        toPort: features
-
-      # OrientationExtractor to Filter
-      - id: 05a6d315-61a1-4021-acaa-606cb1a7435a
-        from: d60f93c1-c55e-49ee-9332-657f4408ba05
-        to: 1c385359-698d-40df-aed8-e8b9b0eaac67
-        fromPort: features
-        toPort: features
-
-      # Filter to AttributeMapper
-      - id: bbd0c116-cf6c-4f5f-b7c1-3c6011c013d3
-        from: 1c385359-698d-40df-aed8-e8b9b0eaac67
         to: 0740c8ce-3c27-416f-9a13-5b2086090426
-        fromPort: incorrectOrientation
+        fromPort: inCorrectOrientation
         toPort: features
 
       # AttributeMapper to FeatureWriter
@@ -1117,6 +1093,33 @@ graphs:
         from: 2ccf00f0-202b-4bf5-b2a1-0c27a0e82a37
         to: 787f4304-c435-4d76-bd66-1fe3fb4ffc80
         fromPort: features
+        toPort: features
+
+      # Everything the overlap pipeline could not use
+      - id: c3100000-0000-4000-8000-000000000201
+        from: b4d2d577-28a0-43a3-8a23-0ae562be1d04  # TwoDimensionForcer
+        to: c3100000-0000-4000-8000-000000000002    # UnusableForOverlapSink
+        fromPort: rejected
+        toPort: features
+      - id: c3100000-0000-4000-8000-000000000202
+        from: c93837eb-e050-46f3-9c97-66d7273fe1e5  # Dissolver
+        to: c3100000-0000-4000-8000-000000000002
+        fromPort: rejected
+        toPort: features
+      - id: c3100000-0000-4000-8000-000000000203
+        from: b684d916-5efe-4dfa-be20-fed9b101239d  # LineOnLineOverlayerLOD1
+        to: c3100000-0000-4000-8000-000000000002
+        fromPort: rejected
+        toPort: features
+      - id: c3100000-0000-4000-8000-000000000204
+        from: 5dab814a-c4c6-47e0-8688-1c5667c775fb  # LineOnLineOverlayerLOD23
+        to: c3100000-0000-4000-8000-000000000002
+        fromPort: rejected
+        toPort: features
+      - id: c3100000-0000-4000-8000-000000000205
+        from: e85ef1d5-a8fb-49e8-895a-b0a055c7b4c0  # AreaOnAreaOverlayer
+        to: c3100000-0000-4000-8000-000000000002
+        fromPort: rejected
         toPort: features
 
       # OverlapAttributeMapper to OverlapCsvWriter

--- a/engine/runtime/geometry/src/validation_next.rs
+++ b/engine/runtime/geometry/src/validation_next.rs
@@ -16,7 +16,6 @@ pub(crate) use simplicity::{
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 
-use kiddo::{KdTree, SquaredEuclidean};
 use serde::{Deserialize, Serialize};
 
 use crate::coordinate::{CoordinateFrame, UnitKind};
@@ -899,16 +898,25 @@ impl DuplicateCoord for [f64; 3] {
 /// point. Exact bit-equality when `tolerance` is `None`; otherwise two coords are
 /// coincident when within `tolerance` distance.
 ///
+/// The tolerant path buckets coordinates into a grid of cells `tolerance` across.
+/// Two coordinates within `tolerance` of each other always land in the same cell
+/// or in one of its immediate neighbours, so scanning that neighbourhood and then
+/// measuring is exact. A k-d tree is the more obvious index, but a reprojected
+/// surface puts many vertices on a single axis value, which a fixed-size bucket
+/// cannot split.
+///
+/// A tolerance that is not a positive finite number carries no usable cell size
+/// and is treated as exact equality.
+///
 /// # Precondition
 ///
 /// Every coordinate must be finite. `DuplicatePoints` depends on
 /// [`Finite`](ValidationType::Finite) (see
 /// [`dependencies`](ValidationType::dependencies)), so the gated driver never
 /// reaches this check until finiteness has passed, and this routine relies on
-/// that rather than re-checking. A non-finite coordinate would corrupt
-/// detection: [`norm_bits`] collides distinct NaNs into a false duplicate, and a
-/// NaN poisons the k-d tree, so any caller outside the gated driver must uphold
-/// it.
+/// that rather than re-checking. A non-finite coordinate would corrupt detection:
+/// [`norm_bits`] collides distinct NaNs into a false duplicate, and a NaN has no
+/// cell, so any caller outside the gated driver must uphold it.
 pub(crate) fn check_duplicate_points<const N: usize>(
     frame: &CoordinateFrame,
     coords: impl IntoIterator<Item = [f64; N]>,
@@ -918,7 +926,7 @@ pub(crate) fn check_duplicate_points<const N: usize>(
     [f64; N]: DuplicateCoord,
 {
     let mut push = |c: [f64; N]| report.push(c.into_point(frame));
-    match tolerance {
+    match tolerance.filter(|t| t.is_finite() && *t > 0.0) {
         None => {
             let mut seen = HashSet::new();
             for c in coords {
@@ -930,18 +938,67 @@ pub(crate) fn check_duplicate_points<const N: usize>(
         }
         Some(t) => {
             let radius = t * t;
-            let mut tree: KdTree<f64, N> = KdTree::new();
-            let mut n: u64 = 0;
+            let mut cells: HashMap<[i64; N], Vec<[f64; N]>> = HashMap::new();
             for c in coords {
-                if n > 0 && tree.nearest_one::<SquaredEuclidean>(&c).distance <= radius {
+                let cell = grid_cell(&c, t);
+                if neighbour_has_coincident(&cells, cell, &c, radius) {
                     push(c);
                 } else {
-                    tree.add(&c, n);
-                    n += 1;
+                    cells.entry(cell).or_default().push(c);
                 }
             }
         }
     }
+}
+
+/// The grid cell a coordinate falls in, for a grid of cells `size` across.
+fn grid_cell<const N: usize>(coord: &[f64; N], size: f64) -> [i64; N] {
+    coord.map(|v| (v / size).floor() as i64)
+}
+
+/// Whether `cell` or any cell touching it already holds a coordinate within
+/// `radius` (a squared distance) of `coord`.
+fn neighbour_has_coincident<const N: usize>(
+    cells: &HashMap<[i64; N], Vec<[f64; N]>>,
+    cell: [i64; N],
+    coord: &[f64; N],
+    radius: f64,
+) -> bool {
+    for i in 0..3usize.pow(N as u32) {
+        let mut neighbour = cell;
+        let mut rem = i;
+        let mut in_range = true;
+        for axis in &mut neighbour {
+            let offset = rem % 3;
+            rem /= 3;
+            match axis.checked_add(offset as i64 - 1) {
+                Some(v) => *axis = v,
+                None => {
+                    in_range = false;
+                    break;
+                }
+            }
+        }
+        if !in_range {
+            continue;
+        }
+        let Some(coords) = cells.get(&neighbour) else {
+            continue;
+        };
+        if coords.iter().any(|c| squared_distance(c, coord) <= radius) {
+            return true;
+        }
+    }
+    false
+}
+
+fn squared_distance<const N: usize>(a: &[f64; N], b: &[f64; N]) -> f64 {
+    let mut acc = 0.0;
+    for axis in 0..N {
+        let d = a[axis] - b[axis];
+        acc += d * d;
+    }
+    acc
 }
 
 /// Twice the signed area of a 2D ring (shoelace), wrapping the last vertex back
@@ -1469,6 +1526,40 @@ mod tests {
         let positions = one_failure(validate_one(&ls, ValidationType::DuplicatePoints, &lenient));
         assert_eq!(positions.len(), 1);
         assert_eq!(offending_point(&positions[0]), [0.001, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn duplicate_tolerance_handles_many_coordinates_on_one_axis_value() {
+        // A reprojected road surface has long axis-aligned runs. Hundreds of
+        // vertices sharing an axis value used to overflow a k-d tree bucket; the
+        // spacing here is wider than the tolerance, so none of them coincide.
+        let coords: Vec<[f64; 3]> = (0..500).map(|i| [0.0, i as f64, 0.0]).collect();
+        let ls = LineString3D::from_coords(CoordinateFrame::Euclidean, coords);
+        let lenient = ValidationParams {
+            duplicate_tolerance: Some(0.01),
+            ..Default::default()
+        };
+        assert_eq!(
+            validate_one(&ls, ValidationType::DuplicatePoints, &lenient),
+            ValidationResult::Success
+        );
+    }
+
+    #[test]
+    fn duplicate_tolerance_finds_a_pair_split_across_grid_cells() {
+        // 0.9999 and 1.0001 fall either side of a cell boundary at 1.0 for a
+        // tolerance of 0.001, so only a neighbourhood scan pairs them.
+        let ls = LineString3D::from_coords(
+            CoordinateFrame::Euclidean,
+            [[0.9999, 0.0, 0.0], [5.0, 0.0, 0.0], [1.0001, 0.0, 0.0]],
+        );
+        let lenient = ValidationParams {
+            duplicate_tolerance: Some(0.001),
+            ..Default::default()
+        };
+        let positions = one_failure(validate_one(&ls, ValidationType::DuplicatePoints, &lenient));
+        assert_eq!(positions.len(), 1);
+        assert_eq!(offending_point(&positions[0]), [1.0001, 0.0, 0.0]);
     }
 
     #[test]

--- a/engine/runtime/geometry/src/validation_next.rs
+++ b/engine/runtime/geometry/src/validation_next.rs
@@ -16,6 +16,7 @@ pub(crate) use simplicity::{
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 
+use kiddo::{ImmutableKdTree, SquaredEuclidean};
 use serde::{Deserialize, Serialize};
 
 use crate::coordinate::{CoordinateFrame, UnitKind};
@@ -898,15 +899,11 @@ impl DuplicateCoord for [f64; 3] {
 /// point. Exact bit-equality when `tolerance` is `None`; otherwise two coords are
 /// coincident when within `tolerance` distance.
 ///
-/// The tolerant path buckets coordinates into a grid of cells `tolerance` across.
-/// Two coordinates within `tolerance` of each other always land in the same cell
-/// or in one of its immediate neighbours, so scanning that neighbourhood and then
-/// measuring is exact. A k-d tree is the more obvious index, but a reprojected
-/// surface puts many vertices on a single axis value, which a fixed-size bucket
-/// cannot split.
+/// The tolerant path indexes the coordinates in a k-d tree; see
+/// [`duplicates_within`].
 ///
-/// A tolerance that is not a positive finite number carries no usable cell size
-/// and is treated as exact equality.
+/// A tolerance that is not a positive finite number carries no usable radius and
+/// is treated as exact equality.
 ///
 /// # Precondition
 ///
@@ -915,8 +912,8 @@ impl DuplicateCoord for [f64; 3] {
 /// [`dependencies`](ValidationType::dependencies)), so the gated driver never
 /// reaches this check until finiteness has passed, and this routine relies on
 /// that rather than re-checking. A non-finite coordinate would corrupt detection:
-/// [`norm_bits`] collides distinct NaNs into a false duplicate, and a NaN has no
-/// cell, so any caller outside the gated driver must uphold it.
+/// [`norm_bits`] collides distinct NaNs into a false duplicate, and a NaN poisons
+/// the k-d tree, so any caller outside the gated driver must uphold it.
 pub(crate) fn check_duplicate_points<const N: usize>(
     frame: &CoordinateFrame,
     coords: impl IntoIterator<Item = [f64; N]>,
@@ -937,68 +934,48 @@ pub(crate) fn check_duplicate_points<const N: usize>(
             }
         }
         Some(t) => {
-            let radius = t * t;
-            let mut cells: HashMap<[i64; N], Vec<[f64; N]>> = HashMap::new();
-            for c in coords {
-                let cell = grid_cell(&c, t);
-                if neighbour_has_coincident(&cells, cell, &c, radius) {
-                    push(c);
-                } else {
-                    cells.entry(cell).or_default().push(c);
+            let coords: Vec<[f64; N]> = coords.into_iter().collect();
+            for (c, duplicate) in coords.iter().zip(duplicates_within(&coords, t)) {
+                if duplicate {
+                    push(*c);
                 }
             }
         }
     }
 }
 
-/// The grid cell a coordinate falls in, for a grid of cells `size` across.
-fn grid_cell<const N: usize>(coord: &[f64; N], size: f64) -> [i64; N] {
-    coord.map(|v| (v / size).floor() as i64)
-}
-
-/// Whether `cell` or any cell touching it already holds a coordinate within
-/// `radius` (a squared distance) of `coord`.
-fn neighbour_has_coincident<const N: usize>(
-    cells: &HashMap<[i64; N], Vec<[f64; N]>>,
-    cell: [i64; N],
-    coord: &[f64; N],
-    radius: f64,
-) -> bool {
-    for i in 0..3usize.pow(N as u32) {
-        let mut neighbour = cell;
-        let mut rem = i;
-        let mut in_range = true;
-        for axis in &mut neighbour {
-            let offset = rem % 3;
-            rem /= 3;
-            match axis.checked_add(offset as i64 - 1) {
-                Some(v) => *axis = v,
-                None => {
-                    in_range = false;
-                    break;
-                }
+/// Which of `coords` coincide with an earlier coordinate, within `tolerance`.
+///
+/// Scanning in index order, a coordinate that is not already flagged claims every
+/// later coordinate within `tolerance` of it, so a cluster of coincident
+/// coordinates is reported against its first member alone.
+///
+/// # Precondition
+///
+/// Every coordinate must be finite; a NaN poisons the k-d tree.
+fn duplicates_within<const N: usize>(coords: &[[f64; N]], tolerance: f64) -> Vec<bool> {
+    let mut duplicate = vec![false; coords.len()];
+    if coords.len() < 2 {
+        return duplicate;
+    }
+    // The mutable KdTree panics on degenerate point distributions;
+    // ImmutableKdTree does not.
+    let tree: ImmutableKdTree<f64, N> = ImmutableKdTree::new_from_slice(coords);
+    // `within_unsorted` excludes the radius itself, so step it up to keep a pair
+    // exactly `tolerance` apart coincident.
+    let radius = (tolerance * tolerance).next_up();
+    for i in 0..coords.len() {
+        if duplicate[i] {
+            continue;
+        }
+        for neighbour in tree.within_unsorted::<SquaredEuclidean>(&coords[i], radius) {
+            let j = neighbour.item as usize;
+            if j > i {
+                duplicate[j] = true;
             }
         }
-        if !in_range {
-            continue;
-        }
-        let Some(coords) = cells.get(&neighbour) else {
-            continue;
-        };
-        if coords.iter().any(|c| squared_distance(c, coord) <= radius) {
-            return true;
-        }
     }
-    false
-}
-
-fn squared_distance<const N: usize>(a: &[f64; N], b: &[f64; N]) -> f64 {
-    let mut acc = 0.0;
-    for axis in 0..N {
-        let d = a[axis] - b[axis];
-        acc += d * d;
-    }
-    acc
+    duplicate
 }
 
 /// Twice the signed area of a 2D ring (shoelace), wrapping the last vertex back
@@ -1530,9 +1507,8 @@ mod tests {
 
     #[test]
     fn duplicate_tolerance_handles_many_coordinates_on_one_axis_value() {
-        // A reprojected road surface has long axis-aligned runs. Hundreds of
-        // vertices sharing an axis value used to overflow a k-d tree bucket; the
-        // spacing here is wider than the tolerance, so none of them coincide.
+        // Hundreds of vertices sharing an axis value, spaced wider than the
+        // tolerance: none coincide.
         let coords: Vec<[f64; 3]> = (0..500).map(|i| [0.0, i as f64, 0.0]).collect();
         let ls = LineString3D::from_coords(CoordinateFrame::Euclidean, coords);
         let lenient = ValidationParams {
@@ -1546,9 +1522,22 @@ mod tests {
     }
 
     #[test]
-    fn duplicate_tolerance_finds_a_pair_split_across_grid_cells() {
-        // 0.9999 and 1.0001 fall either side of a cell boundary at 1.0 for a
-        // tolerance of 0.001, so only a neighbourhood scan pairs them.
+    fn duplicate_tolerance_flags_many_coordinates_on_one_position() {
+        // All coordinates exactly coincident: every vertex past the first is a
+        // duplicate.
+        let coords: Vec<[f64; 3]> = vec![[1.0, 2.0, 3.0]; 500];
+        let ls = LineString3D::from_coords(CoordinateFrame::Euclidean, coords);
+        let lenient = ValidationParams {
+            duplicate_tolerance: Some(0.01),
+            ..Default::default()
+        };
+        let positions = one_failure(validate_one(&ls, ValidationType::DuplicatePoints, &lenient));
+        assert_eq!(positions.len(), 499);
+    }
+
+    #[test]
+    fn duplicate_tolerance_flags_a_non_adjacent_pair() {
+        // The coincident pair is 0.0002 apart but not adjacent in the list.
         let ls = LineString3D::from_coords(
             CoordinateFrame::Euclidean,
             [[0.9999, 0.0, 0.0], [5.0, 0.0, 0.0], [1.0001, 0.0, 0.0]],

--- a/engine/testing/data/testcases/quality-check/plateau4/03-tran/L-TRAN-02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/03-tran/L-TRAN-02/workflow_test.json
@@ -1,7 +1,6 @@
 {
   "description": "Test for plateau4 L-TRAN-02 inspection.",
   "skip": true,
-  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/03-tran/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/03-tran/L-TRAN-03/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/03-tran/L-TRAN-03/workflow_test.json
@@ -1,6 +1,5 @@
 {
   "description": "Test for plateau4 L-TRAN-03 inspection.",
-  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/03-tran/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/03-tran/Z-TRAN-01-surface-orientation/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/03-tran/Z-TRAN-01-surface-orientation/workflow_test.json
@@ -1,6 +1,5 @@
 {
   "description": "Test for checking transportation objects' surface orientation errors.",
-  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/03-tran/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/03-tran/Z-tran-00_no-error/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/03-tran/Z-tran-00_no-error/workflow_test.json
@@ -1,6 +1,5 @@
 {
   "description": "Verify output files: no errors, empty CityGML",
-  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/03-tran/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/03-tran/common/C01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/03-tran/common/C01/workflow_test.json
@@ -1,6 +1,5 @@
 {
   "description": "Test quality check for C01. L-TRAN-02 隣接面重複 is excluded from the summary because the input files are duplicates (with different names).",
-  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/03-tran/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau4/03-tran/common/C05/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/03-tran/common/C05/workflow_test.json
@@ -1,6 +1,5 @@
 {
   "description": "Test quality check for C05",
-  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/03-tran/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.146"
+version = "0.2.147"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.336"
+version = "0.1.337"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
# Overview

Migrates the plateau4 `03-tran` quality check to `new-geometry`, lifting `skipNewGeometry` from all six of its testcases.

## What I've done

- Rebuilt the surface-check part of the workflow on new-geometry actions, and filled the gaps this exposed in the engine.

## What I haven't done

- `L-TRAN-02` stays `skip: true` (unrelated to this migration).

## How I tested

Test inputs and expected CSV/JSON are unchanged — the six `03-tran` testcases now run in the new-geometry world against the same expectations. Added unit tests for the two engine-side changes.

## Screenshot

## Which point I want you to review particularly

## Memo

`extractTags` is deliberately left empty: hoisting traffic areas into their own features would break the per-road grouping the overlap check depends on, so each geometry instead carries the object it belongs to as a per-member attribute.

The tolerant path of `check_duplicate_points` used to abort on real input — a reprojected road surface puts hundreds of vertices on one axis value, overflowing a k-d tree bucket — so it is now indexed by grid cell.