### PR TITLE
fix(engine): citygml parser axis order

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.160"
+version = "0.2.161"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "Inflector",
  "approx",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5024,7 +5024,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "bytes",
  "clap",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-diagnostics"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5163,7 +5163,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5180,7 +5180,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "approx",
  "bvh",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5256,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5265,7 +5265,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5297,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5351,7 +5351,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5365,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "bytes",
  "futures",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "bytes",
  "futures",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5415,7 +5415,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5453,7 +5453,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "ahash",
  "bytes",
@@ -5489,7 +5489,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.537"
+version = "0.0.538"
 dependencies = [
  "async-trait",
  "axum",
@@ -8257,7 +8257,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.350"
+version = "0.1.351"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.537"
+version = "0.0.538"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/action-processor/src/citygml_parser/GEOMETRY_MAPPING.md
+++ b/engine/runtime/action-processor/src/citygml_parser/GEOMETRY_MAPPING.md
@@ -273,13 +273,6 @@ The `faces → Polygon` edge is conceptual: a `PolygonMesh` face has the same ri
 structure as a `Polygon` but is stored in the mesh's shared CSR buffers, not as
 separate `Polygon` values.
 
-## Coordinate order
-
-GML `posList` / `pos` for the geographic CRSs used by CityGML are in
-latitude, longitude, height order. The reader stores coordinates in `x, y, z`
-order, so the leading latitude/longitude pair is swapped to `x = longitude`,
-`y = latitude`. Reprojection to other CRSs happens in later workflow steps.
-
 ## Note on representation
 
 Abstract substitution-group hubs are not drawn: aggregate members are almost

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.160"
+version = "0.2.161"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.350"
+version = "0.1.351"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
# What I have done
This PR removes a stale section in the CityGML reader's mapping doc.
It *removes* the stale section instead of *correcting* it, because the axis-order convention is obvious from the doc inside the `geometry` crate.