### PR TITLE
fix(api): report RUNNING for jobs executing on the cloud run worker

### DIFF
--- a/server/api/internal/usecase/interactor/job.go
+++ b/server/api/internal/usecase/interactor/job.go
@@ -171,6 +171,8 @@ func (i *Job) RunCloudRunWorker(j *job.Job, p gateway.RunJobParam) {
 			}
 		}()
 
+		i.markCloudRunJobRunning(ctx, j.ID())
+
 		status, err := i.cloudRunWorker.RunJob(ctx, p)
 		if err != nil {
 			log.Errorfc(ctx, "job: cloud run worker %s run error: %v", j.ID(), err)
@@ -195,6 +197,8 @@ func (i *Job) PreviewSchemaCloudRunWorker(j *job.Job, p gateway.ProbeSchemaParam
 			}
 		}()
 
+		i.markCloudRunJobRunning(ctx, j.ID())
+
 		status, err := i.cloudRunWorker.PreviewSchema(ctx, p)
 		if err != nil {
 			log.Errorfc(ctx, "job: preview-schema cloud run worker %s run error: %v", j.ID(), err)
@@ -204,6 +208,31 @@ func (i *Job) PreviewSchemaCloudRunWorker(j *job.Job, p gateway.ProbeSchemaParam
 			i.failCloudRunJob(ctx, j.ID())
 		}
 	}()
+}
+
+// markCloudRunJobRunning flips a dispatched job to RUNNING: Cloud Run jobs are
+// never polled (no GCPJobID) and the worker only ever publishes a terminal
+// event, so without this they sit in PENDING for their entire run.
+func (i *Job) markCloudRunJobRunning(ctx context.Context, jobID id.JobID) {
+	lock := i.getJobLock(jobID.String())
+	lock.Lock()
+	defer lock.Unlock()
+
+	j, err := i.jobRepo.FindByID(ctx, jobID)
+	if err != nil {
+		log.Errorfc(ctx, "job: failed to reload cloud run job %s: %v", jobID, err)
+		return
+	}
+	if j.Status() != job.StatusPending {
+		return
+	}
+
+	j.SetStatus(job.StatusRunning)
+	if err := i.jobRepo.Save(ctx, j); err != nil {
+		log.Errorfc(ctx, "job: failed to save cloud run job %s: %v", jobID, err)
+		return
+	}
+	i.subscriptions.Notify(jobID.String(), job.StatusRunning)
 }
 
 // failCloudRunJob marks a debug job failed when the worker call fails. A

--- a/server/api/internal/usecase/interactor/job_test.go
+++ b/server/api/internal/usecase/interactor/job_test.go
@@ -195,6 +195,53 @@ func newCheckStatusJob(jobRepo *mockCheckStatusJobRepo, diagRepo repo.NodeDiagno
 	}
 }
 
+type mockCloudRunWorker struct {
+	runJob func(ctx context.Context, p gateway.RunJobParam) (gateway.JobStatus, error)
+}
+
+func (m *mockCloudRunWorker) RunJob(ctx context.Context, p gateway.RunJobParam) (gateway.JobStatus, error) {
+	return m.runJob(ctx, p)
+}
+
+func (m *mockCloudRunWorker) PreviewSchema(ctx context.Context, p gateway.ProbeSchemaParam) (gateway.JobStatus, error) {
+	return gateway.JobStatusCompleted, nil
+}
+
+func (m *mockCloudRunWorker) CancelJob(ctx context.Context, jobID id.JobID) error { return nil }
+
+func TestJob_RunCloudRunWorker_MarksRunningBeforeWorkerCall(t *testing.T) {
+	pending, err := job.New().NewID().Workspace(accountsid.NewWorkspaceID()).Status(job.StatusPending).StartedAt(time.Now()).Build()
+	require.NoError(t, err)
+
+	jobRepo := &mockCheckStatusJobRepo{job: pending}
+	i := newCheckStatusJob(jobRepo, &mockDiagnosticsRepo{}, &mockCheckStatusRedis{})
+
+	seen := make(chan job.Status, 1)
+	i.cloudRunWorker = &mockCloudRunWorker{runJob: func(ctx context.Context, p gateway.RunJobParam) (gateway.JobStatus, error) {
+		seen <- jobRepo.job.Status()
+		return gateway.JobStatusCompleted, nil
+	}}
+
+	i.RunCloudRunWorker(pending, gateway.RunJobParam{JobID: pending.ID()})
+
+	assert.Equal(t, job.StatusRunning, <-seen)
+	assert.Equal(t, 1, jobRepo.saveCalls)
+}
+
+func TestJob_markCloudRunJobRunning_TerminalUntouched(t *testing.T) {
+	done, err := job.New().NewID().Workspace(accountsid.NewWorkspaceID()).Status(job.StatusPending).StartedAt(time.Now()).Build()
+	require.NoError(t, err)
+	done.SetWorkerStatus(job.StatusCompleted)
+
+	jobRepo := &mockCheckStatusJobRepo{job: done}
+	i := newCheckStatusJob(jobRepo, &mockDiagnosticsRepo{}, &mockCheckStatusRedis{})
+
+	i.markCloudRunJobRunning(context.Background(), done.ID())
+
+	assert.Equal(t, job.StatusCompleted, jobRepo.job.Status())
+	assert.Equal(t, 0, jobRepo.saveCalls)
+}
+
 func TestJob_checkJobStatus_TerminalDiagnosticsMerge(t *testing.T) {
 	event := loadJobCompleteEventFixture(t)
 	jobID := id.MustJobID(event.JobID)


### PR DESCRIPTION
## Overview

Job status never shows RUNNING — it sits in PENDING for the entire run, then jumps straight to COMPLETED/FAILED, even while action logs are already streaming.

All jobs in this environment run on the Cloud Run worker (no GCP Batch job has been created since October 2025). Cloud Run jobs have an empty `GCPJobID`, so the monitoring loop skips Batch polling — the only source that ever produced RUNNING — and the worker publishes only a terminal complete event to Redis. Nothing produces an intermediate state.

## What's changed

- `markCloudRunJobRunning`: flips a dispatched job PENDING → RUNNING right before the blocking worker call, saves it, and notifies subscribers. Dispatch is the running signal, matching what Batch's RUNNING state conveys.
- Called from both `RunCloudRunWorker` and `PreviewSchemaCloudRunWorker`.
- The write holds the per-job lock and only flips PENDING, so a concurrent cancel, completion, or infra-failure write is never clobbered; `Cancel` and `failCloudRunJob` take the same lock and re-check state.

## Verification

- New tests: worker mock observes RUNNING at the moment it is invoked; a terminal job is left untouched with no save.
- `go test ./internal/usecase/interactor/ ./pkg/job/ -race` — pass
- `go test ./e2e/ -run Job` — pass
- `make lint` — pass