### PR TITLE
fix(engine): batch source-intermediate appends instead of one write per feature

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "Inflector",
  "approx",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5024,7 +5024,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "bytes",
  "clap",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-diagnostics"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5163,7 +5163,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5180,7 +5180,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "approx",
  "bvh",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5256,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5265,7 +5265,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5297,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5351,7 +5351,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5365,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "bytes",
  "futures",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "bytes",
  "futures",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5415,7 +5415,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5453,7 +5453,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "ahash",
  "bytes",
@@ -5489,7 +5489,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.536"
+version = "0.0.537"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.536"
+version = "0.0.537"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/runtime/src/executor/processor_node.rs
+++ b/engine/runtime/runtime/src/executor/processor_node.rs
@@ -523,6 +523,11 @@ impl<F: Future + Unpin + Debug> ReceiverLoop for ProcessorNode<F> {
     }
 
     fn on_terminate(&mut self, ctx: NodeContext) -> Result<(), ExecutionError> {
+        self.source_intermediate_recorder.flush(
+            &self.feature_state,
+            &self.node_name,
+            self.node_handle.id.as_ref(),
+        );
         let channel_manager = Arc::clone(&self.channel_manager);
         let channel_manager_guard = channel_manager.read();
         let processor = Arc::clone(&self.processor);

--- a/engine/runtime/runtime/src/executor/sink_node.rs
+++ b/engine/runtime/runtime/src/executor/sink_node.rs
@@ -225,6 +225,11 @@ impl<F: Future + Unpin + Debug> ReceiverLoop for SinkNode<F> {
                     // Upstream dropped its sender without a Terminate (e.g. it
                     // failed) — on_terminate() below is never reached, so flush
                     // accumulated summaries and reject rows here or they're lost.
+                    self.source_intermediate_recorder.flush(
+                        &self.feature_state,
+                        &self.node_name,
+                        self.node_handle.id.as_ref(),
+                    );
                     let summaries =
                         crate::diagnostics::emit_summaries(&self.event_hub, &self.diagnostics);
                     *self.summaries_sink.lock() = summaries;
@@ -342,6 +347,11 @@ impl<F: Future + Unpin + Debug> ReceiverLoop for SinkNode<F> {
                     is_terminated[index] = true;
                     sel.remove(index);
                     if is_terminated.iter().all(|value| *value) {
+                        self.source_intermediate_recorder.flush(
+                            &self.feature_state,
+                            &self.node_name,
+                            self.node_handle.id.as_ref(),
+                        );
                         let features_count = self
                             .features_written
                             .load(std::sync::atomic::Ordering::Relaxed);

--- a/engine/runtime/runtime/src/executor/source_intermediate.rs
+++ b/engine/runtime/runtime/src/executor/source_intermediate.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use parking_lot::Mutex;
 use petgraph::{graph::NodeIndex, visit::EdgeRef, Direction};
 use reearth_flow_state::State;
 
@@ -10,12 +11,19 @@ use crate::{
 
 use super::execution_dag::ExecutionDag;
 
+/// One flush = one storage append (open/write/close), which costs milliseconds
+/// on remote-backed filesystems — per-feature appends made large runs I/O-bound
+/// (~24ms per feature on Cloud Run). Matches the feature store's granularity.
+const FLUSH_LINES: usize = 512;
+
 #[derive(Debug)]
 pub struct SourceIntermediateRecorder {
     /// Track incoming edge IDs for source intermediate data
     incoming_edge_ids: Vec<EdgeId>,
     /// Track which upstream nodes are sources
     incoming_is_source: Vec<bool>,
+    /// Buffered JSONL lines per edge file, flushed at FLUSH_LINES and on flush().
+    buffers: Mutex<HashMap<String, Vec<String>>>,
 }
 
 impl SourceIntermediateRecorder {
@@ -49,6 +57,7 @@ impl SourceIntermediateRecorder {
         Self {
             incoming_edge_ids,
             incoming_is_source,
+            buffers: Mutex::new(HashMap::new()),
         }
     }
 
@@ -83,21 +92,74 @@ impl SourceIntermediateRecorder {
             }
         };
 
-        if let Err(e) = feature_state.append_sync(&ctx.feature, &file_id) {
+        let line = match feature_state.to_jsonl_line(&ctx.feature) {
+            Ok(line) => line,
+            Err(e) => {
+                tracing::warn!(
+                    "source-intermediate-serialize failed: node={}({}) edge_id={} feature_id={} err={:?}",
+                    node_name,
+                    node_id,
+                    file_id,
+                    ctx.feature.id,
+                    e,
+                );
+                return;
+            }
+        };
+
+        let full = {
+            let mut buffers = self.buffers.lock();
+            let buf = buffers.entry(file_id.clone()).or_default();
+            buf.push(line);
+            if buf.len() >= FLUSH_LINES {
+                Some(std::mem::take(buf))
+            } else {
+                None
+            }
+        };
+        if let Some(lines) = full {
+            self.write_lines(feature_state, &file_id, lines, node_name, node_id);
+        }
+    }
+
+    /// Drains every buffered edge file. Call at node terminate; a node that
+    /// dies without terminating loses its tail, the same trade the feature
+    /// store makes for batched writes.
+    pub fn flush(&self, feature_state: &State, node_name: &str, node_id: &str) {
+        let drained: Vec<(String, Vec<String>)> = self.buffers.lock().drain().collect();
+        for (file_id, lines) in drained {
+            self.write_lines(feature_state, &file_id, lines, node_name, node_id);
+        }
+    }
+
+    fn write_lines(
+        &self,
+        feature_state: &State,
+        file_id: &str,
+        lines: Vec<String>,
+        node_name: &str,
+        node_id: &str,
+    ) {
+        if lines.is_empty() {
+            return;
+        }
+        let count = lines.len();
+        if let Err(e) = feature_state.append_jsonl_lines_sync(&lines.concat(), file_id) {
             tracing::warn!(
-                "source-intermediate-append failed: node={}({}) edge_id={} err={:?}",
+                "source-intermediate-append failed: node={}({}) edge_id={} lines={} err={:?}",
                 node_name,
                 node_id,
                 file_id,
+                count,
                 e,
             );
         } else {
             tracing::debug!(
-                "source-intermediate-append OK: node={}({}) edge_id={} feature_id={}",
+                "source-intermediate-append OK: node={}({}) edge_id={} lines={}",
                 node_name,
                 node_id,
                 file_id,
-                ctx.feature.id,
+                count,
             );
         }
     }

--- a/engine/runtime/state/src/lib.rs
+++ b/engine/runtime/state/src/lib.rs
@@ -114,6 +114,28 @@ impl State {
             .map_err(Error::other)
     }
 
+    /// Serializes one object as a JSONL line, trailing newline included.
+    pub fn to_jsonl_line<T>(&self, obj: &T) -> Result<String>
+    where
+        for<'de> T: Serialize + Deserialize<'de>,
+    {
+        Ok(self.object_to_string(obj)? + "\n")
+    }
+
+    /// Appends pre-serialized JSONL lines in one storage write. `append_sync`
+    /// pays a full open/write/close per call — milliseconds on remote-backed
+    /// filesystems — so per-feature writers batch lines and flush through this.
+    pub fn append_jsonl_lines_sync(&self, lines: &str, id: &str) -> Result<()> {
+        if lines.is_empty() {
+            return Ok(());
+        }
+        let content = self.encode(lines.as_bytes())?;
+        let p = self.id_to_location(id, self.jsonl_ext());
+        self.storage
+            .append_sync(p.as_path(), content)
+            .map_err(Error::other)
+    }
+
     pub async fn get<T>(&self, id: &str) -> Result<T>
     where
         for<'de> T: Deserialize<'de>,
@@ -754,6 +776,29 @@ mod tests {
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
     struct Data {
         x: i32,
+    }
+
+    #[tokio::test]
+    async fn batched_jsonl_append_round_trips_like_per_object_appends() {
+        let temp_dir = Builder::new().prefix("batched_append_").tempdir().unwrap();
+        let root = format!("file://{}", temp_dir.path().to_str().unwrap());
+        let storage_resolver = Arc::new(StorageResolver::new());
+        let state = State::new(&Uri::for_test(&root), &storage_resolver).unwrap();
+
+        let lines: String = (0..3)
+            .map(|x| state.to_jsonl_line(&Data { x }).unwrap())
+            .collect();
+        state.append_jsonl_lines_sync(&lines, "edge-1").unwrap();
+        state.append_jsonl_lines_sync("", "edge-1").unwrap();
+        state
+            .append_jsonl_lines_sync(&state.to_jsonl_line(&Data { x: 3 }).unwrap(), "edge-1")
+            .unwrap();
+
+        let all = state.read_jsonl_auto_sync::<Data>("edge-1").unwrap();
+        assert_eq!(
+            all,
+            vec![Data { x: 0 }, Data { x: 1 }, Data { x: 2 }, Data { x: 3 }]
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Overview

The "30k features: 2.5min locally, 15min in prod" slowdown, root-caused end to end:

1. Profiled prod job `722d8edc` (15m54s): one unbroken **919-second silent gap** at **2% CPU** — waiting, not computing.
2. Ruled out with production evidence: the node-status publish flood (removed in #2440; runtime unchanged), CPU capacity, input download (13MB in 1.2s), Cloud Run throttling (connected run had the same profile).
3. Reproduced locally (same workflow + data): 146s wall, **31s CPU**. A debug-level run attributed **142 of 146 seconds** to `source-intermediate-append` — one per feature.

`SourceIntermediateRecorder` (Dec 2025, powers incremental runs) calls `State::append_sync` **per feature**: each call is a full open → write-one-JSON-line → close through opendal's blocking bridge, plus a per-line zstd frame when compression is on. ~3.7ms/feature locally, ~24ms/feature on Cloud Run × 38k source-edge features. Longstanding, not a recent regression.

## What's changed

- The recorder buffers JSONL lines per edge file and flushes every **512 lines as one storage append** — the feature store's granularity. New `State::to_jsonl_line` / `append_jsonl_lines_sync` carry the batch.
- Flush hooks: processor `on_terminate`, sink all-inputs-terminated, and the sink's upstream-died path (where summaries already flush). A node that dies without terminating loses its buffered tail — the same trade the feature store already makes.
- Batched flushes emit fewer zstd frames; the decoder already concatenates frames, and uncompressed bytes are identical, so readers are unaffected.

## Measured result

Same workflow, same data, same machine:

| | before | after |
|---|---|---|
| wall clock | 145.9s | **3.8s** |
| CPU (user) | 13.7s | 3.3s (now compute-bound) |

Prod projection: the per-append cost is ~6× worse there, so the 15.5-minute job should land well under a minute.

## Verification

- New round-trip test: batched + empty + single-line appends read back identically via `read_jsonl_auto_sync`
- `cargo fmt` / `clippy` clean; full state + runtime suites pass; engine 0.0.536 → 0.0.537