### PR TITLE
test(api): apply review feedback from the regression-fix PRs

### DIFF
--- a/server/api/internal/infrastructure/gcpbatch/batch_test.go
+++ b/server/api/internal/infrastructure/gcpbatch/batch_test.go
@@ -101,16 +101,16 @@ func TestBatchRepo_SubmitJob_DiagnosticsEnv(t *testing.T) {
 		},
 	}
 
-	jobID, _ := id.JobIDFrom("test-job-id")
-	projectID, _ := id.ProjectIDFrom("test-project-id")
-	workspaceID, _ := accountsid.WorkspaceIDFrom("test-workspace-id")
+	jobID := id.NewJobID()
+	projectID := id.NewProjectID()
+	workspaceID := accountsid.NewWorkspaceID()
 
 	var captured *batchpb.CreateJobRequest
 	mockClient.On("CreateJob", ctx, mock.AnythingOfType("*batchpb.CreateJobRequest")).
 		Run(func(args mock.Arguments) { captured = args.Get(1).(*batchpb.CreateJobRequest) }).
-		Return(&batchpb.Job{Name: "projects/test-project/locations/us-central1/jobs/test-job-id"}, nil)
+		Return(&batchpb.Job{Name: "projects/test-project/locations/us-central1/jobs/" + jobID.String()}, nil)
 
-	_, err := batchRepo.SubmitJob(ctx, jobID, "gs://b/wf.yaml", "gs://b/md.json", nil, projectID, accountsid.WorkspaceID(workspaceID), nil, nil)
+	_, err := batchRepo.SubmitJob(ctx, jobID, "gs://b/wf.yaml", "gs://b/md.json", nil, projectID, workspaceID, nil, nil)
 	assert.NoError(t, err)
 
 	vars := captured.Job.TaskGroups[0].TaskSpec.Environment.Variables

--- a/server/api/internal/usecase/interactor/job_test.go
+++ b/server/api/internal/usecase/interactor/job_test.go
@@ -196,7 +196,8 @@ func newCheckStatusJob(jobRepo *mockCheckStatusJobRepo, diagRepo repo.NodeDiagno
 }
 
 type mockCloudRunWorker struct {
-	runJob func(ctx context.Context, p gateway.RunJobParam) (gateway.JobStatus, error)
+	runJob        func(ctx context.Context, p gateway.RunJobParam) (gateway.JobStatus, error)
+	previewSchema func(ctx context.Context, p gateway.ProbeSchemaParam) (gateway.JobStatus, error)
 }
 
 func (m *mockCloudRunWorker) RunJob(ctx context.Context, p gateway.RunJobParam) (gateway.JobStatus, error) {
@@ -204,7 +205,7 @@ func (m *mockCloudRunWorker) RunJob(ctx context.Context, p gateway.RunJobParam) 
 }
 
 func (m *mockCloudRunWorker) PreviewSchema(ctx context.Context, p gateway.ProbeSchemaParam) (gateway.JobStatus, error) {
-	return gateway.JobStatusCompleted, nil
+	return m.previewSchema(ctx, p)
 }
 
 func (m *mockCloudRunWorker) CancelJob(ctx context.Context, jobID id.JobID) error { return nil }
@@ -223,6 +224,25 @@ func TestJob_RunCloudRunWorker_MarksRunningBeforeWorkerCall(t *testing.T) {
 	}}
 
 	i.RunCloudRunWorker(pending, gateway.RunJobParam{JobID: pending.ID()})
+
+	assert.Equal(t, job.StatusRunning, <-seen)
+	assert.Equal(t, 1, jobRepo.saveCalls)
+}
+
+func TestJob_PreviewSchemaCloudRunWorker_MarksRunningBeforeWorkerCall(t *testing.T) {
+	pending, err := job.New().NewID().Workspace(accountsid.NewWorkspaceID()).Status(job.StatusPending).StartedAt(time.Now()).Build()
+	require.NoError(t, err)
+
+	jobRepo := &mockCheckStatusJobRepo{job: pending}
+	i := newCheckStatusJob(jobRepo, &mockDiagnosticsRepo{}, &mockCheckStatusRedis{})
+
+	seen := make(chan job.Status, 1)
+	i.cloudRunWorker = &mockCloudRunWorker{previewSchema: func(ctx context.Context, p gateway.ProbeSchemaParam) (gateway.JobStatus, error) {
+		seen <- jobRepo.job.Status()
+		return gateway.JobStatusCompleted, nil
+	}}
+
+	i.PreviewSchemaCloudRunWorker(pending, gateway.ProbeSchemaParam{JobID: pending.ID()})
 
 	assert.Equal(t, job.StatusRunning, <-seen)
 	assert.Equal(t, 1, jobRepo.saveCalls)

--- a/server/api/internal/usecase/interactor/projectAccess_test.go
+++ b/server/api/internal/usecase/interactor/projectAccess_test.go
@@ -19,17 +19,18 @@ import (
 
 func TestProjectAccess_Fetch(t *testing.T) {
 	// The shared-link fetch is anonymous and token-authorized: no user in the
-	// context, and a deny-all checker must not be consulted.
+	// context, and consulting the permission checker at all fails the test.
 	ctx := context.Background()
 
 	mem := memory.New()
-	mockPermissionCheckerFalse := NewMockPermissionChecker(func(ctx context.Context, resource, action string) (bool, error) {
+	forbiddenPermissionChecker := NewMockPermissionChecker(func(ctx context.Context, resource, action string) (bool, error) {
+		t.Errorf("permission checker consulted on the token-authorized fetch path (resource=%s action=%s)", resource, action)
 		return false, nil
 	})
 	i := &ProjectAccess{
 		projectRepo:       mem.Project,
 		projectAccessRepo: mem.ProjectAccess,
-		permissionChecker: mockPermissionCheckerFalse,
+		permissionChecker: forbiddenPermissionChecker,
 	}
 
 	// Set up a workspace, project, and shared project access


### PR DESCRIPTION
## Overview

Re-lands three review-feedback commits that missed their squash merges (#2423, #2424, #2427 merged while these were still local). All test-only.

- **#2423**: the shared-fetch test's permission checker now fails the test via `t.Errorf` if it is consulted at all, instead of silently returning deny — reintroducing a permission check on the token-authorized path is an explicit failure.
- **#2424**: covers `PreviewSchemaCloudRunWorker` marking the job RUNNING before the blocking worker call, mirroring the existing `RunCloudRunWorker` test.
- **#2427**: the diagnostics env test builds its IDs with `id.NewJobID()`/`id.NewProjectID()`/`accountsid.NewWorkspaceID()` instead of non-UUID strings with ignored parse errors.

## Verification

- `go test ./internal/usecase/interactor/ ./internal/infrastructure/gcpbatch/` — pass