### PR TITLE
fix(ui): enhance context menu data handling for selected nodes when selected via cmd/ctrl [FLOW-DEV-246]

### DIFF
--- a/ui/src/features/Canvas/hooks.ts
+++ b/ui/src/features/Canvas/hooks.ts
@@ -121,12 +121,16 @@ export default ({
       if (!position) return;
       const { styles } = position;
 
+      const selectedNodes = nodes.filter((n) => n.selected);
+      const isPartOfSelection =
+        selectedNodes.length > 1 && selectedNodes.some((n) => n.id === node.id);
+
       setContextMenu({
-        data: node,
+        data: isPartOfSelection ? selectedNodes : node,
         styles,
       });
     },
-    [setContextMenu],
+    [nodes, setContextMenu],
   );
 
   const handleSelectionContextMenu = useCallback(


### PR DESCRIPTION
# Overview
This PR updates the Canvas node context-menu handler so that when a user right-clicks a node that is part of a multi-selection (e.g., created via Cmd/Ctrl-click), the context menu receives the full selected-node set rather than just the single clicked node. This aligns the context menu behavior with how selection-based operations are expected to work in the UI workflow builder.
## What I've done
- Detects when the right-clicked node is part of a multi-selection and passes the selected nodes array to the context menu.
- Updates the `handleNodeContextMenu` callback dependencies to include `nodes` so selection state is current.
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
