### PR TITLE
feat(engine): carry node identity on synthesized failure diagnostics

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "Inflector",
  "approx",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5024,7 +5024,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "bytes",
  "clap",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-diagnostics"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5163,7 +5163,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5180,7 +5180,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "approx",
  "bvh",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5256,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5265,7 +5265,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5297,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5351,7 +5351,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5365,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "bytes",
  "futures",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "bytes",
  "futures",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5415,7 +5415,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5453,7 +5453,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "ahash",
  "bytes",
@@ -5489,7 +5489,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.528"
+version = "0.0.529"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.528"
+version = "0.0.529"
 
 [profile.dev]
 opt-level = 0

--- a/engine/worker/src/command.rs
+++ b/engine/worker/src/command.rs
@@ -591,28 +591,27 @@ fn derive_job_result(summary_success: Option<bool>, handler_all_success: bool) -
 /// before producing a RunSummary: one fatal row per failed node the handler
 /// captured, or a single workflow-level row when it captured none.
 fn failure_summary(error_detail: String, handler: &NodeFailureHandler) -> RunSummary {
-    let fatal = |node_id: Option<String>| {
+    let fatal = |node_id: Option<String>, name: Option<String>| {
         let mut d = Diagnostic::from_draft(
             DiagnosticDraft::new(ErrorCode::InternalUnclassified)
                 .with_message(error_detail.clone()),
             node_id,
-            None,
+            name,
             None,
         );
         d.effective_disposition = Some(Disposition::Fatal);
         d
     };
 
-    let mut node_ids = handler.failed_nodes();
-    node_ids.sort();
-    node_ids.dedup();
-
-    let mut failed_nodes: Vec<Diagnostic> = node_ids
+    let mut failed_nodes: Vec<Diagnostic> = handler
+        .failure_details()
         .into_iter()
-        .map(|node_id| fatal(Some(node_id)))
+        .map(|node| fatal(Some(node.id), node.name))
         .collect();
+    // A run that died before any node event (e.g. a graph-build error) still
+    // gets a workflow-level row carrying the execution error.
     if failed_nodes.is_empty() {
-        failed_nodes.push(fatal(None));
+        failed_nodes.push(fatal(None, None));
     }
 
     RunSummary {
@@ -628,10 +627,23 @@ mod tests {
 
     #[test]
     fn failure_summary_builds_a_fatal_row_per_failed_node_deduped() {
+        use crate::event_handler::FailedNode;
+
         let handler = NodeFailureHandler::new();
-        handler.failed_sinks.lock().push("node-a".to_string());
-        handler.failed_sinks.lock().push("node-a".to_string());
-        handler.failed_sinks.lock().push("node-b".to_string());
+        // A status-Failed capture (no name) followed by the processor event for
+        // the same node (named), plus a second node — 2 rows, name preserved.
+        handler.failed_details.lock().push(FailedNode {
+            id: "node-a".to_string(),
+            name: None,
+        });
+        handler.failed_details.lock().push(FailedNode {
+            id: "node-a".to_string(),
+            name: Some("CityGML Reader".to_string()),
+        });
+        handler.failed_details.lock().push(FailedNode {
+            id: "node-b".to_string(),
+            name: None,
+        });
 
         let summary = failure_summary("ExecutionError(Source(..))".to_string(), &handler);
 
@@ -640,6 +652,13 @@ mod tests {
             assert_eq!(row.effective_disposition, Some(Disposition::Fatal));
             assert_eq!(row.message, "ExecutionError(Source(..))");
         }
+        assert_eq!(summary.failed_nodes[0].node_id.as_deref(), Some("node-a"));
+        assert_eq!(
+            summary.failed_nodes[0].action_type.as_deref(),
+            Some("CityGML Reader")
+        );
+        assert_eq!(summary.failed_nodes[1].node_id.as_deref(), Some("node-b"));
+        assert_eq!(summary.failed_nodes[1].action_type, None);
         assert!(summary.aggregated_diagnostics.is_empty());
         assert_eq!(summary.dropped_event_count, 0);
     }

--- a/engine/worker/src/event_handler.rs
+++ b/engine/worker/src/event_handler.rs
@@ -12,19 +12,30 @@ use reearth_flow_worker::types::node_status_event::{
     NodeMetrics as PublishNodeMetrics, NodeStatus as PublishNodeStatus, NodeStatusEvent,
 };
 
+/// The identity a failure event carried: always a node id, plus the node's
+/// name when the event had one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FailedNode {
+    pub(crate) id: String,
+    pub(crate) name: Option<String>,
+}
+
 #[derive(Debug)]
 pub(crate) struct NodeFailureHandler {
     pub(crate) failed_processor_nodes: Arc<Mutex<Vec<NodeHandle>>>,
     pub(crate) failed_sinks: Arc<Mutex<Vec<String>>>,
+    /// Superset of the two above plus status-Failed transitions (how source
+    /// failures surface). Feeds the synthesized failure diagnostics only —
+    /// never all_success(), which would change job-result semantics.
+    pub(crate) failed_details: Arc<Mutex<Vec<FailedNode>>>,
 }
 
 impl NodeFailureHandler {
     pub(crate) fn new() -> Self {
-        let failed_processor_nodes = Arc::new(Mutex::new(Vec::new()));
-        let failed_sinks = Arc::new(Mutex::new(Vec::new()));
         Self {
-            failed_processor_nodes,
-            failed_sinks,
+            failed_processor_nodes: Arc::new(Mutex::new(Vec::new())),
+            failed_sinks: Arc::new(Mutex::new(Vec::new())),
+            failed_details: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -42,17 +53,51 @@ impl NodeFailureHandler {
         failed_nodes.extend(self.failed_sinks.lock().iter().cloned());
         failed_nodes
     }
+
+    /// Deduped by node id, keeping the first named entry for each.
+    pub(crate) fn failure_details(&self) -> Vec<FailedNode> {
+        let mut out: Vec<FailedNode> = Vec::new();
+        for detail in self.failed_details.lock().iter() {
+            match out.iter_mut().find(|d| d.id == detail.id) {
+                Some(existing) => {
+                    if existing.name.is_none() {
+                        existing.name = detail.name.clone();
+                    }
+                }
+                None => out.push(detail.clone()),
+            }
+        }
+        out
+    }
 }
 
 #[async_trait::async_trait]
 impl reearth_flow_runtime::event::EventHandler for NodeFailureHandler {
     async fn on_event(&self, event: &reearth_flow_runtime::event::Event) {
         match event {
-            reearth_flow_runtime::event::Event::ProcessorFailed { node, .. } => {
+            reearth_flow_runtime::event::Event::ProcessorFailed { node, name } => {
                 self.failed_processor_nodes.lock().push(node.clone());
+                self.failed_details.lock().push(FailedNode {
+                    id: node.id.to_string(),
+                    name: Some(name.clone()),
+                });
             }
             reearth_flow_runtime::event::Event::SinkFinishFailed { name } => {
                 self.failed_sinks.lock().push(name.clone());
+                self.failed_details.lock().push(FailedNode {
+                    id: name.clone(),
+                    name: Some(name.clone()),
+                });
+            }
+            reearth_flow_runtime::event::Event::NodeStatusChanged {
+                node_handle,
+                status: NodeStatus::Failed,
+                ..
+            } => {
+                self.failed_details.lock().push(FailedNode {
+                    id: node_handle.id.to_string(),
+                    name: None,
+                });
             }
             _ => {}
         }
@@ -194,6 +239,46 @@ mod tests {
     use reearth_flow_worker::pubsub::EncodableMessage;
 
     use super::*;
+
+    /// Status-Failed transitions are how source failures surface; they must
+    /// reach failure_details without flipping all_success, which still drives
+    /// the job result.
+    #[tokio::test]
+    async fn status_failed_feeds_details_but_not_all_success() {
+        let handler = NodeFailureHandler::new();
+
+        handler
+            .on_event(&reearth_flow_runtime::event::Event::NodeStatusChanged {
+                node_handle: NodeHandle::for_test("node-a"),
+                status: NodeStatus::Failed,
+                feature_id: None,
+                metrics: None,
+            })
+            .await;
+        handler
+            .on_event(&reearth_flow_runtime::event::Event::ProcessorFailed {
+                node: NodeHandle::for_test("node-a"),
+                name: "CityGML Reader".to_string(),
+            })
+            .await;
+
+        assert!(!handler.all_success());
+        let details = handler.failure_details();
+        assert_eq!(details.len(), 1);
+        assert_eq!(details[0].name.as_deref(), Some("CityGML Reader"));
+
+        let status_only = NodeFailureHandler::new();
+        status_only
+            .on_event(&reearth_flow_runtime::event::Event::NodeStatusChanged {
+                node_handle: NodeHandle::for_test("node-b"),
+                status: NodeStatus::Failed,
+                feature_id: None,
+                metrics: None,
+            })
+            .await;
+        assert!(status_only.all_success());
+        assert_eq!(status_only.failure_details().len(), 1);
+    }
 
     #[derive(Debug, Default, Clone)]
     struct CountingPublisher {


### PR DESCRIPTION
## Overview

Follow-up to #2432. The synthesized Err-path failure rows ship with `nodeId`/`actionType` null for most failure classes, e.g. this real response for a failed run:

```json
{ "code": "internal.unclassified", "nodeId": null, "actionType": null,
  "message": "ExecutionError(Source(\"Missing required parameter ...\"))" }
```

`NodeFailureHandler` only listened to `ProcessorFailed` and `SinkFinishFailed` — discarding `ProcessorFailed`'s node name and ignoring `NodeStatusChanged(Failed)` entirely, which is how **source failures** surface. A CityGML Reader source error therefore produced a bare workflow-level row even though the runtime had published the failing node's id moments earlier.

## What's changed

- The handler captures all three signals into a `failure_details` list: `ProcessorFailed` (id + name), `SinkFinishFailed` (name), `NodeStatusChanged(Failed)` (id). Deduped by node id; the first named entry wins.
- Synthesized rows now carry `nodeId` and the node name as `actionType` — the same convention the runtime's own `synthesize_process_error_fatal` uses.
- `all_success()` deliberately keeps its original two inputs, so job-result derivation is byte-for-byte unchanged — a transient status-Failed can never flip a job's result.

## Known remaining case

A run that dies before any node event (graph-build errors like the missing-parameter example above) still gets the workflow-level row — the runner's error type carries no node context. Fixing that means enriching the runtime's `ExecutionError` with the offending node, which is a separate, larger change.

## Verification

- New tests: status-Failed feeds details without affecting `all_success`; dedupe keeps the named entry; synthesized rows carry id + name with the workflow-level fallback intact
- `cargo fmt` / `clippy` clean; full worker suite passes; engine 0.0.528 → 0.0.529