### PR TITLE
fix(ui): add default batch node constants and integrate into layout logic to ensure parents and children are kept [FLOW-DEV-255]

### DIFF
--- a/ui/src/global-constants.ts
+++ b/ui/src/global-constants.ts
@@ -5,6 +5,9 @@ export const DEFAULT_NODE_SIZE = { width: 150, height: 25 };
 export const DEFAULT_GRID_SIZE = 16.5;
 export const DEFAULT_LAYOUT_X_SPACING = DEFAULT_GRID_SIZE * 5; // 82.5px — 5 grid units
 export const DEFAULT_LAYOUT_Y_SPACING = DEFAULT_GRID_SIZE * 3; // 49.5px — 3 grid units
+// A batch node's inner padding, and the smallest size it can be resized to
+export const DEFAULT_BATCH_PADDING = 8;
+export const DEFAULT_BATCH_MIN_SIZE = { width: 250, height: 150 };
 export const ALLOWED_WORKFLOW_FILE_EXTENSIONS = ".json, .yaml, .yml";
 export const ALLOWED_PROJECT_IMPORT_EXTENSIONS = ".zip";
 export const ALLOWED_ASSET_IMPORT_EXTENSIONS =

--- a/ui/src/lib/reactFlow/nodeTypes/BatchNode/hooks.ts
+++ b/ui/src/lib/reactFlow/nodeTypes/BatchNode/hooks.ts
@@ -1,12 +1,14 @@
 import { useReactFlow } from "@xyflow/react";
 import { useCallback } from "react";
 
+import {
+  DEFAULT_BATCH_MIN_SIZE,
+  DEFAULT_BATCH_PADDING,
+} from "@flow/global-constants";
 import { Node, NodeData } from "@flow/types";
 
 import useBatch from "../../useBatch";
 import { convertHextoRgba } from "../utils";
-
-const minSize = { width: 250, height: 150 };
 
 export default ({ id, data }: { id: string; data: NodeData }) => {
   const { getNodes, updateNode } = useReactFlow<Node>();
@@ -30,9 +32,15 @@ export default ({ id, data }: { id: string; data: NodeData }) => {
     });
 
     return {
-      // Add 8px padding to the maxX and maxY to show that node cannot be resized beyond the placement of child nodes
-      width: Math.max(minSize.width, maxX + 8),
-      height: Math.max(minSize.height, maxY + 8),
+      // Add padding to the maxX and maxY to show that node cannot be resized beyond the placement of child nodes
+      width: Math.max(
+        DEFAULT_BATCH_MIN_SIZE.width,
+        maxX + DEFAULT_BATCH_PADDING,
+      ),
+      height: Math.max(
+        DEFAULT_BATCH_MIN_SIZE.height,
+        maxY + DEFAULT_BATCH_PADDING,
+      ),
     };
   }, [getNodes, id]);
 

--- a/ui/src/utils/autoLayout.ts
+++ b/ui/src/utils/autoLayout.ts
@@ -1,6 +1,8 @@
 import dagre from "@dagrejs/dagre";
 
 import {
+  DEFAULT_BATCH_MIN_SIZE,
+  DEFAULT_BATCH_PADDING,
   DEFAULT_LAYOUT_X_SPACING,
   DEFAULT_LAYOUT_Y_SPACING,
   DEFAULT_NODE_SIZE,
@@ -9,7 +11,68 @@ import { Algorithm, Direction, Edge, Node } from "@flow/types";
 
 export type DagreDirection = "TB" | "LR";
 
-const dagreGraph = new dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}));
+type Size = { width: number; height: number };
+type Position = { x: number; y: number };
+type GraphEdge = { source: string; target: string };
+
+const toPixels = (value: string | number | undefined): number | undefined => {
+  const parsed = typeof value === "string" ? parseFloat(value) : value;
+  return typeof parsed === "number" && Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : undefined;
+};
+
+const getNodeSize = (node: Node): Size => ({
+  width:
+    toPixels(node.style?.width) ??
+    toPixels(node.measured?.width) ??
+    DEFAULT_NODE_SIZE.width,
+  height:
+    toPixels(node.style?.height) ??
+    toPixels(node.measured?.height) ??
+    DEFAULT_NODE_SIZE.height,
+});
+
+const layoutWithDagre = (
+  nodes: Node[],
+  edges: GraphEdge[],
+  sizes: Map<string, Size>,
+  direction: Direction,
+): Map<string, Position> => {
+  const isHorizontal = direction === "Horizontal";
+  const dagreGraph = new dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}));
+
+  // In LR layout: ranksep = gap between columns (x), nodesep = gap between rows (y)
+  // In TB layout: ranksep = gap between rows (y), nodesep = gap between columns (x)
+  dagreGraph.setGraph({
+    rankdir: isHorizontal ? "LR" : "TB",
+    ranksep: isHorizontal ? DEFAULT_LAYOUT_X_SPACING : DEFAULT_LAYOUT_Y_SPACING,
+    nodesep: isHorizontal ? DEFAULT_LAYOUT_Y_SPACING : DEFAULT_LAYOUT_X_SPACING,
+  });
+
+  nodes.forEach((node) => {
+    dagreGraph.setNode(node.id, sizes.get(node.id) ?? DEFAULT_NODE_SIZE);
+  });
+
+  edges.forEach((edge) => {
+    dagreGraph.setEdge(edge.source, edge.target);
+  });
+
+  dagre.layout(dagreGraph);
+
+  const positions = new Map<string, Position>();
+  nodes.forEach((node) => {
+    const nodeWithPosition = dagreGraph.node(node.id);
+    const size = sizes.get(node.id) ?? DEFAULT_NODE_SIZE;
+    // Shift dagre center anchor to React Flow top-left anchor
+    positions.set(node.id, {
+      x: nodeWithPosition.x - size.width / 2,
+      y: nodeWithPosition.y - size.height / 2,
+    });
+  });
+
+  return positions;
+};
 
 export const autoLayout = (
   algorithm: Algorithm = "dagre",
@@ -17,49 +80,110 @@ export const autoLayout = (
   nodes: Node[],
   edges: Edge[],
 ) => {
-  if (algorithm === "dagre") {
-    const isHorizontal = direction === "Horizontal";
-    // In LR layout: ranksep = gap between columns (x), nodesep = gap between rows (y)
-    // In TB layout: ranksep = gap between rows (y), nodesep = gap between columns (x)
-    dagreGraph.setGraph({
-      rankdir: isHorizontal ? "LR" : "TB",
-      ranksep: isHorizontal
-        ? DEFAULT_LAYOUT_X_SPACING
-        : DEFAULT_LAYOUT_Y_SPACING,
-      nodesep: isHorizontal
-        ? DEFAULT_LAYOUT_Y_SPACING
-        : DEFAULT_LAYOUT_X_SPACING,
-    });
+  if (algorithm !== "dagre") return { nodes, edges };
 
-    nodes.forEach((node) => {
-      dagreGraph.setNode(node.id, {
-        width: DEFAULT_NODE_SIZE.width,
-        height: DEFAULT_NODE_SIZE.height,
-      });
-    });
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
 
-    edges.forEach((edge) => {
-      dagreGraph.setEdge(edge.source, edge.target);
-    });
+  const parentIdOf = (node: Node | undefined) =>
+    node?.parentId && nodeById.has(node.parentId) ? node.parentId : undefined;
 
-    dagre.layout(dagreGraph);
+  const childrenByParentId = new Map<string, Node[]>();
+  nodes.forEach((node) => {
+    const parentId = parentIdOf(node);
+    if (!parentId) return;
+    childrenByParentId.set(parentId, [
+      ...(childrenByParentId.get(parentId) ?? []),
+      node,
+    ]);
+  });
 
-    const newNodes: Node[] = nodes.map((node) => {
-      const nodeWithPosition = dagreGraph.node(node.id);
-      const newNode: Node = {
-        ...node,
-        // Shift dagre center anchor to React Flow top-left anchor
-        position: {
-          x: nodeWithPosition.x - DEFAULT_NODE_SIZE.width / 2,
-          y: nodeWithPosition.y - DEFAULT_NODE_SIZE.height / 2,
-        },
+  const sizes = new Map(nodes.map((node) => [node.id, getNodeSize(node)]));
+  const positions = new Map<string, Position>();
+
+  childrenByParentId.forEach((children, parentId) => {
+    const childIds = new Set(children.map((child) => child.id));
+    const innerEdges = edges.filter(
+      (edge) => childIds.has(edge.source) && childIds.has(edge.target),
+    );
+    const childPositions = layoutWithDagre(
+      children,
+      innerEdges,
+      sizes,
+      direction,
+    );
+
+    const minX = Math.min(...[...childPositions.values()].map((p) => p.x));
+    const minY = Math.min(...[...childPositions.values()].map((p) => p.y));
+
+    let contentWidth = 0;
+    let contentHeight = 0;
+
+    children.forEach((child) => {
+      const childPosition = childPositions.get(child.id);
+      if (!childPosition) return;
+      const size = sizes.get(child.id) ?? DEFAULT_NODE_SIZE;
+      const position = {
+        x: childPosition.x - minX + DEFAULT_BATCH_PADDING,
+        y: childPosition.y - minY + DEFAULT_BATCH_PADDING,
       };
-
-      return newNode;
+      positions.set(child.id, position);
+      contentWidth = Math.max(contentWidth, position.x + size.width);
+      contentHeight = Math.max(contentHeight, position.y + size.height);
     });
 
-    return { nodes: newNodes, edges };
-  }
+    sizes.set(parentId, {
+      width: Math.max(
+        DEFAULT_BATCH_MIN_SIZE.width,
+        contentWidth + DEFAULT_BATCH_PADDING,
+      ),
+      height: Math.max(
+        DEFAULT_BATCH_MIN_SIZE.height,
+        contentHeight + DEFAULT_BATCH_PADDING,
+      ),
+    });
+  });
 
-  return { nodes, edges };
+  const rootNodes = nodes.filter((node) => !parentIdOf(node));
+  const rootIds = new Set(rootNodes.map((node) => node.id));
+  const rootIdOf = (nodeId: string) => {
+    let currentId: string | undefined = nodeId;
+    for (let depth = 0; currentId && depth <= nodes.length; depth++) {
+      if (rootIds.has(currentId)) return currentId;
+      currentId = parentIdOf(nodeById.get(currentId));
+    }
+    return undefined;
+  };
+
+  const rootEdges = edges.reduce<GraphEdge[]>((acc, edge) => {
+    const source = rootIdOf(edge.source);
+    const target = rootIdOf(edge.target);
+    if (!source || !target || source === target) return acc;
+    return [...acc, { source, target }];
+  }, []);
+
+  layoutWithDagre(rootNodes, rootEdges, sizes, direction).forEach(
+    (position, nodeId) => positions.set(nodeId, position),
+  );
+
+  const newNodes: Node[] = nodes.map((node) => {
+    const newNode: Node = {
+      ...node,
+      position: positions.get(node.id) ?? node.position,
+    };
+
+    const size = childrenByParentId.has(node.id)
+      ? sizes.get(node.id)
+      : undefined;
+    if (size) {
+      newNode.style = {
+        ...node.style,
+        width: `${size.width}px`,
+        height: `${size.height}px`,
+      };
+    }
+
+    return newNode;
+  });
+
+  return { nodes: newNodes, edges };
 };

--- a/ui/src/utils/autoLayout.ts
+++ b/ui/src/utils/autoLayout.ts
@@ -91,10 +91,12 @@ export const autoLayout = (
   nodes.forEach((node) => {
     const parentId = parentIdOf(node);
     if (!parentId) return;
-    childrenByParentId.set(parentId, [
-      ...(childrenByParentId.get(parentId) ?? []),
-      node,
-    ]);
+    const siblings = childrenByParentId.get(parentId);
+    if (siblings) {
+      siblings.push(node);
+    } else {
+      childrenByParentId.set(parentId, [node]);
+    }
   });
 
   const sizes = new Map(nodes.map((node) => [node.id, getNodeSize(node)]));
@@ -154,12 +156,13 @@ export const autoLayout = (
     return undefined;
   };
 
-  const rootEdges = edges.reduce<GraphEdge[]>((acc, edge) => {
+  const rootEdges: GraphEdge[] = [];
+  edges.forEach((edge) => {
     const source = rootIdOf(edge.source);
     const target = rootIdOf(edge.target);
-    if (!source || !target || source === target) return acc;
-    return [...acc, { source, target }];
-  }, []);
+    if (!source || !target || source === target) return;
+    rootEdges.push({ source, target });
+  });
 
   layoutWithDagre(rootNodes, rootEdges, sizes, direction).forEach(
     (position, nodeId) => positions.set(nodeId, position),


### PR DESCRIPTION
# Overview
Updates the UI’s graph auto-layout to better account for Batch (group) nodes by introducing shared batch sizing constants and using them in both layout and resize-bound calculations, helping keep batch parents sized around their children.
## What I've done
- Added shared batch sizing constants (`DEFAULT_BATCH_PADDING`, `DEFAULT_BATCH_MIN_SIZE`) to centralize batch sizing rules.
- Refactored `autoLayout` (dagre) to compute child layouts inside batch nodes, resize batch nodes based on child bounds, then lay out roots.
- Updated BatchNode resize bounds logic to use the shared constants instead of local hardcoded values.
## What I haven't done
- Notes are still defaulted to the start of the workflow as we do not have anyway currently to tell a note node to have a relationship with another node (there is no link).
## How I tested

## Screenshot

https://github.com/user-attachments/assets/87523b97-18ad-473e-bebb-aa880082bf76
## Which point I want you to review particularly

## Memo
