### PR TITLE
fix(api): deliver engine diagnostics batch env wiring and GCS persistence

### DIFF
--- a/server/api/internal/app/config/config.go
+++ b/server/api/internal/app/config/config.go
@@ -77,6 +77,7 @@ type (
 		Worker_MachineType                     string `envconfig:"WORKER_MACHINE_TYPE" default:"e2-standard-4" pp:",omitempty"`
 		Worker_MaxConcurrency                  string `envconfig:"WORKER_MAX_CONCURRENCY" default:"4" pp:",omitempty"`
 		Worker_NodeStatusPropagationDelayMS    string `envconfig:"WORKER_NODE_STATUS_PROPAGATION_DELAY_MS" default:"1000" pp:",omitempty"`
+		Worker_PubSubDiagnosticTopic           string `envconfig:"WORKER_PUBSUB_DIAGNOSTIC_TOPIC" default:"flow-diagnostic" pp:",omitempty"`
 		Worker_PubSubEdgePassThroughEventTopic string `envconfig:"WORKER_PUBSUB_EDGE_PASS_THROUGH_EVENT_TOPIC" default:"flow-edge-pass-through" pp:",omitempty"`
 		Worker_PubSubJobCompleteTopic          string `envconfig:"WORKER_PUBSUB_JOB_COMPLETE_TOPIC" default:"flow-job-complete" pp:",omitempty"`
 		Worker_PubSubLogStreamTopic            string `envconfig:"WORKER_PUBSUB_LOG_STREAM_TOPIC" default:"flow-log-stream" pp:",omitempty"`
@@ -114,6 +115,7 @@ type (
 		Web_Disabled                    bool          `pp:",omitempty"`
 		Worker_MaxRetries               string        `envconfig:"WORKER_MAX_RETRIES" default:"3" pp:",omitempty"`
 		Worker_CompressIntermediateData bool          `envconfig:"WORKER_COMPRESS_INTERMEDIATE_DATA" default:"false" pp:",omitempty"`
+		Worker_EnableDiagnostics        bool          `envconfig:"WORKER_ENABLE_DIAGNOSTICS" default:"false" pp:",omitempty"`
 		Worker_FeatureWriterDisable     bool          `envconfig:"WORKER_FEATURE_WRITER_DISABLE" default:"false" pp:",omitempty"`
 		Worker_UseSpotVMs               bool          `envconfig:"WORKER_USE_SPOT_VMS" default:"false" pp:",omitempty"`
 		CMS_UseTLS                      bool          `envconfig:"REEARTH_FLOW_GRPC_USETLS" default:"true" pp:",omitempty"`

--- a/server/api/internal/app/repo.go
+++ b/server/api/internal/app/repo.go
@@ -199,6 +199,7 @@ func initBatch(ctx context.Context, conf *config.Config) gateway.Batch {
 		ImageURI:                        conf.Worker_ImageURL,
 		MachineType:                     conf.Worker_MachineType,
 		NodeStatusPropagationDelayMS:    conf.Worker_NodeStatusPropagationDelayMS,
+		PubSubDiagnosticTopic:           conf.Worker_PubSubDiagnosticTopic,
 		PubSubEdgePassThroughEventTopic: conf.Worker_PubSubEdgePassThroughEventTopic,
 		PubSubLogStreamTopic:            conf.Worker_PubSubLogStreamTopic,
 		PubSubJobCompleteTopic:          conf.Worker_PubSubJobCompleteTopic,
@@ -213,6 +214,7 @@ func initBatch(ctx context.Context, conf *config.Config) gateway.Batch {
 		TaskCount:                       taskCount,
 		ThreadPoolSize:                  conf.Worker_ThreadPoolSize,
 		CompressIntermediateData:        conf.Worker_CompressIntermediateData,
+		EnableDiagnostics:               conf.Worker_EnableDiagnostics,
 		FeatureWriterDisable:            conf.Worker_FeatureWriterDisable,
 		UseSpotVMs:                      conf.Worker_UseSpotVMs,
 	}

--- a/server/api/internal/infrastructure/gcpbatch/batch.go
+++ b/server/api/internal/infrastructure/gcpbatch/batch.go
@@ -30,6 +30,7 @@ type BatchConfig struct {
 	ImageURI                        string
 	MachineType                     string
 	NodeStatusPropagationDelayMS    string
+	PubSubDiagnosticTopic           string
 	PubSubEdgePassThroughEventTopic string
 	PubSubLogStreamTopic            string
 	PubSubJobCompleteTopic          string
@@ -48,6 +49,7 @@ type BatchConfig struct {
 	MaxRetryCount                   int
 	TaskCount                       int
 	CompressIntermediateData        bool
+	EnableDiagnostics               bool
 	FeatureWriterDisable            bool
 	UseSpotVMs                      bool
 }
@@ -263,6 +265,7 @@ func (b *BatchRepo) submitCommand(
 				}
 				vars := map[string]string{
 					"FLOW_WORKER_ENABLE_JSON_LOG":               "true",
+					"FLOW_WORKER_DIAGNOSTIC_TOPIC":              b.config.PubSubDiagnosticTopic,
 					"FLOW_WORKER_EDGE_PASS_THROUGH_EVENT_TOPIC": b.config.PubSubEdgePassThroughEventTopic,
 					"FLOW_WORKER_LOG_STREAM_TOPIC":              b.config.PubSubLogStreamTopic,
 					"FLOW_WORKER_JOB_COMPLETE_TOPIC":            b.config.PubSubJobCompleteTopic,
@@ -290,6 +293,9 @@ func (b *BatchRepo) submitCommand(
 				}
 				if b.config.FeatureWriterDisable {
 					vars["FLOW_RUNTIME_FEATURE_WRITER_DISABLE"] = strconv.FormatBool(b.config.FeatureWriterDisable)
+				}
+				if b.config.EnableDiagnostics {
+					vars["FLOW_WORKER_ENABLE_DIAGNOSTICS"] = "true"
 				}
 
 				return vars

--- a/server/api/internal/infrastructure/gcpbatch/batch_test.go
+++ b/server/api/internal/infrastructure/gcpbatch/batch_test.go
@@ -87,6 +87,37 @@ func TestBatchRepo_SubmitJob(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+func TestBatchRepo_SubmitJob_DiagnosticsEnv(t *testing.T) {
+	ctx := context.Background()
+	mockClient := new(mockBatchClient)
+	batchRepo := &BatchRepo{
+		client: mockClient,
+		config: BatchConfig{
+			ProjectID:             "test-project",
+			Region:                "us-central1",
+			ImageURI:              "gcr.io/test-project/reearth-flow:latest",
+			PubSubDiagnosticTopic: "flow-diagnostic",
+			EnableDiagnostics:     true,
+		},
+	}
+
+	jobID, _ := id.JobIDFrom("test-job-id")
+	projectID, _ := id.ProjectIDFrom("test-project-id")
+	workspaceID, _ := accountsid.WorkspaceIDFrom("test-workspace-id")
+
+	var captured *batchpb.CreateJobRequest
+	mockClient.On("CreateJob", ctx, mock.AnythingOfType("*batchpb.CreateJobRequest")).
+		Run(func(args mock.Arguments) { captured = args.Get(1).(*batchpb.CreateJobRequest) }).
+		Return(&batchpb.Job{Name: "projects/test-project/locations/us-central1/jobs/test-job-id"}, nil)
+
+	_, err := batchRepo.SubmitJob(ctx, jobID, "gs://b/wf.yaml", "gs://b/md.json", nil, projectID, accountsid.WorkspaceID(workspaceID), nil, nil)
+	assert.NoError(t, err)
+
+	vars := captured.Job.TaskGroups[0].TaskSpec.Environment.Variables
+	assert.Equal(t, "flow-diagnostic", vars["FLOW_WORKER_DIAGNOSTIC_TOPIC"])
+	assert.Equal(t, "true", vars["FLOW_WORKER_ENABLE_DIAGNOSTICS"])
+}
+
 func TestBatchRepo_SubmitJob_SpotVM(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Overview

Diagnostics come back empty for every job, including failed ones. Two independent gaps, both fixed here:

1. **The enable flag never reached Batch workers.** The env map in `gcpbatch/batch.go` carries every other event topic but had no `FLOW_WORKER_DIAGNOSTIC_TOPIC` / `FLOW_WORKER_ENABLE_DIAGNOSTICS`, so the engine's off-by-default gate stayed off.
2. **Diagnostics had no durable, driver-agnostic store.** Durability was Mongo-only (subscriber write + API terminal merge); the postgres driver has no diagnostics repo, so completed jobs would keep diagnostics only for the 24h Redis TTL and `failedNodes` would always be empty.

## What's changed

**Batch env wiring (api)**
- `FLOW_WORKER_DIAGNOSTIC_TOPIC` always set from `REEARTH_FLOW_WORKER_PUBSUB_DIAGNOSTIC_TOPIC` (default `flow-diagnostic`); `FLOW_WORKER_ENABLE_DIAGNOSTICS=true` set only when `REEARTH_FLOW_WORKER_ENABLE_DIAGNOSTICS` is true, mirroring the engine's default-off gate. Test asserts both on the submitted `CreateJobRequest`.

**GCS persistence (engine + api)** — same durability path logs already use
- Worker writes `diagnostics.json` into its local job root before the artifact sweep, so it lands at `artifacts/<jobID>/diagnostics.json` with zero new upload code. Content is the JobComplete wire shape but **uncapped** (the Pub/Sub event caps at top-50; GCS has no size limit).
- API reads it back through the existing `ReadArtifact` seam whenever the database yields no rows: Redis stays the live leg, the DB stays preferred when populated, and the artifact carries finished jobs on any driver — including postgres.

To enable on a Batch-dispatch environment, set `REEARTH_FLOW_WORKER_ENABLE_DIAGNOSTICS=true` on the API service after this merges.

## Verification

- engine: `cargo fmt` / `cargo clippy` clean, 43 worker tests pass incl. new uncapped-summary and artifact-write tests
- api: `go test ./internal/usecase/interactor/ ./internal/infrastructure/gcpbatch/ -race` — 239 pass incl. new artifact-fallback tests (failed nodes, per-node filter, dropped count, repo-suppresses-artifact, missing-file); `make lint` clean