### PR TITLE
fix(engine): ship terminal diagnostics for runs whose runner errored out

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "Inflector",
  "approx",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5024,7 +5024,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "bytes",
  "clap",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-diagnostics"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5163,7 +5163,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5180,7 +5180,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "approx",
  "bvh",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5256,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5265,7 +5265,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5297,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5351,7 +5351,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5365,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "bytes",
  "futures",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "bytes",
  "futures",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5415,7 +5415,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5453,7 +5453,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "ahash",
  "bytes",
@@ -5489,7 +5489,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.527"
+version = "0.0.528"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.527"
+version = "0.0.528"
 
 [profile.dev]
 opt-level = 0

--- a/engine/worker/src/command.rs
+++ b/engine/worker/src/command.rs
@@ -6,7 +6,7 @@ use reearth_flow_common::{
     dir::setup_job_directory,
     uri::{Protocol, Uri},
 };
-use reearth_flow_diagnostics::RunSummary;
+use reearth_flow_diagnostics::{Diagnostic, DiagnosticDraft, Disposition, ErrorCode, RunSummary};
 use reearth_flow_runner::runner::AsyncRunner;
 use reearth_flow_runtime::incremental::IncrementalRunConfig;
 use reearth_flow_state::State;
@@ -259,7 +259,13 @@ impl RunWorkerCommand {
             artifact_uri,
         )
         .await;
-        let run_summary: Option<RunSummary> = result.as_ref().ok().cloned();
+        // The runner returns Err without a RunSummary, which would leave exactly
+        // the runs that failed with no failedNodes and no diagnostics artifact;
+        // rebuild the terminal view from the failure handler instead.
+        let run_summary: RunSummary = match &result {
+            Ok(summary) => summary.clone(),
+            Err(e) => failure_summary(format!("{e:?}"), &node_failure_handler),
+        };
         let job_result = match &result {
             Ok(summary) => {
                 let handler_success = node_failure_handler.all_success();
@@ -284,29 +290,23 @@ impl RunWorkerCommand {
         };
         // Written before cleanup so the artifact sweep uploads it; uncapped,
         // unlike the size-capped complete event. Never fails the run.
-        if let Some(summary) = &run_summary {
-            let artifact_event = JobCompleteEvent::with_full_summary(
-                workflow_id,
-                meta.job_id,
-                job_result.clone(),
-                summary,
-            );
-            if let Err(e) = write_diagnostics_artifact(meta.job_id, &artifact_event) {
-                tracing::warn!("Failed to write diagnostics artifact: {e:?}");
-            }
+        let artifact_event = JobCompleteEvent::with_full_summary(
+            workflow_id,
+            meta.job_id,
+            job_result.clone(),
+            &run_summary,
+        );
+        if let Err(e) = write_diagnostics_artifact(meta.job_id, &artifact_event) {
+            tracing::warn!("Failed to write diagnostics artifact: {e:?}");
         }
         self.cleanup(&meta, &storage_resolver).await?;
-        let complete_event = match &run_summary {
-            // Pass the uncapped summary — with_summary caps internally; capping twice would double-cap the overflow marker.
-            Some(summary) => JobCompleteEvent::with_summary(
-                workflow_id,
-                meta.job_id,
-                job_result.clone(),
-                summary,
-            ),
-            // Known gap: Err path (incl. onFatal:Terminate per-feature errors) omits aggregatedDiagnostics/droppedEventCount even though the run produced them.
-            None => JobCompleteEvent::new(workflow_id, meta.job_id, job_result.clone()),
-        };
+        // Pass the uncapped summary — with_summary caps internally; capping twice would double-cap the overflow marker.
+        let complete_event = JobCompleteEvent::with_summary(
+            workflow_id,
+            meta.job_id,
+            job_result.clone(),
+            &run_summary,
+        );
         match &pubsub {
             PubSubBackend::Google(p) => p.publish(complete_event).await.map_err(Error::run),
             PubSubBackend::Noop(p) => p
@@ -587,9 +587,76 @@ fn derive_job_result(summary_success: Option<bool>, handler_all_success: bool) -
     }
 }
 
+/// Rebuilds the terminal failed-nodes view for a run whose runner errored out
+/// before producing a RunSummary: one fatal row per failed node the handler
+/// captured, or a single workflow-level row when it captured none.
+fn failure_summary(error_detail: String, handler: &NodeFailureHandler) -> RunSummary {
+    let fatal = |node_id: Option<String>| {
+        let mut d = Diagnostic::from_draft(
+            DiagnosticDraft::new(ErrorCode::InternalUnclassified)
+                .with_message(error_detail.clone()),
+            node_id,
+            None,
+            None,
+        );
+        d.effective_disposition = Some(Disposition::Fatal);
+        d
+    };
+
+    let mut node_ids = handler.failed_nodes();
+    node_ids.sort();
+    node_ids.dedup();
+
+    let mut failed_nodes: Vec<Diagnostic> = node_ids
+        .into_iter()
+        .map(|node_id| fatal(Some(node_id)))
+        .collect();
+    if failed_nodes.is_empty() {
+        failed_nodes.push(fatal(None));
+    }
+
+    RunSummary {
+        failed_nodes,
+        aggregated_diagnostics: Vec::new(),
+        dropped_event_count: 0,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn failure_summary_builds_a_fatal_row_per_failed_node_deduped() {
+        let handler = NodeFailureHandler::new();
+        handler.failed_sinks.lock().push("node-a".to_string());
+        handler.failed_sinks.lock().push("node-a".to_string());
+        handler.failed_sinks.lock().push("node-b".to_string());
+
+        let summary = failure_summary("ExecutionError(Source(..))".to_string(), &handler);
+
+        assert_eq!(summary.failed_nodes.len(), 2);
+        for row in &summary.failed_nodes {
+            assert_eq!(row.effective_disposition, Some(Disposition::Fatal));
+            assert_eq!(row.message, "ExecutionError(Source(..))");
+        }
+        assert!(summary.aggregated_diagnostics.is_empty());
+        assert_eq!(summary.dropped_event_count, 0);
+    }
+
+    #[test]
+    fn failure_summary_falls_back_to_a_workflow_level_row() {
+        let handler = NodeFailureHandler::new();
+
+        let summary = failure_summary("boom".to_string(), &handler);
+
+        assert_eq!(summary.failed_nodes.len(), 1);
+        assert_eq!(summary.failed_nodes[0].node_id, None);
+        assert_eq!(
+            summary.failed_nodes[0].effective_disposition,
+            Some(Disposition::Fatal)
+        );
+    }
 
     #[test]
     fn derive_job_result_success_when_both_signals_agree_on_success() {


### PR DESCRIPTION
## Overview

The failing-run verification on the test env exposed the engine's documented "Err path" gap in production: when the runner returns `Err` (execution errors — bad source, missing parameter), there is no `RunSummary`, so the worker published a bare JobComplete event and skipped `diagnostics.json`. Result: `Job.failedNodes` empty, nothing in Mongo, no GCS artifact — **for exactly the runs that failed**. Observed live on two failed runs (`a52ab2aa`, `170a2cf9`, CityGML Reader execution errors): terminal FAILED, ERROR user-facing logs flowing, zero diagnostics anywhere. A clean run writes everything.

## What's changed

- On the Err path, synthesize the terminal view from what the run did record: one **fatal `internal.unclassified` row per failed node** captured by `NodeFailureHandler` (deduped — the runtime reports a node failure more than once), carrying the execution error as the message; a single workflow-level fatal row when the handler captured none (e.g. source factory errors).
- `run_summary` is now always present: the complete event and `diagnostics.json` both carry it on every run; the "Known gap" branch is gone.
- Uses the registry construction path (`Diagnostic::from_draft`) and the same `internal.unclassified` convention the runtime already uses for synthesized rows, so `effectiveDisposition: fatal` drives `failedNodes` exactly per the design doc.

## Verification

- New tests: per-node fatal rows deduped with the error message; workflow-level fallback row when the handler captured nothing
- `cargo fmt` / `cargo clippy` clean; full worker suite passes
- Engine version 0.0.527 → 0.0.528