### PR TITLE
fix(api): let anyone fetch a shared project by its token

### DIFF
--- a/server/api/internal/usecase/interactor/projectAccess.go
+++ b/server/api/internal/usecase/interactor/projectAccess.go
@@ -60,9 +60,6 @@ func (i *ProjectAccess) Fetch(ctx context.Context, token string) (project *proje
 	if prj == nil {
 		return nil, rerror.ErrNotFound
 	}
-	if err := i.checkPermission(ctx, rbac.ActionAny, prj.Workspace()); err != nil {
-		return nil, err
-	}
 
 	return prj, nil
 }

--- a/server/api/internal/usecase/interactor/projectAccess_test.go
+++ b/server/api/internal/usecase/interactor/projectAccess_test.go
@@ -18,24 +18,18 @@ import (
 )
 
 func TestProjectAccess_Fetch(t *testing.T) {
-	// prepare
-	mockAuthInfo := &appx.AuthInfo{
-		Token: "token",
-	}
-	mockUser := accountsuser.New().NewID().Name("hoge").Email("abc@bb.cc").MustBuild()
-
+	// The shared-link fetch is anonymous and token-authorized: no user in the
+	// context, and a deny-all checker must not be consulted.
 	ctx := context.Background()
-	ctx = adapter.AttachAuthInfo(ctx, mockAuthInfo)
-	ctx = adapter.AttachUser(ctx, mockUser)
 
 	mem := memory.New()
-	mockPermissionCheckerTrue := NewMockPermissionChecker(func(ctx context.Context, resource, action string) (bool, error) {
-		return true, nil
+	mockPermissionCheckerFalse := NewMockPermissionChecker(func(ctx context.Context, resource, action string) (bool, error) {
+		return false, nil
 	})
 	i := &ProjectAccess{
 		projectRepo:       mem.Project,
 		projectAccessRepo: mem.ProjectAccess,
-		permissionChecker: mockPermissionCheckerTrue,
+		permissionChecker: mockPermissionCheckerFalse,
 	}
 
 	// Set up a workspace, project, and shared project access


### PR DESCRIPTION
## Overview

`sharedProject` returns `operation denied` for anyone who is not a maintainer/owner of the owning workspace — including anonymous visitors following a share link. Production logs on `reearth-flow-api` (reearth-oss) show repeated `Permission denied for resource=projectAccess` warnings.

`ProjectAccess.Fetch` checked `projectAccess:any` against the project's workspace. That policy grants only maintainer/owner, and the workspace-role guard from #2406 made the check effective (previously a stale global maintainer role let every caller through Cerbos).

## What's changed

- Drop the workspace permission check from `ProjectAccess.Fetch`: the share token plus the access record's public flag is the authorization for this path. `Share`/`Unshare` keep their maintainer/owner checks.
- Unit test now runs `Fetch` anonymously with a deny-all permission checker, so reintroducing a permission check on this path fails the test.

## Verification

- `go test ./internal/usecase/interactor/ -run TestProjectAccess -race` — pass
- `go test ./e2e/ -run TestProjectShareFlow` — pass (fetches the shared project with no auth header)
- `make lint` — pass