### PR TITLE
refactor(engine): apply action standard to CSV Reader and expose it

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.156"
+version = "0.2.157"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "Inflector",
  "approx",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5024,7 +5024,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "bytes",
  "clap",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-diagnostics"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5163,7 +5163,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5180,7 +5180,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "approx",
  "bvh",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5256,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5265,7 +5265,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5297,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5351,7 +5351,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5365,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "bytes",
  "futures",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "bytes",
  "futures",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5415,7 +5415,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5453,7 +5453,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "ahash",
  "bytes",
@@ -5489,7 +5489,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.532"
+version = "0.0.533"
 dependencies = [
  "async-trait",
  "axum",
@@ -8257,7 +8257,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.346"
+version = "0.1.347"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.157"
+version = "0.2.158"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "Inflector",
  "approx",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5024,7 +5024,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "bytes",
  "clap",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-diagnostics"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5163,7 +5163,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5180,7 +5180,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "approx",
  "bvh",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5256,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5265,7 +5265,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5297,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5351,7 +5351,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5365,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "bytes",
  "futures",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "bytes",
  "futures",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5415,7 +5415,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5453,7 +5453,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "ahash",
  "bytes",
@@ -5489,7 +5489,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.533"
+version = "0.0.534"
 dependencies = [
  "async-trait",
  "axum",
@@ -8257,7 +8257,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.347"
+version = "0.1.348"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.533"
+version = "0.0.534"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.532"
+version = "0.0.533"
 
 [profile.dev]
 opt-level = 0

--- a/engine/dev-docs/action-review-findings.md
+++ b/engine/dev-docs/action-review-findings.md
@@ -466,8 +466,8 @@ workflow that names it, so no existing workflow broke.
 
 | Bucket | Count | Trigger to re-expose |
 |---|---|---|
-| Exposed and audited | 78 | — |
-| Does not run in the shipped build | 17 | Its new-geometry port landing (Notion FLOW-DEV-182) |
+| Exposed and audited | 79 | — |
+| Does not run in the shipped build | 16 | Its new-geometry port landing (Notion FLOW-DEV-182) |
 | **Pending audit** | **6** | An engine-side §8 pass — the list below |
 | Flagged for removal | 2 | None; they owe an engine-side deletion |
 | Retired on design grounds | 2 | A scope decision, see below |
@@ -478,15 +478,6 @@ so §7.2 handed it a decision rather than an audit. The §8 re-check was run aga
 new-geometry build and found no correctness defect; its outcome is in the Geometry A section
 below, along with the one item that stays deferred.
 
-⚠️ **`CSV Reader` runs but is still counted in the does-not-run bucket.** Its port merged as
-#2405 and `file/csv.rs` now has a `#[cfg(feature = "new-geometry")] async fn start`, so it
-executes in the shipped build; it is not in `base_actions.go`, and it is not in the pending-audit
-list either, so no bucket currently describes it. It was reviewed in the Input batch (#2280) —
-`offset`/`headerRows`/`geometry` were re-verified in the pass below — which by the rule above
-makes it Bufferer's case: **a re-exposure decision, not an audit.** Verified 2026-08-27.
-Its Notion row still reads "In progress" while its merged code runs, so the tracker is not the
-thing to check here. **Trigger:** none pending; this is ready to decide.
-
 **The `impl:` finding that appeared to block it never described the shipped build**, and this is
 worth keeping as a warning rather than deleting. That finding — only points, curves and single
 polygons buffered, every other type emitted **unbuffered** — was written against the legacy
@@ -495,13 +486,15 @@ finding's text survived the port, so it reads as live. Anyone re-reading a findi
 before an action's geometry port should confirm which implementation it describes before
 treating it as a blocker.
 
-**`CSV Reader`'s port landed in #2405 (merged 2026-08-27) and it is the same case as Bufferer.**
-It now has a `#[cfg(feature = "new-geometry")] start` (`file/csv.rs:166`) so it runs, and it was
-reviewed in the Input batch (#2280) — so §7.2 hands it a decision rather than an audit. Like
-Bufferer's, that review predates the 2026-08-20/21 rescoping (§7, the §8 `impl:` line, the §6 tag
-rewrite), so the decision needs an §8 re-check against the new-geometry code first. It is not in
-`base_actions.go`. Note the table has no bucket for "runs, reviewed, awaiting a decision" — that
-is why this is prose, and it is the slot Bufferer occupied until this PR.
+**`CSV Reader`'s port landed in #2405, and it has now been audited and exposed** — outcome in
+the addendum at the bottom of this file. It was triaged as Bufferer's case (reviewed in the Input
+batch #2280, so a decision rather than an audit), and that triage was overturned before any work
+started: #2280 merged 2026-07-23, which is *earlier than every Changelog entry in the standard
+except its own*. §7 did not exist, §8 had no `impl:` line, and §4.3 and §6 have both been
+corrected since. A review that predates that much of the standard supplies almost no coverage, so
+it was audited in full. **The general rule: date the prior review against the Changelog before
+calling anything a re-check** — Bufferer's review (#2317, 2026-07-31) postdates most of those
+entries and CSV Reader's does not, which is what separates the two cases.
 
 **`Area Calculator`'s port landed in #2385 (merged 2026-08-27), it went to pending audit per
 §7.2, and it has now been audited and exposed** — outcome in the addendum at the bottom of this
@@ -1466,3 +1459,82 @@ and the document disagreed with it, exactly as in Batches 6 and 7.
 
 **So the rule is not "predict the post-merge number", it is "recount at merge time".** A
 predicted figure is one more piece of text that merges cleanly and is wrong. Count the file.
+
+---
+
+### Addendum — CSV Reader, audited and exposed
+
+Triaged as a re-check under §7.2's "already reviewed" case, then audited in full. The triage was
+overturned before any work started, and the reason generalises: **date the prior review against
+the standard's Changelog before calling anything a re-check.** #2280 merged 2026-07-23, earlier
+than every Changelog entry except the one it introduced itself. §7 did not exist, §8 had no
+`impl:` line, §4.3 and §6 have both been *corrected* since, and §"How to use" was rescoped so
+that text which merely reads well is no longer exempt. What survived from #2280 was §1, part of
+§3, and §5. Bufferer's review (#2317, 2026-07-31) postdates most of those entries; this one
+predates all of them, which is the whole difference between the two cases.
+
+```
+CSV Reader
+  runs:    OK — `#[cfg(feature = "new-geometry")] start`, file/csv.rs:166
+  impl:    `geometryMode` accepted by every fixture and README, applied by nothing
+  desc:    OK
+  params:  7, under the §3.5 guideline. Block title was `CsvReader Parameters` (pre-#2240)
+  ports:   `features` only — fail-the-read vs `rejected` settled by amending §4.3
+  cat/tags: Input / ["csv"] — both OK, tags match the sibling readers per §6
+  i18n:    es/zh descriptions dropped TSV; fr was an English placeholder; all four
+             carried the stale `CsvReader` block title
+```
+
+**`geometryMode` was removed deliberately, in two steps, and the leftovers outlived it.** History:
+#1615 introduced `#[serde(tag = "geometryMode")]` with a derived schema — tag in the schema, tag
+required by serde, consistent. #1641 replaced the derive with a hand-written `impl JsonSchema`
+"to hide the redundant geometryMode field from UI" **but kept the tag**, so for that window the
+schema omitted a key serde still required: a config built from the schema could not deserialize.
+#1655 then made the enum `untagged`, which restored consistency by deleting the discriminator.
+The end state is sound — the mode is inferable from which columns are supplied — but every
+workflow and both READMEs still passed the dead key: 9 fixture nodes across 6 files and 8 more
+occurrences in documentation. Removed. **The tell for this shape is a hand-written
+`impl JsonSchema`: it decouples the schema from the struct, so serde and the schema can disagree
+without anything failing.**
+
+**Not a translation argument, contrary to a first reading.** Restoring the tag was considered
+partly to make the two variant labels translatable. It would not have: `apply_parameter_i18n`
+reaches a `oneOf` variant only when it carries a literal `enum` key at its top level, which
+neither a tagged variant (its tag sits at `properties.type.enum[0]`) nor an untagged branch does.
+Both shapes are equally unreachable, so translation is an argument for neither. The fix is the
+queued i18n reach work, not a schema reshape.
+
+**§4.3 amended rather than followed.** #2405 removed a `rejected` port and made an unparseable
+geometry value fail the whole read; §4.3's table said malformed input routes to `rejected`. The
+code was right and the rule was incomplete: a source has no incoming feature for a rejection to
+attach to, and a reader that emits part of a file while dropping the rest hides corrupt input at
+the only point the user can still fix it. §4.3 now carves sources out explicitly, with the
+absence-versus-malformed line preserved. Note the old port was advertised and never emitted to,
+so the pre-#2405 state was its own §4.3 defect.
+
+**The example READMEs were non-functional, which no test could have caught.** Both used
+pre-#2240 PascalCase action names — `CsvReader`, `CsvWriter`, `GeoJsonWriter` — while the
+fixtures beside them use the current space-separated names, so every YAML snippet a user might
+copy would fail with "Action not found". Fixed, along with a parameter list missing `headerRows`
+and `encoding` entirely, and a vendor name that §2 now prohibits. **Worth a sweep: nothing links
+a README to the schema, so #2240's rename could not have reached them.**
+
+**A failing test that was not a defect.** `test_executor_csv_wkt_roundtrip_3d` is one of the 37
+`workflow-tests` failures on main. It fails **only in the legacy build** and passes with
+`--features new-geometry`: `parse_geometry` is cfg-swapped (`csv_geometry.rs:207-213`) and only
+the new-geometry arm tolerates the bare 3D WKT that our own CSV Writer emits. `workflow-tests`
+defaults to `default = []`, i.e. legacy. **Run any failure in that suite both ways before calling
+it a defect** — and note `cargo test … | tail` exited 0 on the failing run, so read the body for
+`test result:`, never the exit code.
+
+**Filed, not fixed:**
+
+- `CSV Reader` is already listed in the schemars-flatten ordering finding above (`dataset`/`inline`
+  render after `format` and `encoding`). Unchanged here; it wants the shared fix, not a local one.
+- **50 actions carry a parameter-block title that is an internal PascalCase struct name** —
+  `CsvReader Parameters`, `CenterPointReplacerParam`, `GeoJsonWriter Parameters`. CSV Reader's own
+  is fixed in all four i18n files as well as the schema, since `parameterI18n[""].title` overrides
+  it. **Trigger:** a batch willing to sweep all 50, or the next time each is audited.
+- `dataset` and `inline` are both schema-optional while omitting both fails at runtime, against
+  §3.2. Shared by all nine readers. **Trigger:** the same flatten fix above, which has to touch
+  every reader's param struct anyway.

--- a/engine/dev-docs/action-standard.md
+++ b/engine/dev-docs/action-standard.md
@@ -213,6 +213,8 @@ Ask: did the action *attempt* the transformation and fail, or was there simply *
 
 A missing attribute is **usually a no-op, not a failure.** Treating it as a failure is the most common way this rule gets broken, because "the attribute wasn't there" sounds like an error when it is normally just an absence.
 
+**Sources are outside this rule.** A source receives no features, so it has nothing to route — there is no incoming feature for a `rejected` outcome to attach to. When a reader meets input it cannot parse, the correct behaviour is to fail the read with an error naming the offending location, not to route somewhere: a reader that emits part of a file and quietly drops the rest hides corrupt input at the point where the user can still fix it. This does not license failing on absence. A blank cell where a value is optional is the no-op case above, and the feature is still emitted; reserve the failure for input that is present and malformed.
+
 **Check the paired producer.** Extractor/Replacer, Splitter/Merger and similar pairs only work if both halves agree. If the producer conditionally skips writing its attribute, the consumer *must* tolerate its absence — a `rejected` port on the consumer silently deletes the features the producer deliberately left alone.
 
 **Adding a port is a data-loss change.** A new port is unwired in every existing workflow, so features newly routed to it are dropped on the floor rather than reaching the destination they used to. Before adding one: grep the fixtures for the action name to size the blast radius, and run `cargo make test-qc` afterwards. Silent loss shows up as a downstream count that quietly drops, not as a test error at the changed node.
@@ -335,6 +337,10 @@ If an action is clean on all dimensions, write: `ActionName — OK`
 ## Changelog
 
 Material rule changes, newest first. **A rule added here does not retroactively apply to actions already reviewed** — when a change would alter a past verdict, say so in the entry, and treat previously-reviewed actions as owing a re-check against the new rule.
+
+### 2026-08-28
+
+- **§4.3** — added the carve-out that sources sit outside the port-completeness rule: a reader has no incoming feature to reject, so input it cannot parse fails the read rather than routing to `rejected`. Settled while auditing `CSV Reader`, whose new-geometry read removed a `rejected` port that had been advertised but never emitted to. The table above continues to govern processors unchanged, so no past verdict changes.
 
 ### 2026-08-27
 

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -1526,7 +1526,7 @@ Reads features from CSV and TSV files.
 ```json
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "CsvReader Parameters",
+  "title": "CSV Reader Parameters",
   "description": "Configure how CSV and TSV files are processed and read",
   "type": "object",
   "required": [
@@ -1622,7 +1622,7 @@ Reads features from CSV and TSV files.
     },
     "geometry": {
       "title": "Geometry Configuration",
-      "description": "Optional configuration for parsing geometry from CSV columns",
+      "description": "Names the columns that hold geometry, either as Well-Known Text or as separate coordinate columns. Those columns are read as the feature's geometry instead of as attributes. Rows become attribute-only features when omitted.",
       "anyOf": [
         {
           "$ref": "#/definitions/GeometryConfig"
@@ -1707,7 +1707,7 @@ Reads features from CSV and TSV files.
       "properties": {
         "epsg": {
           "title": "EPSG Code",
-          "description": "Coordinate Reference System code (e.g., 4326 for WGS84)",
+          "description": "Coordinate reference system of the values in the file, such as 4326 for WGS 84. When the referenced system declares latitude first, the two horizontal ordinates are stored in that order; elevation is never reordered. Values are read as plain coordinates when omitted.",
           "type": [
             "integer",
             "null"

--- a/engine/runtime/action-source/src/file/csv.rs
+++ b/engine/runtime/action-source/src/file/csv.rs
@@ -94,7 +94,7 @@ pub(super) struct CsvReader {
     params: CsvReaderCompiledParam,
 }
 
-/// # CsvReader Parameters
+/// # CSV Reader Parameters
 /// Configure how CSV and TSV files are processed and read
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]

--- a/engine/runtime/action-source/src/file/reader/csv.rs
+++ b/engine/runtime/action-source/src/file/reader/csv.rs
@@ -31,7 +31,7 @@ pub struct CsvReaderParam {
     /// Number of consecutive rows that make up the header (default: 1). When 0, column names are auto-generated as "column1", "column2", and so on; when greater than 1, names are formed by joining values from each header row with "_".
     pub(crate) header_rows: Option<usize>,
     /// # Geometry Configuration
-    /// Optional configuration for parsing geometry from CSV columns
+    /// Names the columns that hold geometry, either as Well-Known Text or as separate coordinate columns. Those columns are read as the feature's geometry instead of as attributes. Rows become attribute-only features when omitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) geometry: Option<GeometryConfig>,
 }

--- a/engine/runtime/action-source/src/file/reader/csv_geometry.rs
+++ b/engine/runtime/action-source/src/file/reader/csv_geometry.rs
@@ -34,7 +34,7 @@ pub struct GeometryConfig {
     #[serde(flatten)]
     pub mode: GeometryMode,
     /// # EPSG Code
-    /// Coordinate Reference System code (e.g., 4326 for WGS84)
+    /// Coordinate reference system of the values in the file, such as 4326 for WGS 84. When the referenced system declares latitude first, the two horizontal ordinates are stored in that order; elevation is never reordered. Values are read as plain coordinates when omitted.
     pub epsg: Option<u16>,
 }
 

--- a/engine/runtime/examples/fixture/workflow/examples/csv-reader/README.md
+++ b/engine/runtime/examples/fixture/workflow/examples/csv-reader/README.md
@@ -1,6 +1,6 @@
 # CSV Reader Examples
 
-This directory contains example workflows demonstrating how to use the CsvReader action with geometry support.
+This directory contains example workflows demonstrating how to use the CSV Reader action with geometry support.
 
 ## Examples
 
@@ -17,12 +17,11 @@ id,name,population,geometry
 
 **Configuration:**
 ```yaml
-action: CsvReader
+action: CSV Reader
 with:
   format: csv
   dataset: ./sample-with-wkt.csv
   geometry:
-    geometryMode: wkt
     column: geometry
     epsg: 4326
 ```
@@ -48,12 +47,11 @@ id,name,temperature,longitude,latitude,elevation
 
 **Configuration:**
 ```yaml
-action: CsvReader
+action: CSV Reader
 with:
   format: csv
   dataset: ./sample-with-coords.csv
   geometry:
-    geometryMode: coordinates
     xColumn: longitude
     yColumn: latitude
     zColumn: elevation  # optional
@@ -68,15 +66,20 @@ with:
 - `dataset`: Path to CSV file (can use expressions)
 - `inline`: Inline CSV content (alternative to `dataset`)
 - `offset`: Number of rows to skip before header (default: 0)
+- `headerRows`: Number of consecutive rows making up the header (default: 1). `0` auto-generates `column1`, `column2`, …; values above 1 join each row's values with `_`
+- `encoding`: Character encoding of the input file, such as `Shift-JIS` (default: UTF-8)
 
 ### Geometry Configuration
 
 The `geometry` parameter is optional. If omitted, no geometry parsing is performed.
 
+The mode is inferred from which columns you supply: `column` reads WKT, `xColumn` and `yColumn` read separate coordinate columns.
+
+A geometry cell that is empty, whitespace-only, or absent because the row is short yields no geometry and the feature is still emitted. A cell with content in it that will not parse fails the read, naming the column, the value and the row number.
+
 #### WKT Mode
 ```yaml
 geometry:
-  geometryMode: wkt
   column: <column_name>    # Name of column containing WKT
   epsg: <epsg_code>        # Optional: CRS code (e.g., 4326 for WGS84)
 ```
@@ -84,7 +87,6 @@ geometry:
 #### Coordinates Mode
 ```yaml
 geometry:
-  geometryMode: coordinates
   xColumn: <column_name>   # X coordinate (longitude)
   yColumn: <column_name>   # Y coordinate (latitude)
   zColumn: <column_name>   # Optional: Z coordinate (elevation)
@@ -107,7 +109,7 @@ cargo run --package reearth-flow-cli -- run --workflow ./coordinates-example.yml
 ## Output
 
 All examples output features that can be:
-- Written to GeoJSON with `GeoJsonWriter`
+- Written to GeoJSON with `GeoJSON Writer`
 - Written back to CSV with `Feature Writer`
 - Processed with other Flow actions (filters, transformers, etc.)
 
@@ -117,4 +119,4 @@ Features will have:
 - `geometry.epsg`: EPSG code if specified
 - `geometry.value`: Parsed geometry (if geometry config provided)
 
-**Note**: When geometry parsing is enabled, the columns used for geometry (WKT column, or X/Y/Z columns) are automatically excluded from the feature attributes to avoid redundancy. This follows GIS industry standards (similar to QGIS, PostGIS, ArcGIS).
+**Note**: When geometry parsing is enabled, the columns used for geometry (WKT column, or X/Y/Z columns) are automatically excluded from the feature attributes to avoid redundancy. This follows the convention used by PostGIS and GDAL/OGR.

--- a/engine/runtime/examples/fixture/workflow/examples/csv-reader/README.md
+++ b/engine/runtime/examples/fixture/workflow/examples/csv-reader/README.md
@@ -64,10 +64,12 @@ with:
 
 - `format`: `csv` or `tsv` (tab-separated values)
 - `dataset`: Path to CSV file (can use expressions)
-- `inline`: Inline CSV content (alternative to `dataset`)
+- `inline`: Inline CSV content, as an alternative to `dataset`
 - `offset`: Number of rows to skip before header (default: 0)
 - `headerRows`: Number of consecutive rows making up the header (default: 1). `0` auto-generates `column1`, `column2`, …; values above 1 join each row's values with `_`
 - `encoding`: Character encoding of the input file, such as `Shift-JIS` (default: UTF-8)
+
+Supply exactly one of `dataset` or `inline`. Omitting both fails at run time with "Missing required parameter `dataset` or `inline`"; supplying both uses `inline` and ignores `dataset`. The schema marks neither as required, so nothing catches this before the workflow runs.
 
 ### Geometry Configuration
 

--- a/engine/runtime/examples/fixture/workflow/examples/csv-reader/coordinates-example.yml
+++ b/engine/runtime/examples/fixture/workflow/examples/csv-reader/coordinates-example.yml
@@ -18,7 +18,6 @@ graphs:
             type: flowExpr
             value: variables["csvFile"]
           geometry:
-            geometryMode: coordinates
             xColumn: longitude
             yColumn: latitude
             zColumn: elevation

--- a/engine/runtime/examples/fixture/workflow/examples/csv-reader/wkt-example.yml
+++ b/engine/runtime/examples/fixture/workflow/examples/csv-reader/wkt-example.yml
@@ -18,7 +18,6 @@ graphs:
             type: flowExpr
             value: variables["csvFile"]
           geometry:
-            geometryMode: wkt
             column: geometry
             epsg: 4326
 

--- a/engine/runtime/examples/fixture/workflow/examples/csv-writer/README.md
+++ b/engine/runtime/examples/fixture/workflow/examples/csv-writer/README.md
@@ -1,6 +1,6 @@
 # CSV Writer Examples
 
-This directory contains example workflows demonstrating how to use the CsvWriter action with geometry export support.
+This directory contains example workflows demonstrating how to use the CSV Writer action with geometry export support.
 
 ## Examples
 
@@ -18,12 +18,11 @@ id,name,population,geometry
 
 **Configuration:**
 ```yaml
-action: CsvWriter
+action: CSV Writer
 with:
   format: csv
   output: ./output-roundtrip-wkt.csv
   geometry:
-    geometryMode: wkt
     column: geometry
 ```
 
@@ -56,12 +55,11 @@ id,name,temperature,longitude,latitude,elevation
 
 **Configuration:**
 ```yaml
-action: CsvWriter
+action: CSV Writer
 with:
   format: csv
   output: ./output-roundtrip-coords.csv
   geometry:
-    geometryMode: coordinates
     xColumn: longitude
     yColumn: latitude
     zColumn: elevation  # optional
@@ -90,16 +88,14 @@ The `geometry` parameter is optional. If omitted, no geometry export is performe
 #### WKT Mode
 ```yaml
 geometry:
-  geometryMode: wkt
   column: <column_name>    # Name of column to write WKT
 ```
 
-Works with all geometry types supported by CsvReader.
+Works with all geometry types supported by CSV Reader.
 
 #### Coordinates Mode
 ```yaml
 geometry:
-  geometryMode: coordinates
   xColumn: <column_name>   # X coordinate (longitude)
   yColumn: <column_name>   # Y coordinate (latitude)
   zColumn: <column_name>   # Optional: Z coordinate (elevation)
@@ -134,4 +130,4 @@ Geometry columns are always placed at the END of the CSV (after all attribute co
 
 ## Backward Compatibility
 
-If no `geometry` parameter is provided, CsvWriter behaves exactly as before - geometry data is not exported to the CSV file. This ensures existing workflows continue to work without modification.
+If no `geometry` parameter is provided, CSV Writer behaves exactly as before - geometry data is not exported to the CSV file. This ensures existing workflows continue to work without modification.

--- a/engine/runtime/examples/fixture/workflow/examples/csv-writer/roundtrip-coords.yml
+++ b/engine/runtime/examples/fixture/workflow/examples/csv-writer/roundtrip-coords.yml
@@ -18,7 +18,6 @@ graphs:
             type: flowExpr
             value: variables["inputCsv"]
           geometry:
-            geometryMode: coordinates
             xColumn: longitude
             yColumn: latitude
             zColumn: elevation
@@ -34,7 +33,6 @@ graphs:
             type: string
             value: ./output-roundtrip-coords.csv
           geometry:
-            geometryMode: coordinates
             xColumn: longitude
             yColumn: latitude
             zColumn: elevation

--- a/engine/runtime/examples/fixture/workflow/examples/csv-writer/roundtrip-wkt.yml
+++ b/engine/runtime/examples/fixture/workflow/examples/csv-writer/roundtrip-wkt.yml
@@ -18,7 +18,6 @@ graphs:
             type: flowExpr
             value: variables["inputCsv"]
           geometry:
-            geometryMode: wkt
             column: geometry
             epsg: 4326
 
@@ -32,7 +31,6 @@ graphs:
             type: string
             value: ./output-roundtrip-wkt.csv
           geometry:
-            geometryMode: wkt
             column: geometry
 
     edges:

--- a/engine/runtime/examples/fixture/workflow/executor-testing/csv-wkt-roundtrip-3d.yml
+++ b/engine/runtime/examples/fixture/workflow/executor-testing/csv-wkt-roundtrip-3d.yml
@@ -38,7 +38,6 @@ graphs:
               line3d,"LINESTRING(0 0 0, 1 1 1)"
               polygon3d,"POLYGON((0 0 0, 4 0 0, 4 4 1, 0 0 0))"
           geometry:
-            geometryMode: wkt
             column: geometry
 
       - id: ab7621a5-3dc9-491b-a2bc-07035d30dc9c
@@ -51,7 +50,6 @@ graphs:
             type: string
             value: output.csv
           geometry:
-            geometryMode: wkt
             column: geometry
 
     edges:

--- a/engine/runtime/examples/fixture/workflow/executor-testing/geojson-to-csv-wkt.yml
+++ b/engine/runtime/examples/fixture/workflow/executor-testing/geojson-to-csv-wkt.yml
@@ -47,7 +47,6 @@ graphs:
             type: string
             value: output.csv
           geometry:
-            geometryMode: wkt
             column: geometry
 
     edges:

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -1573,7 +1573,7 @@
       "description": "Reads features from CSV and TSV files.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "CsvReader Parameters",
+        "title": "CSV Reader Parameters",
         "description": "Configure how CSV and TSV files are processed and read",
         "type": "object",
         "required": [
@@ -1669,7 +1669,7 @@
           },
           "geometry": {
             "title": "Geometry Configuration",
-            "description": "Optional configuration for parsing geometry from CSV columns",
+            "description": "Names the columns that hold geometry, either as Well-Known Text or as separate coordinate columns. Those columns are read as the feature's geometry instead of as attributes. Rows become attribute-only features when omitted.",
             "anyOf": [
               {
                 "$ref": "#/definitions/GeometryConfig"
@@ -1754,7 +1754,7 @@
             "properties": {
               "epsg": {
                 "title": "EPSG Code",
-                "description": "Coordinate Reference System code (e.g., 4326 for WGS84)",
+                "description": "Coordinate reference system of the values in the file, such as 4326 for WGS 84. When the referenced system declares latitude first, the two horizontal ordinates are stored in that order; elevation is never reordered. Values are read as plain coordinates when omitted.",
                 "type": [
                   "integer",
                   "null"

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -1570,10 +1570,10 @@
     {
       "name": "CSV Reader",
       "type": "source",
-      "description": "Lee características de un archivo CSV",
+      "description": "Lee entidades de archivos CSV y TSV",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "CsvReader Parameters",
+        "title": "CSV Reader Parameters",
         "description": "Configure how CSV and TSV files are processed and read",
         "type": "object",
         "required": [
@@ -1669,7 +1669,7 @@
           },
           "geometry": {
             "title": "Geometry Configuration",
-            "description": "Optional configuration for parsing geometry from CSV columns",
+            "description": "Names the columns that hold geometry, either as Well-Known Text or as separate coordinate columns. Those columns are read as the feature's geometry instead of as attributes. Rows become attribute-only features when omitted.",
             "anyOf": [
               {
                 "$ref": "#/definitions/GeometryConfig"
@@ -1754,7 +1754,7 @@
             "properties": {
               "epsg": {
                 "title": "EPSG Code",
-                "description": "Coordinate Reference System code (e.g., 4326 for WGS84)",
+                "description": "Coordinate reference system of the values in the file, such as 4326 for WGS 84. When the referenced system declares latitude first, the two horizontal ordinates are stored in that order; elevation is never reordered. Values are read as plain coordinates when omitted.",
                 "type": [
                   "integer",
                   "null"

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -1570,10 +1570,10 @@
     {
       "name": "CSV Reader",
       "type": "source",
-      "description": "Read Features from CSV or TSV File",
+      "description": "Lit des entités depuis des fichiers CSV et TSV",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "CsvReader Parameters",
+        "title": "CSV Reader Parameters",
         "description": "Configure how CSV and TSV files are processed and read",
         "type": "object",
         "required": [
@@ -1669,7 +1669,7 @@
           },
           "geometry": {
             "title": "Geometry Configuration",
-            "description": "Optional configuration for parsing geometry from CSV columns",
+            "description": "Names the columns that hold geometry, either as Well-Known Text or as separate coordinate columns. Those columns are read as the feature's geometry instead of as attributes. Rows become attribute-only features when omitted.",
             "anyOf": [
               {
                 "$ref": "#/definitions/GeometryConfig"
@@ -1754,7 +1754,7 @@
             "properties": {
               "epsg": {
                 "title": "EPSG Code",
-                "description": "Coordinate Reference System code (e.g., 4326 for WGS84)",
+                "description": "Coordinate reference system of the values in the file, such as 4326 for WGS 84. When the referenced system declares latitude first, the two horizontal ordinates are stored in that order; elevation is never reordered. Values are read as plain coordinates when omitted.",
                 "type": [
                   "integer",
                   "null"

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -1573,7 +1573,7 @@
       "description": "CSV および TSV ファイルから地物を読み取る",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "CsvReader パラメータ",
+        "title": "CSV Reader パラメータ",
         "description": "CSV / TSV ファイルの処理方法を設定する",
         "type": "object",
         "required": [
@@ -1669,7 +1669,7 @@
           },
           "geometry": {
             "title": "ジオメトリ設定",
-            "description": "CSV 列からジオメトリを解析するための設定（任意）",
+            "description": "ジオメトリを保持する列を指定する。Well-Known Text の単一列か、座標を分けた複数の列を指定できる。指定した列は属性ではなく地物のジオメトリとして読み取られる。省略時は各行が属性のみの地物になる",
             "anyOf": [
               {
                 "$ref": "#/definitions/GeometryConfig"
@@ -1754,7 +1754,7 @@
             "properties": {
               "epsg": {
                 "title": "EPSG コード",
-                "description": "座標参照系コード（例: WGS84 の場合は 4326）",
+                "description": "ファイル内の値が従う座標参照系。たとえば WGS 84 は 4326。参照先が緯度を先に定義する場合、水平方向の2つの座標値はその順序で格納され、標高の順序は変わらない。省略時は通常の座標として読み取る",
                 "type": [
                   "integer",
                   "null"

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -1570,10 +1570,10 @@
     {
       "name": "CSV Reader",
       "type": "source",
-      "description": "从CSV文件读取要素",
+      "description": "从CSV和TSV文件读取要素",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "CsvReader Parameters",
+        "title": "CSV Reader Parameters",
         "description": "Configure how CSV and TSV files are processed and read",
         "type": "object",
         "required": [
@@ -1669,7 +1669,7 @@
           },
           "geometry": {
             "title": "Geometry Configuration",
-            "description": "Optional configuration for parsing geometry from CSV columns",
+            "description": "Names the columns that hold geometry, either as Well-Known Text or as separate coordinate columns. Those columns are read as the feature's geometry instead of as attributes. Rows become attribute-only features when omitted.",
             "anyOf": [
               {
                 "$ref": "#/definitions/GeometryConfig"
@@ -1754,7 +1754,7 @@
             "properties": {
               "epsg": {
                 "title": "EPSG Code",
-                "description": "Coordinate Reference System code (e.g., 4326 for WGS84)",
+                "description": "Coordinate reference system of the values in the file, such as 4326 for WGS 84. When the referenced system declares latitude first, the two horizontal ordinates are stored in that order; elevation is never reordered. Values are read as plain coordinates when omitted.",
                 "type": [
                   "integer",
                   "null"

--- a/engine/schema/i18n/actions/es.json
+++ b/engine/schema/i18n/actions/es.json
@@ -588,10 +588,10 @@
     },
     {
       "name": "CSV Reader",
-      "description": "Lee características de un archivo CSV",
+      "description": "Lee entidades de archivos CSV y TSV",
       "parameterI18n": {
         "": {
-          "title": "CsvReader Parameters",
+          "title": "CSV Reader Parameters",
           "description": "Configure how CSV and TSV files are processed and read"
         },
         "dataset": {
@@ -608,7 +608,7 @@
         },
         "geometry": {
           "title": "Geometry Configuration",
-          "description": "Optional configuration for parsing geometry from CSV columns"
+          "description": "Names the columns that hold geometry, either as Well-Known Text or as separate coordinate columns. Those columns are read as the feature's geometry instead of as attributes. Rows become attribute-only features when omitted."
         },
         "headerRows": {
           "title": "Header Row Count",
@@ -627,7 +627,7 @@
         "GeometryConfig": {
           "epsg": {
             "title": "EPSG Code",
-            "description": "Coordinate Reference System code (e.g., 4326 for WGS84)"
+            "description": "Coordinate reference system of the values in the file, such as 4326 for WGS 84. When the referenced system declares latitude first, the two horizontal ordinates are stored in that order; elevation is never reordered. Values are read as plain coordinates when omitted."
           }
         }
       },

--- a/engine/schema/i18n/actions/fr.json
+++ b/engine/schema/i18n/actions/fr.json
@@ -588,10 +588,10 @@
     },
     {
       "name": "CSV Reader",
-      "description": "Read Features from CSV or TSV File",
+      "description": "Lit des entités depuis des fichiers CSV et TSV",
       "parameterI18n": {
         "": {
-          "title": "CsvReader Parameters",
+          "title": "CSV Reader Parameters",
           "description": "Configure how CSV and TSV files are processed and read"
         },
         "dataset": {
@@ -608,7 +608,7 @@
         },
         "geometry": {
           "title": "Geometry Configuration",
-          "description": "Optional configuration for parsing geometry from CSV columns"
+          "description": "Names the columns that hold geometry, either as Well-Known Text or as separate coordinate columns. Those columns are read as the feature's geometry instead of as attributes. Rows become attribute-only features when omitted."
         },
         "headerRows": {
           "title": "Header Row Count",
@@ -627,7 +627,7 @@
         "GeometryConfig": {
           "epsg": {
             "title": "EPSG Code",
-            "description": "Coordinate Reference System code (e.g., 4326 for WGS84)"
+            "description": "Coordinate reference system of the values in the file, such as 4326 for WGS 84. When the referenced system declares latitude first, the two horizontal ordinates are stored in that order; elevation is never reordered. Values are read as plain coordinates when omitted."
           }
         }
       },

--- a/engine/schema/i18n/actions/ja.json
+++ b/engine/schema/i18n/actions/ja.json
@@ -591,7 +591,7 @@
       "description": "CSV および TSV ファイルから地物を読み取る",
       "parameterI18n": {
         "": {
-          "title": "CsvReader パラメータ",
+          "title": "CSV Reader パラメータ",
           "description": "CSV / TSV ファイルの処理方法を設定する"
         },
         "dataset": {
@@ -608,7 +608,7 @@
         },
         "geometry": {
           "title": "ジオメトリ設定",
-          "description": "CSV 列からジオメトリを解析するための設定（任意）"
+          "description": "ジオメトリを保持する列を指定する。Well-Known Text の単一列か、座標を分けた複数の列を指定できる。指定した列は属性ではなく地物のジオメトリとして読み取られる。省略時は各行が属性のみの地物になる"
         },
         "headerRows": {
           "title": "ヘッダー行数",
@@ -627,7 +627,7 @@
         "GeometryConfig": {
           "epsg": {
             "title": "EPSG コード",
-            "description": "座標参照系コード（例: WGS84 の場合は 4326）"
+            "description": "ファイル内の値が従う座標参照系。たとえば WGS 84 は 4326。参照先が緯度を先に定義する場合、水平方向の2つの座標値はその順序で格納され、標高の順序は変わらない。省略時は通常の座標として読み取る"
           }
         }
       },

--- a/engine/schema/i18n/actions/zh.json
+++ b/engine/schema/i18n/actions/zh.json
@@ -588,10 +588,10 @@
     },
     {
       "name": "CSV Reader",
-      "description": "从CSV文件读取要素",
+      "description": "从CSV和TSV文件读取要素",
       "parameterI18n": {
         "": {
-          "title": "CsvReader Parameters",
+          "title": "CSV Reader Parameters",
           "description": "Configure how CSV and TSV files are processed and read"
         },
         "dataset": {
@@ -608,7 +608,7 @@
         },
         "geometry": {
           "title": "Geometry Configuration",
-          "description": "Optional configuration for parsing geometry from CSV columns"
+          "description": "Names the columns that hold geometry, either as Well-Known Text or as separate coordinate columns. Those columns are read as the feature's geometry instead of as attributes. Rows become attribute-only features when omitted."
         },
         "headerRows": {
           "title": "Header Row Count",
@@ -627,7 +627,7 @@
         "GeometryConfig": {
           "epsg": {
             "title": "EPSG Code",
-            "description": "Coordinate Reference System code (e.g., 4326 for WGS84)"
+            "description": "Coordinate reference system of the values in the file, such as 4326 for WGS 84. When the referenced system declares latitude first, the two horizontal ordinates are stored in that order; elevation is never reordered. Values are read as plain coordinates when omitted."
           }
         }
       },

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.157"
+version = "0.2.158"
 edition = "2021"
 
 [features]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.156"
+version = "0.2.157"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.346"
+version = "0.1.347"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.347"
+version = "0.1.348"
 edition = "2021"
 
 [features]

--- a/server/api/internal/app/base_actions.go
+++ b/server/api/internal/app/base_actions.go
@@ -30,6 +30,7 @@ package app
 //     attribute flattening; it needs a decision on scope before it is offered.
 var baseActions = map[string]bool{
 	// Input
+	"CSV Reader":          true,
 	"Feature Creator":     true,
 	"File Path Extractor": true,
 	"GeoJSON Reader":      true,


### PR DESCRIPTION
Audits `CSV Reader` against the action standard and adds it to the base palette.

Its new-geometry port (#2405) left it running but unexposed. It had been reviewed once, in the Input batch (#2280), so §7.2 would ordinarily hand it a decision rather than an audit. That review merged 2026-07-23 — earlier than every Changelog entry in the standard except the one it introduced itself. §7 did not exist, §8 had no `impl:` line, and §4.3 and §6 have both been *corrected* since. It was audited in full.

## Action changes

- **`geometry` and `epsg` descriptions** now state what the code does. `epsg` documents the ordinate order a latitude-first CRS imposes, which applies to coordinate columns as well as WKT.
- **Parameter block title** `CsvReader Parameters` → `CSV Reader Parameters`, in the schema and in all four i18n files — `parameterI18n[""].title` overrides the schema, so both are required for the rename to take effect.
- **i18n corrections**: the `es` and `zh` descriptions claimed CSV only, where the action reads CSV and TSV; `fr` was an untranslated English placeholder carrying a pre-#2240 action name.
- **Exposed** in `base_actions.go`.

## `geometryMode` removed from fixtures and docs

`geometryMode` was a serde discriminator until #1655 made `GeometryMode` untagged; nothing has read it since. It remained in 6 workflow fixtures (9 nodes) and in both example READMEs (8 occurrences), where it taught a parameter that does nothing. Removed. Mode selection is by which columns are supplied, and that is now documented.

## Example READMEs repaired

Both used pre-#2240 action names (`CsvReader`, `CsvWriter`, `GeoJsonWriter`), so every YAML snippet in them fails with "Action not found". The reader's parameter list was also missing `headerRows` and `encoding`. Fixed, with mode inference and parse-failure behaviour documented and a vendor name §2 prohibits removed.

## Standard: §4.3 gains a source carve-out

#2405 removed a `rejected` port and made unparseable input fail the read, while §4.3's table routed malformed input to `rejected`. The code is right and the rule was incomplete: a source receives no features, so there is no incoming feature for a rejection to attach to, and a reader that emits part of a file while dropping the rest hides corrupt input where the user can still fix it. §4.3 now says so, with the absence-versus-malformed distinction preserved. The pre-#2405 port was advertised and never emitted to, which was its own §4.3 defect.

## Filed, not fixed

- `CSV Reader` is already listed in the schemars-flatten ordering finding; it wants the shared fix across all nine readers, not a local one.
- `dataset` and `inline` are both schema-optional while omitting both fails at runtime, against §3.2. Shared by all nine readers.
- 49 other actions carry a parameter-block title that is an internal PascalCase struct name.

## Verification

| Check | Result |
|---|---|
| `format` / `clippy` workspace / `clippy -p` legacy | clean, 0 warnings |
| `test-rs` | 4113 passed / 0 failed |
| `test-qc` | 49 passed / 0 failed / 143 ignored |
| `workflow-tests` (new-geometry) | 49 passed / 0 failed |
| `check-schema` | clean |
| `go test ./internal/app/` | ok |

`workflow-tests` in the **legacy** world reports 42 failures both on this branch and on `origin/main` (`7e6efdec8`), with identical failing test names. That suite is not run by CI and defaults to the legacy build. One of those failures, `test_executor_csv_wkt_roundtrip_3d`, belongs to CSV Reader and passes under `--features new-geometry`: `parse_geometry` is cfg-swapped and only the new-geometry arm accepts the bare 3D WKT the CSV Writer emits.