### PR TITLE
fix(api): read user-facing logs from the per-job stream and poll every 2s

### DIFF
--- a/server/api/internal/infrastructure/redis/userfacinglog.go
+++ b/server/api/internal/infrastructure/redis/userfacinglog.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -68,7 +69,79 @@ func (e *UserFacingLogEntry) ToDomain() (*userfacinglog.UserFacingLog, error) {
 	), nil
 }
 
+// GetUserFacingLogs reads the per-job stream userfacinglog:<jobID> the
+// subscriber dual-writes — an O(job) XRANGE instead of a keyspace-wide scan.
+// Jobs from before the dual-write have no stream and fall back to the scan.
 func (r *redisLog) GetUserFacingLogs(
+	ctx context.Context,
+	since time.Time,
+	until time.Time,
+	jobID id.JobID,
+) ([]*userfacinglog.UserFacingLog, error) {
+	logs, found, err := r.userFacingLogsFromStream(ctx, since, until, jobID)
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		return logs, nil
+	}
+	return r.userFacingLogsFromScan(ctx, since, until, jobID)
+}
+
+func (r *redisLog) userFacingLogsFromStream(
+	ctx context.Context,
+	since time.Time,
+	until time.Time,
+	jobID id.JobID,
+) ([]*userfacinglog.UserFacingLog, bool, error) {
+	streamKey := fmt.Sprintf("userfacinglog:%s", jobID.String())
+	exists, err := r.client.Exists(ctx, streamKey).Result()
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to check log stream: %w", err)
+	}
+	if exists == 0 {
+		return nil, false, nil
+	}
+
+	// Entry IDs are arrival-time based; pad the lower bound and filter on the
+	// event timestamp so arrival skew cannot drop rows.
+	start := strconv.FormatInt(since.UTC().Add(-time.Minute).UnixMilli(), 10)
+	entries, err := r.client.XRange(ctx, streamKey, start, "+").Result()
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to read log stream: %w", err)
+	}
+
+	sinceUTC := since.UTC()
+	untilUTC := until.UTC()
+	result := make([]*userfacinglog.UserFacingLog, 0, len(entries))
+	for _, entry := range entries {
+		raw, ok := entry.Values["data"].(string)
+		if !ok {
+			continue
+		}
+
+		var e UserFacingLogEntry
+		if err := json.Unmarshal([]byte(raw), &e); err != nil {
+			reearth_log.Warnfc(ctx, "gql: failed to unmarshal user-facing log stream entry: %s", raw)
+			continue
+		}
+
+		ts := e.Timestamp.UTC()
+		if ts.Before(sinceUTC) || ts.After(untilUTC) {
+			continue
+		}
+
+		domainLog, err := e.ToDomain()
+		if err != nil {
+			reearth_log.Warnfc(ctx, "gql: failed to convert user-facing log entry to domain: %v", err)
+			continue
+		}
+		result = append(result, domainLog)
+	}
+	return result, true, nil
+}
+
+func (r *redisLog) userFacingLogsFromScan(
 	ctx context.Context,
 	since time.Time,
 	until time.Time,

--- a/server/api/internal/infrastructure/redis/userfacinglog_test.go
+++ b/server/api/internal/infrastructure/redis/userfacinglog_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strconv"
 	"testing"
 	"time"
 
@@ -47,6 +48,8 @@ func TestRedisLog_GetUserFacingLogs(t *testing.T) {
 		data1, _ := json.Marshal(entry1)
 		data2, _ := json.Marshal(entry2)
 
+		mock.ExpectExists("userfacinglog:" + jobID.String()).SetVal(0)
+
 		pattern := "userfacinglog:*:" + jobID.String() + ":*"
 
 		// Mock SCAN command
@@ -77,6 +80,8 @@ func TestRedisLog_GetUserFacingLogs(t *testing.T) {
 		redisLog, err := redis.NewRedisLog(client)
 		require.NoError(t, err)
 
+		mock.ExpectExists("userfacinglog:" + jobID.String()).SetVal(0)
+
 		pattern := "userfacinglog:*:" + jobID.String() + ":*"
 
 		// Mock SCAN command to return error
@@ -98,6 +103,8 @@ func TestRedisLog_GetUserFacingLogs(t *testing.T) {
 		client, mock := redismock.NewClientMock()
 		redisLog, err := redis.NewRedisLog(client)
 		require.NoError(t, err)
+
+		mock.ExpectExists("userfacinglog:" + jobID.String()).SetVal(0)
 
 		pattern := "userfacinglog:*:" + jobID.String() + ":*"
 
@@ -139,6 +146,8 @@ func TestRedisLog_GetUserFacingLogs(t *testing.T) {
 		oldData, _ := json.Marshal(oldEntry)
 		recentData, _ := json.Marshal(recentEntry)
 
+		mock.ExpectExists("userfacinglog:" + jobID.String()).SetVal(0)
+
 		pattern := "userfacinglog:*:" + jobID.String() + ":*"
 
 		// Mock SCAN command
@@ -168,6 +177,8 @@ func TestRedisLog_GetUserFacingLogs(t *testing.T) {
 		redisLog, err := redis.NewRedisLog(client)
 		require.NoError(t, err)
 
+		mock.ExpectExists("userfacinglog:" + jobID.String()).SetVal(0)
+
 		pattern := "userfacinglog:*:" + jobID.String() + ":*"
 
 		// Mock SCAN command
@@ -186,6 +197,66 @@ func TestRedisLog_GetUserFacingLogs(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Empty(t, result)
 
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestRedisLog_GetUserFacingLogs_Stream(t *testing.T) {
+	ctx := context.Background()
+	jobID := id.NewJobID()
+	workflowID := id.NewWorkflowID()
+	now := time.Now().UTC()
+	streamKey := "userfacinglog:" + jobID.String()
+
+	entry := func(ts time.Time, message string) string {
+		data, _ := json.Marshal(map[string]interface{}{
+			"workflowId": workflowID.String(),
+			"jobId":      jobID.String(),
+			"timestamp":  ts,
+			"level":      "info",
+			"message":    message,
+		})
+		return string(data)
+	}
+
+	t.Run("stream is preferred over the key scan", func(t *testing.T) {
+		client, mock := redismock.NewClientMock()
+		redisLog, err := redis.NewRedisLog(client)
+		require.NoError(t, err)
+
+		since := now.Add(-1 * time.Hour)
+		until := now
+		start := strconv.FormatInt(since.Add(-time.Minute).UnixMilli(), 10)
+
+		mock.ExpectExists(streamKey).SetVal(1)
+		mock.ExpectXRange(streamKey, start, "+").SetVal([]goredis.XMessage{
+			{ID: "1-0", Values: map[string]interface{}{"data": entry(now.Add(-30*time.Minute), "streamed log")}},
+			{ID: "2-0", Values: map[string]interface{}{"data": entry(now.Add(-2*time.Hour), "outside window")}},
+		})
+
+		result, err := redisLog.GetUserFacingLogs(ctx, since, until, jobID)
+
+		assert.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, "streamed log", result[0].Message())
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("existing empty stream does not fall back to the scan", func(t *testing.T) {
+		client, mock := redismock.NewClientMock()
+		redisLog, err := redis.NewRedisLog(client)
+		require.NoError(t, err)
+
+		since := now.Add(-1 * time.Hour)
+		start := strconv.FormatInt(since.Add(-time.Minute).UnixMilli(), 10)
+
+		mock.ExpectExists(streamKey).SetVal(1)
+		mock.ExpectXRange(streamKey, start, "+").SetVal([]goredis.XMessage{})
+
+		result, err := redisLog.GetUserFacingLogs(ctx, since, now, jobID)
+
+		assert.NoError(t, err)
+		assert.Empty(t, result)
 		assert.NoError(t, mock.ExpectationsWereMet())
 	})
 }

--- a/server/api/internal/usecase/interactor/userfacinglog.go
+++ b/server/api/internal/usecase/interactor/userfacinglog.go
@@ -116,7 +116,9 @@ func (li *UserFacingLogInteractor) startWatchingLogsIfNeeded(jobID id.JobID, sin
 }
 
 func (li *UserFacingLogInteractor) runLogMonitoringLoop(ctx context.Context, jobID id.JobID, since time.Time) {
-	ticker := time.NewTicker(15 * time.Second)
+	// 2s keeps short debug runs live in the console; the stream-backed Redis
+	// read is O(job), so the faster cadence stays cheap.
+	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
 
 	jobKey := jobID.String()


### PR DESCRIPTION
## Overview

Real-time logs never show for debug runs. Traced end-to-end on the test env (job `b65f55a7`): the engine publishes correctly, the subscriber ingests and stores correctly, permissions and formats are all fine — the logs simply arrive too late. The subscription watcher polls Redis on a **15s ticker** (first poll 15s after subscribe), so any run shorter than that finishes before the first read, and everything lands in one flush after the job is already terminal. The console then shows logs only via the completed-job GCS fallback.

The poll was conservative because the read was a keyspace-wide `SCAN`. But #2390 has the subscriber dual-writing every event to a per-job stream (`userfacinglog:<jobID>`) precisely so reads could be cheap — the API read side just never switched over.

## What's changed

- `GetUserFacingLogs` reads the per-job stream with `XRANGE` — O(job), no keyspace scan. Pre-stream jobs (no stream key) fall back to the legacy scan; an existing-but-empty stream does not.
- Stream entry IDs are arrival-time based, so the range lower bound is padded one minute and rows are filtered on the event timestamp — arrival skew can't drop rows.
- Watcher ticker 15s → 2s: live logs reach the console within ~2s. The `Subscribe`-time initial fetch already covers late subscribers.

## Verification

- New tests: stream preferred over scan with window filtering; existing empty stream does not fall back; all 5 existing scan-path tests updated for the stream-absent check — `go test ./internal/infrastructure/redis/` pass
- `go test ./internal/usecase/interactor/ -run UserFacingLog -race` — pass; build + vet clean

## Notes

- The action-log twin (`log:<jobID>` stream, `GetLogs` scan) has the same shape but no UI consumer for live streaming; left for a follow-up.
- Two UI-side issues observed while tracing, worth their own PR: `getWebSocketClient` re-creates its client map every render (memoization never shares connections), and a completed/errored graphql-ws subscription never re-subscribes without a remount.