### PR TITLE
fix(api): load action schema from plateau5 instead of main

### DIFF
--- a/server/api/internal/app/actions.go
+++ b/server/api/internal/app/actions.go
@@ -117,7 +117,7 @@ func loadActionsData(lang string) error {
 		return nil
 	}
 
-	baseURL := "https://raw.githubusercontent.com/reearth/reearth-flow/main/engine/schema/"
+	baseURL := "https://raw.githubusercontent.com/reearth/reearth-flow/plateau5/engine/schema/"
 	filename := "actions.json"
 	if lang != "" {
 		filename = fmt.Sprintf("actions_%s.json", lang)


### PR DESCRIPTION
# Overview

The action schema base URL was hardcoded to the `main` branch, so an API built from `plateau5` served `main`'s `actions.json` regardless of deployment config. This is why `/actions` on the PLATEAU environment listed actions that only exist on `main`, such as `Coordinate Frame Reprojector`.

## What I've done

- Point the schema base URL at the `plateau5` branch.

## What I haven't done

- Nothing here changes how the API is deployed, so this needs a rebuild and redeploy of the PLATEAU environment to take effect.

## How I tested

- Confirmed `actions.json` and `actions_{en,es,fr,ja,zh}.json` all return 200 from the `plateau5` raw URL, and that `go build ./...` and `go test ./internal/app/...` pass.

## Screenshot

## Which point I want you to review particularly

## Memo

The proper fix is #2196 on `main`, which drops the hardcoded URL and reads the schema from the environment's own GCS bucket, with GitHub only as a fallback. I went with hardcoding the branch instead because it is a one-line change that works on a fixed branch like this one, and mirrors the lint fix in #2223.

Doing it properly would take more than merging #2196: a workflow that uploads `plateau5`'s `engine/schema/actions*.json` to the PLATEAU bucket on push, that bucket's name as a secret, and pointing the fallback URL at `plateau5` so a misconfiguration doesn't silently serve `main` again.