### PR TITLE
feat(engine): 2D view for intermediate data

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5166,6 +5166,7 @@ name = "reearth-flow-feature-view"
 version = "0.0.548"
 dependencies = [
  "bytes",
+ "prost",
  "reearth-flow-action-sink",
  "reearth-flow-common",
  "reearth-flow-expr",
@@ -5175,6 +5176,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
+ "tinymvt",
  "zstd",
 ]
 

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.170"
+version = "0.2.171"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "approx",
  "async-trait",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "Inflector",
  "approx",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4961,7 +4961,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5012,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "bytes",
  "clap",
@@ -5065,7 +5065,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-diagnostics"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5163,7 +5163,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "bytes",
  "prost",
@@ -5182,7 +5182,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "approx",
  "bvh",
@@ -5223,7 +5223,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5258,7 +5258,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5299,7 +5299,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5367,7 +5367,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "bytes",
  "futures",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "bytes",
  "futures",
@@ -5403,7 +5403,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5417,7 +5417,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5455,7 +5455,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "ahash",
  "bytes",
@@ -5491,7 +5491,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.548"
+version = "0.0.549"
 dependencies = [
  "async-trait",
  "axum",
@@ -8259,7 +8259,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.360"
+version = "0.1.361"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.548"
+version = "0.0.549"
 
 [profile.dev]
 opt-level = 0

--- a/engine/cli/src/view.rs
+++ b/engine/cli/src/view.rs
@@ -15,12 +15,12 @@ use reearth_flow_storage::resolve::StorageResolver;
 /// out of the table for a glb, a filter narrows a whole edge for a tileset.
 pub fn build_view_command() -> Command {
     Command::new("view")
-        .about("Render intermediate data into a viewable 3D form.")
+        .about("Render intermediate data into a viewable form.")
         .long_about(
             "Read the intermediate-data JSONL a run left on an edge and render its features for \
-             a 3D viewer. `gltf` renders one row into a glb, which is what showing a single \
-             feature wants; `3dtiles` renders a whole edge into a tiled tileset for looking at \
-             all of it at once.",
+             a viewer. `gltf` renders one row into a glb, which is what showing a single \
+             feature wants; `tiles` renders a whole edge into a tiled tileset for looking at \
+             all of it at once, as 3D Tiles for 3D geometry and vector tiles for 2D.",
         )
         .subcommand_required(true)
         .arg_required_else_help(true)
@@ -42,8 +42,11 @@ pub fn build_view_command() -> Command {
                 .display_order(1),
         )
         .subcommand(
-            shared_args(Command::new("3dtiles"))
-                .about("Render a whole edge into a tiled 3D Tiles tileset.")
+            shared_args(Command::new("tiles"))
+                .about(
+                    "Render a whole edge into a tiled tileset: 3D Tiles for 3D geometry, \
+                     vector tiles for 2D.",
+                )
                 .arg(
                     Arg::new("filter")
                         .long("filter")
@@ -57,10 +60,45 @@ pub fn build_view_command() -> Command {
                 .arg(
                     Arg::new("target-tile-size")
                         .long("target-tile-size")
-                        .help("Target content size per tile, in bytes.")
+                        .help("3D only. Target content size per tile, in bytes.")
                         .value_parser(clap::value_parser!(u64))
                         .default_value("1048576")
                         .display_order(5),
+                )
+                .arg(
+                    Arg::new("min-zoom")
+                        .long("min-zoom")
+                        .help("2D only. Lowest zoom the tile pyramid is sliced at.")
+                        .value_parser(clap::value_parser!(u8))
+                        .default_value("0")
+                        .display_order(10),
+                )
+                .arg(
+                    Arg::new("max-zoom")
+                        .long("max-zoom")
+                        .help("2D only. Highest zoom the tile pyramid is sliced at, inclusive.")
+                        .value_parser(clap::value_parser!(u8))
+                        .default_value("15")
+                        .display_order(11),
+                )
+                .arg(
+                    Arg::new("extent")
+                        .long("extent")
+                        .help("2D only. Coordinate grid resolution within a tile.")
+                        .value_parser(clap::value_parser!(i32))
+                        .default_value("4096")
+                        .display_order(12),
+                )
+                .arg(
+                    Arg::new("max-tile-bytes")
+                        .long("max-tile-bytes")
+                        .help(
+                            "2D only. Size cap per tile, in bytes. The visually smallest \
+                             features are dropped until a tile fits under it.",
+                        )
+                        .value_parser(clap::value_parser!(u64))
+                        .default_value("500000")
+                        .display_order(13),
                 )
                 .display_order(2),
         )
@@ -91,7 +129,8 @@ fn shared_args(command: Command) -> Command {
                 .long("name")
                 .help(
                     "Base name for the output. A glTF view writes <name>.glb; a tileset writes \
-                     <name>/tileset.json. Defaults to the input file's name.",
+                     <name>/tileset.json for 3D and <name>/tilejson.json for 2D. Defaults to \
+                     the input file's name.",
                 )
                 .display_order(3),
         )
@@ -146,9 +185,15 @@ enum Shape {
     Gltf {
         row: usize,
     },
-    Cesium3DTiles {
+    /// A whole edge, tiled. What it renders into follows the geometry: 3D Tiles
+    /// for 3D, vector tiles for 2D.
+    Tiles {
         filter: Option<String>,
         target_tile_size: u64,
+        min_zoom: u8,
+        max_zoom: u8,
+        extent: i32,
+        max_tile_bytes: u64,
     },
 }
 
@@ -163,11 +208,17 @@ impl ViewCliCommand {
                     .remove_one::<usize>("row")
                     .ok_or(crate::errors::Error::init("No row provided"))?,
             },
-            "3dtiles" => Shape::Cesium3DTiles {
+            "tiles" => Shape::Tiles {
                 filter: matches.remove_one::<String>("filter"),
                 target_tile_size: matches
                     .remove_one::<u64>("target-tile-size")
                     .unwrap_or(1_048_576),
+                min_zoom: matches.remove_one::<u8>("min-zoom").unwrap_or(0),
+                max_zoom: matches.remove_one::<u8>("max-zoom").unwrap_or(15),
+                extent: matches.remove_one::<i32>("extent").unwrap_or(4096),
+                max_tile_bytes: matches
+                    .remove_one::<u64>("max-tile-bytes")
+                    .unwrap_or(500_000),
             },
             other => return Err(crate::errors::Error::unknown_command(other)),
         };
@@ -205,12 +256,27 @@ impl ViewCliCommand {
         let input = Uri::from_str(self.input.as_str()).map_err(crate::errors::Error::init)?;
         let output = Uri::from_str(self.output.as_str()).map_err(crate::errors::Error::init)?;
 
-        let options = ViewOptions {
+        let mut options = ViewOptions {
             draco: self.draco,
             texel_size: self.texel_size,
             texture_codec: self.texture_codec,
             ..ViewOptions::default()
         };
+        if let Shape::Tiles {
+            target_tile_size,
+            min_zoom,
+            max_zoom,
+            extent,
+            max_tile_bytes,
+            ..
+        } = &self.shape
+        {
+            options.target_tile_size = *target_tile_size;
+            options.min_zoom = *min_zoom;
+            options.max_zoom = *max_zoom;
+            options.extent = *extent;
+            options.max_tile_bytes = *max_tile_bytes;
+        }
         let name = self.name(&input)?;
         let destination = Destination {
             root: &output,
@@ -240,10 +306,7 @@ impl ViewCliCommand {
                     }
                 }
             }
-            Shape::Cesium3DTiles {
-                filter,
-                target_tile_size,
-            } => {
+            Shape::Tiles { filter, .. } => {
                 let selection = match filter {
                     Some(expr) => Selection::Filter {
                         expr,
@@ -254,9 +317,8 @@ impl ViewCliCommand {
                 let loaded = load_selected(&input, selection, &storage_resolver)
                     .map_err(crate::errors::Error::run)?;
                 let selected = loaded.selection.len();
-                let view =
-                    render_tileset(&loaded.selection, *target_tile_size, &options, &destination)
-                        .map_err(crate::errors::Error::run)?;
+                let view = render_tileset(&loaded.selection, &options, &destination)
+                    .map_err(crate::errors::Error::run)?;
                 match view.entry_point {
                     Some(entry_point) => println!(
                         "Rendered {} of {selected} selected features ({} scanned) into {} \
@@ -303,11 +365,11 @@ mod tests {
     #[test]
     fn a_shape_takes_only_its_own_selection() {
         assert!(parse(&["gltf", "--row", "1"]).is_ok());
-        assert!(parse(&["3dtiles", "--filter", "true"]).is_ok());
-        assert!(parse(&["3dtiles"]).is_ok(), "a tileset may take every row");
+        assert!(parse(&["tiles", "--filter", "true"]).is_ok());
+        assert!(parse(&["tiles"]).is_ok(), "a tileset may take every row");
 
         assert!(parse(&["gltf", "--filter", "true"]).is_err());
-        assert!(parse(&["3dtiles", "--row", "1"]).is_err());
+        assert!(parse(&["tiles", "--row", "1"]).is_err());
         assert!(parse(&["gltf"]).is_err(), "a glb needs the rows to render");
     }
 

--- a/engine/cli/src/view.rs
+++ b/engine/cli/src/view.rs
@@ -20,7 +20,8 @@ pub fn build_view_command() -> Command {
             "Read the intermediate-data JSONL a run left on an edge and render its features for \
              a viewer. `gltf` renders one row into a glb, which is what showing a single \
              feature wants; `tiles` renders a whole edge into a tiled tileset for looking at \
-             all of it at once, as 3D Tiles for 3D geometry and vector tiles for 2D.",
+             all of it at once, as 3D Tiles once any 3D geometry is present and vector tiles \
+             for an all-2D edge.",
         )
         .subcommand_required(true)
         .arg_required_else_help(true)
@@ -44,8 +45,9 @@ pub fn build_view_command() -> Command {
         .subcommand(
             shared_args(Command::new("tiles"))
                 .about(
-                    "Render a whole edge into a tiled tileset: 3D Tiles for 3D geometry, \
-                     vector tiles for 2D.",
+                    "Render a whole edge into a tiled tileset: 3D Tiles once any 3D geometry \
+                     is present, with 2D geometry lifted to the elevation it lies at; vector \
+                     tiles for an all-2D edge.",
                 )
                 .arg(
                     Arg::new("filter")

--- a/engine/cli/src/view.rs
+++ b/engine/cli/src/view.rs
@@ -299,14 +299,7 @@ impl ViewCliCommand {
                 };
                 let view = render_feature(selected, &options, &destination)
                     .map_err(crate::errors::Error::run)?;
-                match view.entry_point {
-                    Some(entry_point) => {
-                        println!("Rendered row {row} into {}", entry_point.as_str())
-                    }
-                    None => {
-                        println!("Row {row} carried no renderable geometry; nothing was written")
-                    }
-                }
+                println!("Rendered row {row} into {}", view.entry_point.as_str());
             }
             Shape::Tiles { filter, .. } => {
                 let selection = match filter {
@@ -321,21 +314,14 @@ impl ViewCliCommand {
                 let selected = loaded.selection.len();
                 let view = render_tileset(&loaded.selection, &options, &destination)
                     .map_err(crate::errors::Error::run)?;
-                match view.entry_point {
-                    Some(entry_point) => println!(
-                        "Rendered {} of {selected} selected features ({} scanned) into {} \
-                         ({} file(s))",
-                        view.rendered_features,
-                        loaded.scanned,
-                        entry_point.as_str(),
-                        view.written.len()
-                    ),
-                    None => println!(
-                        "None of the {selected} selected features ({} scanned) carried \
-                         renderable geometry; nothing was written",
-                        loaded.scanned
-                    ),
-                }
+                println!(
+                    "Rendered {} of {selected} selected features ({} scanned) into {} \
+                     ({} file(s))",
+                    view.rendered_features,
+                    loaded.scanned,
+                    view.entry_point.as_str(),
+                    view.written.len()
+                );
             }
         }
         Ok(())

--- a/engine/runtime/action-sink/src/file.rs
+++ b/engine/runtime/action-sink/src/file.rs
@@ -8,7 +8,7 @@ pub mod geojson;
 pub(super) mod geopackage;
 pub(super) mod gltf;
 pub(super) mod json;
-pub(super) mod mvt;
+pub mod mvt;
 pub(super) mod obj;
 #[cfg(not(feature = "new-geometry"))]
 pub(super) mod shapefile;

--- a/engine/runtime/action-sink/src/file/mvt/next/extract.rs
+++ b/engine/runtime/action-sink/src/file/mvt/next/extract.rs
@@ -101,17 +101,16 @@ fn collect_2d(g: &Euclidean2DGeometry, cache: &mut ReprojectionCache, out: &mut 
                 collect_2d(member, cache, out);
             }
         }
-        Euclidean2DGeometry::PolygonMesh(mesh) => {
-            let mut faces = Euclidean2DGeometry::PolygonMesh(mesh.clone());
-            let mut emitted = Vec::new();
-            if faces.split(&mut |geom, _attrs| emitted.push(geom)).is_err() {
-                tracing::warn!("MVT Writer: failed to split polygon mesh into faces, skipping");
+        Euclidean2DGeometry::PolygonMesh(_) | Euclidean2DGeometry::TriangularMesh(_) => {
+            let mut mesh = g.clone();
+            let mut faces = Vec::new();
+            if mesh.split(&mut |geom, _attrs| faces.push(geom)).is_err() {
+                tracing::warn!("MVT Writer: failed to split mesh into faces, skipping");
                 return;
             }
-            for face in &emitted {
+            for face in &faces {
                 collect(face, cache, out);
             }
         }
-        other => tracing::warn!("MVT Writer: unsupported 2D geometry, skipping: {other:?}"),
     }
 }

--- a/engine/runtime/action-sink/src/file/mvt/next/mod.rs
+++ b/engine/runtime/action-sink/src/file/mvt/next/mod.rs
@@ -1,3 +1,10 @@
+//! Vector-tile writer for the new geometry type.
+//!
+//! [`build`] is the whole pipeline: geometry is reprojected to WGS84, sliced
+//! into a `min_zoom..=max_zoom` pyramid and encoded one tile at a time. It
+//! takes no executor context, so both the sink and the intermediate-data view
+//! drive it.
+
 mod extract;
 mod slice;
 mod tile;
@@ -13,7 +20,6 @@ use reearth_flow_runtime::node::FEATURES_PORT;
 use reearth_flow_types::{Attribute, Feature};
 
 use super::sink::{MVTWriter, MVTWriterCompiledParam};
-use super::tileid::TileIdMethod;
 use super::tiling::{TileContent, TileMetadata, VectorLayer};
 use extract::extract;
 use slice::{slice_leaves, TileKey, TiledGeom};
@@ -79,17 +85,109 @@ impl MVTWriter {
     }
 }
 
+/// One feature to tile, with the layer it lands in.
+pub struct TileFeature<'a> {
+    pub feature: &'a Feature,
+    pub layer_name: &'a str,
+    /// Vector-tile feature id, repeated in every tile the feature reaches.
+    /// `None` leaves the encoded feature unidentified.
+    pub id: Option<u64>,
+}
+
+/// Knobs shared by every tile of a tileset.
+#[derive(Clone, Copy)]
+pub struct TileOptions<'a> {
+    /// Lowest zoom sliced; must not exceed `max_zoom`.
+    pub min_zoom: u8,
+    /// Highest zoom sliced, inclusive.
+    pub max_zoom: u8,
+    /// Coordinate grid resolution within a tile.
+    pub extent: i32,
+    /// Size cap per tile; the visually smallest features are dropped until a
+    /// tile fits under it.
+    pub max_tile_bytes: u64,
+    /// Joins array and map attribute values into one string tag. `None` leaves
+    /// them out of the tile.
+    pub array_map_separator: Option<&'a str>,
+    /// `name` of the tilejson document.
+    pub name: Option<&'a str>,
+}
+
+/// A tileset's non-tile output. The tiles stream out through [`build`]'s
+/// `write_tile` callback as they are encoded, so only their count is kept here.
+pub struct BuiltTiles {
+    pub tilejson: String,
+    pub tile_count: usize,
+    /// Features that reached at least one tile; the rest are absent from the
+    /// output.
+    pub rendered_features: usize,
+}
+
+/// Slice `features` into a vector tile pyramid, handing each tile to
+/// `write_tile` as `{z}/{x}/{y}.mvt` relative to the tileset root.
+///
+/// Geometry carrying no geographic CRS, and 3D geometry, are skipped with a
+/// warning rather than tiled.
+pub fn build(
+    features: &[TileFeature<'_>],
+    options: TileOptions<'_>,
+    write_tile: impl Fn(String, Vec<u8>) -> crate::errors::Result<()> + Sync,
+) -> crate::errors::Result<BuiltTiles> {
+    let accum = features
+        .par_iter()
+        .fold(SliceAccum::default, |mut acc, input| {
+            acc.layer_names.insert(input.layer_name.to_string());
+            let mut cache = ReprojectionCache::new();
+            let leaves = extract(&input.feature.geometry, &mut cache);
+            let (content, tiled) = slice_leaves(
+                leaves,
+                options.min_zoom,
+                options.max_zoom,
+                options.extent as u32,
+            );
+            acc.content = std::mem::take(&mut acc.content).union(content);
+            acc.rendered_features += !tiled.is_empty() as usize;
+            for tiled_leaf in tiled {
+                let sliced = to_sliced_feature(input, tiled_leaf.geom);
+                acc.by_tile.entry(tiled_leaf.key).or_default().push(sliced);
+            }
+            acc
+        })
+        .reduce(SliceAccum::default, SliceAccum::merge);
+
+    accum
+        .by_tile
+        .par_iter()
+        .try_for_each(|(&(zoom, x, y), feats)| {
+            let bytes = make_tile(
+                options.extent,
+                feats,
+                options.max_tile_bytes,
+                options.array_map_separator,
+            )?;
+            write_tile(format!("{zoom}/{x}/{y}.mvt"), bytes)
+        })?;
+
+    Ok(BuiltTiles {
+        tilejson: tilejson(&options, &accum.content, &accum.layer_names)?,
+        tile_count: accum.by_tile.len(),
+        rendered_features: accum.rendered_features,
+    })
+}
+
 #[derive(Default)]
 struct SliceAccum {
     content: TileContent,
     layer_names: HashSet<String>,
     by_tile: HashMap<TileKey, Vec<SlicedFeature>>,
+    rendered_features: usize,
 }
 
 impl SliceAccum {
     fn merge(mut self, other: Self) -> Self {
         self.content = self.content.union(other.content);
         self.layer_names.extend(other.layer_names);
+        self.rendered_features += other.rendered_features;
         for (key, feats) in other.by_tile {
             self.by_tile.entry(key).or_default().extend(feats);
         }
@@ -104,47 +202,34 @@ fn write_tileset(
     compress_output: Option<&str>,
     params: &MVTWriterCompiledParam,
 ) -> crate::errors::Result<()> {
-    let min_zoom = params.min_zoom;
-    let max_zoom = params.max_zoom;
-    let extent = params.extent;
-    let max_tile_bytes = params.max_tile_bytes;
-    let array_map_separator = params.array_map_separator.as_deref();
-
-    let accum = upstream
-        .par_iter()
-        .fold(SliceAccum::default, |mut acc, (feature, layer_name)| {
-            acc.layer_names.insert(layer_name.clone());
-            let mut cache = ReprojectionCache::new();
-            let leaves = extract(&feature.geometry, &mut cache);
-            let (content, tiled) = slice_leaves(leaves, min_zoom, max_zoom, extent as u32);
-            acc.content = std::mem::take(&mut acc.content).union(content);
-            for tiled_leaf in tiled {
-                let sliced = to_sliced_feature(layer_name, tiled_leaf.geom, feature);
-                acc.by_tile.entry(tiled_leaf.key).or_default().push(sliced);
-            }
-            acc
+    let features: Vec<TileFeature<'_>> = upstream
+        .iter()
+        .map(|(feature, layer_name)| TileFeature {
+            feature,
+            layer_name,
+            id: None,
         })
-        .reduce(SliceAccum::default, SliceAccum::merge);
+        .collect();
 
-    accum.by_tile.par_iter().try_for_each(|(&key, feats)| {
-        write_tile(
-            ctx,
-            output,
-            key,
-            feats,
-            extent,
-            max_tile_bytes,
-            array_map_separator,
-        )
-    })?;
+    let built = build(
+        &features,
+        TileOptions {
+            min_zoom: params.min_zoom,
+            max_zoom: params.max_zoom,
+            extent: params.extent,
+            max_tile_bytes: params.max_tile_bytes,
+            array_map_separator: params.array_map_separator.as_deref(),
+            name: std::path::Path::new(output)
+                .file_name()
+                .and_then(|name| name.to_str()),
+        },
+        |relative_path, bytes| write_output(ctx, &format!("{output}/{relative_path}"), bytes),
+    )?;
 
-    write_tilejson(
+    write_output(
         ctx,
-        output,
-        min_zoom,
-        max_zoom,
-        &accum.content,
-        &accum.layer_names,
+        &format!("{output}/tilejson.json"),
+        built.tilejson.into_bytes(),
     )?;
 
     if let Some(compress_rel) = compress_output {
@@ -153,47 +238,31 @@ fn write_tileset(
     Ok(())
 }
 
-fn to_sliced_feature(layer_name: &str, geom: TiledGeom, feature: &Feature) -> SlicedFeature {
+fn write_output(ctx: &NodeContext, path: &str, bytes: Vec<u8>) -> crate::errors::Result<()> {
+    crate::SinkOutput::new(&ctx.sandbox_root, path, &ctx.storage_resolver)
+        .and_then(|out| out.write(bytes::Bytes::from(bytes)))
+        .map_err(|e| crate::errors::SinkError::MvtWriter(format!("{e:?}")))
+}
+
+fn to_sliced_feature(input: &TileFeature<'_>, geom: TiledGeom) -> SlicedFeature {
     let geom = match geom {
         TiledGeom::Polygon(parts) => SlicedGeom::Polygon(parts),
         TiledGeom::LineString(lines) => SlicedGeom::LineString(lines),
         TiledGeom::Point(points) => SlicedGeom::Point(points),
     };
     SlicedFeature {
-        layer_name: layer_name.to_string(),
+        layer_name: input.layer_name.to_string(),
         geom,
-        properties: feature.attributes.clone(),
+        properties: input.feature.attributes.clone(),
+        id: input.id,
     }
 }
 
-fn write_tile(
-    ctx: &NodeContext,
-    output_rel: &str,
-    (zoom, x, y): TileKey,
-    feats: &[SlicedFeature],
-    extent: i32,
-    max_tile_bytes: u64,
-    array_map_separator: Option<&str>,
-) -> crate::errors::Result<()> {
-    let bytes = make_tile(extent, feats, max_tile_bytes, array_map_separator)?;
-    let tile_rel = format!("{output_rel}/{zoom}/{x}/{y}.mvt");
-    crate::SinkOutput::new(&ctx.sandbox_root, &tile_rel, &ctx.storage_resolver)
-        .and_then(|out| out.write(bytes::Bytes::from(bytes)))
-        .map_err(|e| crate::errors::SinkError::MvtWriter(format!("{e:?}")))
-}
-
-fn write_tilejson(
-    ctx: &NodeContext,
-    output_rel: &str,
-    min_zoom: u8,
-    max_zoom: u8,
+fn tilejson(
+    options: &TileOptions<'_>,
     content: &TileContent,
     layer_names: &HashSet<String>,
-) -> crate::errors::Result<()> {
-    let basename = std::path::Path::new(output_rel)
-        .file_name()
-        .map(|s| s.to_string_lossy().to_string());
-
+) -> crate::errors::Result<String> {
     let tiles = vec!["/{z}/{x}/{y}.mvt".to_string()];
     let vector_layers: Vec<_> = layer_names
         .iter()
@@ -203,19 +272,15 @@ fn write_tilejson(
         })
         .collect();
     let metadata = TileMetadata::from_tile_content(
-        basename,
-        min_zoom,
-        max_zoom,
+        options.name.map(str::to_string),
+        options.min_zoom,
+        options.max_zoom,
         content,
         tiles,
         vector_layers,
     );
 
-    let metadata = serde_json::to_string_pretty(&metadata)
-        .map_err(|e| crate::errors::SinkError::MvtWriter(format!("{e:?}")))?;
-    let tilejson_rel = format!("{output_rel}/tilejson.json");
-    crate::SinkOutput::new(&ctx.sandbox_root, &tilejson_rel, &ctx.storage_resolver)
-        .and_then(|out| out.write(bytes::Bytes::from(metadata)))
+    serde_json::to_string_pretty(&metadata)
         .map_err(|e| crate::errors::SinkError::MvtWriter(format!("{e:?}")))
 }
 

--- a/engine/runtime/action-sink/src/file/mvt/next/mod.rs
+++ b/engine/runtime/action-sink/src/file/mvt/next/mod.rs
@@ -115,6 +115,7 @@ pub struct TileOptions<'a> {
 
 /// A tileset's non-tile output. The tiles stream out through [`build`]'s
 /// `write_tile` callback as they are encoded, so only their count is kept here.
+#[derive(Debug)]
 pub struct BuiltTiles {
     pub tilejson: String,
     pub tile_count: usize,
@@ -127,12 +128,15 @@ pub struct BuiltTiles {
 /// `write_tile` as `{z}/{x}/{y}.mvt` relative to the tileset root.
 ///
 /// Geometry carrying no geographic CRS, and 3D geometry, are skipped with a
-/// warning rather than tiled.
+/// warning rather than tiled. Fails before any tile is written when
+/// `options` describe no pyramid: an inverted zoom range or a non-positive
+/// extent.
 pub fn build(
     features: &[TileFeature<'_>],
     options: TileOptions<'_>,
     write_tile: impl Fn(String, Vec<u8>) -> crate::errors::Result<()> + Sync,
 ) -> crate::errors::Result<BuiltTiles> {
+    validate(&options)?;
     let accum = features
         .par_iter()
         .fold(SliceAccum::default, |mut acc, input| {
@@ -173,6 +177,23 @@ pub fn build(
         tile_count: accum.by_tile.len(),
         rendered_features: accum.rendered_features,
     })
+}
+
+/// Reject options that describe no pyramid.
+fn validate(options: &TileOptions<'_>) -> crate::errors::Result<()> {
+    if options.min_zoom > options.max_zoom {
+        return Err(crate::errors::SinkError::MvtWriter(format!(
+            "minZoom {} exceeds maxZoom {}",
+            options.min_zoom, options.max_zoom
+        )));
+    }
+    if options.extent <= 0 {
+        return Err(crate::errors::SinkError::MvtWriter(format!(
+            "extent must be positive, got {}",
+            options.extent
+        )));
+    }
+    Ok(())
 }
 
 #[derive(Default)]
@@ -311,4 +332,44 @@ fn compress_tileset(
     std::fs::remove_dir_all(abs_path.as_path())
         .map_err(|e| crate::errors::SinkError::MvtWriter(format!("{e:?}")))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    fn options(min_zoom: u8, max_zoom: u8, extent: i32) -> TileOptions<'static> {
+        TileOptions {
+            min_zoom,
+            max_zoom,
+            extent,
+            max_tile_bytes: 500_000,
+            array_map_separator: None,
+            name: None,
+        }
+    }
+
+    /// Options that describe no pyramid are refused up front rather than
+    /// producing an empty one, and nothing is written for them.
+    #[test]
+    fn options_that_describe_no_pyramid_are_refused() {
+        let written = std::sync::atomic::AtomicUsize::new(0);
+        let write = |_path: String, _bytes: Vec<u8>| {
+            written.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Ok(())
+        };
+
+        let inverted = build(&[], options(16, 15, 4096), write).expect_err("min above max");
+        assert!(inverted
+            .to_string()
+            .contains("minZoom 16 exceeds maxZoom 15"));
+
+        let flat = build(&[], options(0, 15, 0), write).expect_err("no extent");
+        assert!(flat.to_string().contains("extent must be positive"));
+
+        build(&[], options(15, 15, 4096), write).expect("a one-level pyramid is a pyramid");
+        assert_eq!(written.load(std::sync::atomic::Ordering::Relaxed), 0);
+    }
 }

--- a/engine/runtime/action-sink/src/file/mvt/next/tile.rs
+++ b/engine/runtime/action-sink/src/file/mvt/next/tile.rs
@@ -22,6 +22,8 @@ pub(super) struct SlicedFeature {
     pub(super) layer_name: String,
     pub(super) geom: SlicedGeom,
     pub(super) properties: Arc<Attributes>,
+    /// Vector-tile feature id, repeated in every tile the feature reaches.
+    pub(super) id: Option<u64>,
 }
 
 #[derive(Default)]
@@ -139,6 +141,7 @@ fn extend_bounds(points: &[[i32; 2]], min: &mut [i32; 2], max: &mut [i32; 2]) {
 // points, which have no meaningful extent and are exempt from subpixel dropping.
 struct Candidate {
     layer_name: String,
+    id: Option<u64>,
     properties: Arc<Attributes>,
     geom_type: vector_tile::tile::GeomType,
     geometry: Vec<u32>,
@@ -192,6 +195,7 @@ fn build_candidate(extent: i32, feature: &SlicedFeature) -> Option<Candidate> {
 
     Some(Candidate {
         layer_name: feature.layer_name.clone(),
+        id: feature.id,
         properties: feature.properties.clone(),
         geom_type,
         geometry,
@@ -217,7 +221,7 @@ fn encode_tile(
             );
         }
         layer.features.push(vector_tile::tile::Feature {
-            id: None,
+            id: candidate.id,
             tags: layer.tags_enc.take_tags(),
             r#type: Some(candidate.geom_type as i32),
             geometry: candidate.geometry.clone(),
@@ -302,6 +306,7 @@ mod tests {
                 holes: vec![],
             }]),
             properties: Arc::new(Attributes::default()),
+            id: None,
         };
         let small_feature = SlicedFeature {
             layer_name: "layer".to_string(),
@@ -310,6 +315,7 @@ mod tests {
                 holes: vec![],
             }]),
             properties: Arc::new(Attributes::default()),
+            id: None,
         };
         let feats = vec![big_feature, small_feature];
 
@@ -382,6 +388,7 @@ mod tests {
                 holes: vec![],
             }]),
             properties: Arc::new(Attributes::default()),
+            id: None,
         }];
 
         let bytes = make_tile(extent, &feats, u64::MAX, None).unwrap();

--- a/engine/runtime/feature-view/Cargo.toml
+++ b/engine/runtime/feature-view/Cargo.toml
@@ -33,4 +33,6 @@ thiserror.workspace = true
 zstd.workspace = true
 
 [dev-dependencies]
+prost.workspace = true
 tempfile.workspace = true
+tinymvt.workspace = true

--- a/engine/runtime/feature-view/src/lib.rs
+++ b/engine/runtime/feature-view/src/lib.rs
@@ -1,9 +1,10 @@
 //! Renders a viewable form of the features a run leaves on an edge.
 //!
 //! The input is one JSONL file. The output is either a glb holding one picked
-//! feature, or a 3D Tiles tileset for streaming a whole edge. Rendered features
-//! carry no attributes, only [`ROW_INDEX_PROPERTY`], so a click in a viewer
-//! resolves to a row in the table the file came from.
+//! feature, or a tileset for streaming a whole edge: 3D Tiles for 3D geometry,
+//! vector tiles for 2D. Rendered features carry no attributes, only
+//! [`ROW_INDEX_PROPERTY`], so a click in a viewer resolves to a row in the table
+//! the file came from.
 
 // The whole crate is new-geometry only; see Cargo.toml.
 #![cfg(feature = "new-geometry")]
@@ -16,9 +17,11 @@ use reearth_flow_action_sink::errors::SinkError;
 use reearth_flow_action_sink::file::cesium3dtiles::next::{
     build, build_glb, MetadataOptions, RenderOptions,
 };
+use reearth_flow_action_sink::file::mvt::next::{build as build_tiles, TileFeature, TileOptions};
 use reearth_flow_action_sink::SinkOutput;
 use reearth_flow_common::uri::Uri;
-use reearth_flow_geometry::Geometry;
+use reearth_flow_geometry::coordinate::CoordinateFrame;
+use reearth_flow_geometry::{Euclidean2DGeometry, Geometry};
 use reearth_flow_storage::resolve::StorageResolver;
 use reearth_flow_types::{
     Attribute, AttributeValue, Attributes, Code, CodeType, CompiledCode, Feature,
@@ -34,6 +37,10 @@ const FEATURE_EXTENSIONS: [&str; 2] = [".jsonl.zst", ".jsonl"];
 /// The one property a rendered view carries: the row a picked feature sits at in
 /// the table its file came from.
 pub const ROW_INDEX_PROPERTY: &str = "rowIndex";
+
+/// The single layer a 2D view writes, so a viewer's style does not depend on
+/// which node and port the file came from.
+pub const LAYER_NAME: &str = "features";
 
 /// The base name a view takes from its input: the file name with the
 /// intermediate-data extension dropped.
@@ -72,8 +79,12 @@ pub enum Error {
     },
     #[error("Failed to render the view: {0}")]
     Render(#[from] SinkError),
-    #[error("Views of 2D geometry are not supported yet")]
+    #[error("A glTF view needs 3D geometry, and this row holds 2D geometry")]
     TwoDimensional,
+    #[error("A view renders one embedding, and this selection mixes 2D and 3D geometry")]
+    MixedDimensions,
+    #[error("A 2D view is positioned in WGS84, so its geometry needs a CRS; found {frame}")]
+    NonCrs { frame: String },
     #[error("Failed to write {path}: {source}")]
     Write {
         path: String,
@@ -99,6 +110,16 @@ pub struct ViewOptions {
     pub wrap_tolerance: f64,
     /// JPEG by default: a view is built on demand, so we need fast encoding.
     pub texture_codec: TextureCodec,
+    /// Target content size per 3D tile, in bytes.
+    pub target_tile_size: u64,
+    /// Lowest zoom a 2D tile pyramid is sliced at; must not exceed `max_zoom`.
+    pub min_zoom: u8,
+    /// Highest zoom a 2D tile pyramid is sliced at, inclusive.
+    pub max_zoom: u8,
+    /// Coordinate grid resolution within a 2D tile.
+    pub extent: i32,
+    /// Size cap per 2D tile, in bytes.
+    pub max_tile_bytes: u64,
 }
 
 impl Default for ViewOptions {
@@ -111,6 +132,11 @@ impl Default for ViewOptions {
             atlas_extrusion: 0,
             wrap_tolerance: 0.0,
             texture_codec: TextureCodec::Jpeg,
+            target_tile_size: 1_048_576,
+            min_zoom: 0,
+            max_zoom: 15,
+            extent: 4096,
+            max_tile_bytes: 500_000,
         }
     }
 }
@@ -135,6 +161,18 @@ impl ViewOptions {
             schema_key: None,
             skip_unexposed_attributes: false,
             array_map_separator: None,
+        }
+    }
+
+    fn tile_options<'a>(&self, name: &'a str) -> TileOptions<'a> {
+        TileOptions {
+            min_zoom: self.min_zoom,
+            max_zoom: self.max_zoom,
+            extent: self.extent,
+            max_tile_bytes: self.max_tile_bytes,
+            // The row index is a plain number, so nothing needs joining.
+            array_map_separator: None,
+            name: Some(name),
         }
     }
 }
@@ -426,13 +464,27 @@ pub fn render_feature(
 
 /// Render a whole selection into a tileset under `{prefix}/`: the view of an
 /// entire edge.
+///
+/// The shape follows the geometry: 3D renders 3D Tiles, entered at
+/// `tileset.json`; 2D renders vector tiles, entered at `tilejson.json`. A
+/// selection mixing the two has no single shape and is rejected.
 pub fn render_tileset(
     selection: &[Selected],
-    target_tile_size: u64,
     options: &ViewOptions,
     destination: &Destination<'_>,
 ) -> Result<RenderedView> {
-    reject_two_dimensional(selection)?;
+    match embedding(selection)? {
+        Embedding::ThreeDimensional => render_3d_tiles(selection, options, destination),
+        Embedding::TwoDimensional => render_vector_tiles(selection, options, destination),
+    }
+}
+
+/// Render a 3D selection into a 3D Tiles tileset.
+fn render_3d_tiles(
+    selection: &[Selected],
+    options: &ViewOptions,
+    destination: &Destination<'_>,
+) -> Result<RenderedView> {
     let features: Vec<Feature> = selection
         .iter()
         .map(|s| s.feature.with_attributes(row_index_attributes(s.row)))
@@ -444,7 +496,7 @@ pub fn render_tileset(
     let built = build(
         &features,
         options.metadata_options(),
-        target_tile_size,
+        options.target_tile_size,
         options.render_options(),
         |relative_path, bytes| {
             let uri = destination
@@ -472,6 +524,59 @@ pub fn render_tileset(
     })
 }
 
+/// Render a 2D selection into a vector tile pyramid.
+///
+/// The row index is written both as the [`ROW_INDEX_PROPERTY`] tag and as the
+/// tile feature's id, so a viewer can resolve a click either way.
+fn render_vector_tiles(
+    selection: &[Selected],
+    options: &ViewOptions,
+    destination: &Destination<'_>,
+) -> Result<RenderedView> {
+    reject_non_crs(selection)?;
+    let features: Vec<Feature> = selection
+        .iter()
+        .map(|s| s.feature.with_attributes(row_index_attributes(s.row)))
+        .collect();
+    let inputs: Vec<TileFeature<'_>> = features
+        .iter()
+        .zip(selection)
+        .map(|(feature, selected)| TileFeature {
+            feature,
+            layer_name: LAYER_NAME,
+            id: Some(selected.row as u64),
+        })
+        .collect();
+
+    // Encoded tiles are handed over as they are produced rather than collected,
+    // so only their paths come back.
+    let written = Mutex::new(Vec::new());
+    let built = build_tiles(
+        &inputs,
+        options.tile_options(destination.prefix),
+        |relative_path, bytes| {
+            let uri = destination
+                .write_under(&relative_path, bytes)
+                .map_err(|e| SinkError::MvtWriter(format!("{e}")))?;
+            written
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .push(uri);
+            Ok(())
+        },
+    )?;
+
+    let mut written = written.into_inner().unwrap_or_else(PoisonError::into_inner);
+    let entry_point = destination.write_under("tilejson.json", built.tilejson.into_bytes())?;
+    written.push(entry_point.clone());
+
+    Ok(RenderedView {
+        rendered_features: built.rendered_features,
+        entry_point: Some(entry_point),
+        written,
+    })
+}
+
 /// The single-entry attribute set a rendered feature carries.
 fn row_index_attributes(row: usize) -> Attributes {
     let mut attributes = Attributes::new();
@@ -482,38 +587,115 @@ fn row_index_attributes(row: usize) -> Attributes {
     attributes
 }
 
-/// 2D has no view yet, so say so instead of writing a file with nothing in it.
-fn reject_two_dimensional(selection: &[Selected]) -> Result<()> {
-    match selection
-        .iter()
-        .any(|s| holds_two_dimensional(&s.feature.geometry))
-    {
-        true => Err(Error::TwoDimensional),
-        false => Ok(()),
+/// What a selection's geometry is embedded in, which decides the shape its view
+/// takes.
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum Embedding {
+    TwoDimensional,
+    ThreeDimensional,
+}
+
+/// The embedding every feature in `selection` shares. A selection carrying no
+/// geometry at all reads as 3D, which renders an empty 3D tileset.
+fn embedding(selection: &[Selected]) -> Result<Embedding> {
+    let mut seen = Seen::default();
+    for selected in selection {
+        seen.note(&selected.feature.geometry);
+    }
+    match (seen.two_dimensional, seen.three_dimensional) {
+        (true, true) => Err(Error::MixedDimensions),
+        (true, false) => Ok(Embedding::TwoDimensional),
+        (false, _) => Ok(Embedding::ThreeDimensional),
     }
 }
 
-fn holds_two_dimensional(geometry: &Geometry) -> bool {
-    match geometry {
-        Geometry::Euclidean2D(_) => true,
-        Geometry::GeometryCollection(collection) => {
-            collection.members().iter().any(holds_two_dimensional)
+/// Which embeddings a walk has run into so far.
+#[derive(Default)]
+struct Seen {
+    two_dimensional: bool,
+    three_dimensional: bool,
+}
+
+impl Seen {
+    fn note(&mut self, geometry: &Geometry) {
+        match geometry {
+            Geometry::None => {}
+            Geometry::Euclidean2D(_) => self.two_dimensional = true,
+            Geometry::Euclidean3D(_) => self.three_dimensional = true,
+            Geometry::GeometryCollection(collection) => {
+                collection.members().iter().for_each(|m| self.note(m))
+            }
         }
-        Geometry::None | Geometry::Euclidean3D(_) => false,
+    }
+}
+
+/// A glb holds one feature and renders 3D only, so 2D has no per-row view.
+fn reject_two_dimensional(selection: &[Selected]) -> Result<()> {
+    match embedding(selection)? {
+        Embedding::TwoDimensional => Err(Error::TwoDimensional),
+        Embedding::ThreeDimensional => Ok(()),
+    }
+}
+
+/// A vector tile is positioned in WGS84, so every 2D leaf has to name the CRS
+/// its coordinates are in.
+fn reject_non_crs(selection: &[Selected]) -> Result<()> {
+    selection
+        .iter()
+        .try_for_each(|s| check_frames(&s.feature.geometry))
+}
+
+fn check_frames(geometry: &Geometry) -> Result<()> {
+    match geometry {
+        Geometry::None | Geometry::Euclidean3D(_) => Ok(()),
+        Geometry::Euclidean2D(g) => check_frames_2d(g),
+        Geometry::GeometryCollection(collection) => {
+            collection.members().iter().try_for_each(check_frames)
+        }
+    }
+}
+
+fn check_frames_2d(g: &Euclidean2DGeometry) -> Result<()> {
+    let frame = match g {
+        Euclidean2DGeometry::Point(point) => point.frame(),
+        Euclidean2DGeometry::LineString(line_string) => line_string.frame(),
+        Euclidean2DGeometry::Polygon(polygon) => polygon.frame(),
+        Euclidean2DGeometry::PolygonMesh(mesh) => mesh.frame(),
+        Euclidean2DGeometry::TriangularMesh(mesh) => mesh.frame(),
+        Euclidean2DGeometry::Collection(collection) => {
+            return collection.members().iter().try_for_each(check_frames_2d)
+        }
+    };
+    match frame {
+        CoordinateFrame::Crs(_) => Ok(()),
+        other => Err(Error::NonCrs {
+            frame: format!("{other:?}"),
+        }),
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
     use std::path::Path;
 
     use reearth_flow_geometry::collection::Collection3D;
-    use reearth_flow_geometry::coordinate::{CoordinateFrame, EpsgCode};
+    use reearth_flow_geometry::coordinate::EpsgCode;
+    use reearth_flow_geometry::line_string::LineString2D;
     use reearth_flow_geometry::point::Point2D;
+    use reearth_flow_geometry::polygon::Polygon2D;
     use reearth_flow_geometry::triangular_mesh::TriangularMesh3D;
-    use reearth_flow_geometry::{Euclidean2DGeometry, Euclidean3DGeometry};
+    use reearth_flow_geometry::Euclidean3DGeometry;
+    use tinymvt::vector_tile;
 
     use super::*;
+
+    /// Coordinates in a geographic CRS are stored latitude first.
+    const TOKYO: [f64; 2] = [35.6, 139.7];
+
+    fn crs_2d() -> CoordinateFrame {
+        CoordinateFrame::Crs(EpsgCode::new(4326))
+    }
 
     fn triangle(lat: f64) -> TriangularMesh3D {
         TriangularMesh3D::from_soup(
@@ -563,13 +745,59 @@ mod tests {
     fn tileset_to(dir: &Path, selection: &[Selected], options: &ViewOptions) -> RenderedView {
         let root = Uri::for_test(&format!("file://{}", dir.display()));
         let resolver = StorageResolver::new();
-        render_tileset(
-            selection,
-            1_048_576,
-            options,
-            &destination(&root, &resolver),
+        render_tileset(selection, options, &destination(&root, &resolver)).expect("render")
+    }
+
+    fn point_feature(frame: CoordinateFrame) -> Feature {
+        feature(
+            "k",
+            Geometry::Euclidean2D(Euclidean2DGeometry::Point(Point2D::new(frame, TOKYO))),
         )
-        .expect("render")
+    }
+
+    /// A selection of one 2D leaf of each kind, one per row.
+    fn two_dimensional_selection() -> Vec<Selected> {
+        let [lat, lng] = TOKYO;
+        let line = Euclidean2DGeometry::LineString(LineString2D::from_coords(
+            crs_2d(),
+            [TOKYO, [lat + 0.01, lng + 0.01]],
+        ));
+        let ring = [
+            TOKYO,
+            [lat + 0.01, lng],
+            [lat + 0.01, lng + 0.01],
+            [lat, lng + 0.01],
+            TOKYO,
+        ];
+        let polygon = Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings(
+            crs_2d(),
+            ring,
+            Vec::<Vec<[f64; 2]>>::new(),
+        )));
+
+        [
+            Geometry::Euclidean2D(Euclidean2DGeometry::Point(Point2D::new(crs_2d(), TOKYO))),
+            Geometry::Euclidean2D(line),
+            Geometry::Euclidean2D(polygon),
+        ]
+        .into_iter()
+        .enumerate()
+        .map(|(row, geometry)| Selected {
+            row,
+            feature: feature("k", geometry),
+        })
+        .collect()
+    }
+
+    fn read_tiles(view: &RenderedView) -> Vec<vector_tile::Tile> {
+        view.written
+            .iter()
+            .filter(|uri| uri.as_str().ends_with(".mvt"))
+            .map(|uri| {
+                let bytes = std::fs::read(uri.path().as_path()).expect("the tile is written");
+                prost::Message::decode(bytes.as_slice()).expect("a tile decodes")
+            })
+            .collect()
     }
 
     fn destination<'a>(root: &'a Uri, resolver: &'a StorageResolver) -> Destination<'a> {
@@ -643,21 +871,16 @@ mod tests {
         assert_eq!(view.rendered_features, 1);
     }
 
-    /// 2D is not renderable yet, and saying so is an error rather than a panic.
+    /// The per-row glb view is 3D only, and saying so is an error rather than a
+    /// panic.
     #[test]
-    fn a_two_dimensional_selection_is_rejected() {
+    fn a_two_dimensional_row_has_no_glb_view() {
         let dir = tempfile::tempdir().expect("temp dir");
         let root = Uri::for_test(&format!("file://{}", dir.path().display()));
         let resolver = StorageResolver::new();
         let selected = Selected {
             row: 0,
-            feature: feature(
-                "k",
-                Geometry::Euclidean2D(Euclidean2DGeometry::Point(Point2D::new(
-                    CoordinateFrame::Euclidean,
-                    [0.0, 0.0],
-                ))),
-            ),
+            feature: point_feature(crs_2d()),
         };
 
         let error = render_feature(
@@ -665,9 +888,103 @@ mod tests {
             &ViewOptions::default(),
             &destination(&root, &resolver),
         )
-        .expect_err("2D has no view");
+        .expect_err("2D has no per-row view");
 
         assert!(matches!(error, Error::TwoDimensional));
+    }
+
+    /// A 2D selection takes the vector tile shape, and every leaf kind reaches
+    /// the pyramid.
+    #[test]
+    fn a_two_dimensional_selection_renders_vector_tiles() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let selection = two_dimensional_selection();
+        let view = tileset_to(dir.path(), &selection, &ViewOptions::default());
+
+        assert_eq!(view.rendered_features, 3);
+        assert!(view
+            .entry_point
+            .as_ref()
+            .expect("a tilejson is written")
+            .as_str()
+            .ends_with("/out/tilejson.json"));
+        assert!(dir.path().join("out/tilejson.json").exists());
+        assert!(!dir.path().join("out/tileset.json").exists());
+
+        let tiles = read_tiles(&view);
+        assert!(!tiles.is_empty(), "the pyramid holds tiles");
+        for layer in tiles.iter().flat_map(|tile| &tile.layers) {
+            assert_eq!(layer.name, LAYER_NAME);
+            assert_eq!(layer.keys, vec![ROW_INDEX_PROPERTY.to_string()]);
+        }
+    }
+
+    /// The row is carried twice: as the one property, and as the tile feature's
+    /// id, so a click resolves either way.
+    #[test]
+    fn a_vector_tile_carries_the_row_as_its_feature_id() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let selection = two_dimensional_selection();
+        let view = tileset_to(dir.path(), &selection, &ViewOptions::default());
+
+        let ids: BTreeSet<u64> = read_tiles(&view)
+            .iter()
+            .flat_map(|tile| &tile.layers)
+            .flat_map(|layer| &layer.features)
+            .map(|feature| feature.id.expect("a tile feature names its row"))
+            .collect();
+
+        assert_eq!(ids, BTreeSet::from([0, 1, 2]));
+    }
+
+    /// A mixed selection has no single shape, so it is refused rather than
+    /// silently rendering half of it.
+    #[test]
+    fn a_mixed_selection_is_rejected() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let root = Uri::for_test(&format!("file://{}", dir.path().display()));
+        let resolver = StorageResolver::new();
+        let selection = [
+            Selected {
+                row: 0,
+                feature: point_feature(crs_2d()),
+            },
+            Selected {
+                row: 1,
+                feature: mesh_feature("k", 35.0),
+            },
+        ];
+
+        let error = render_tileset(
+            &selection,
+            &ViewOptions::default(),
+            &destination(&root, &resolver),
+        )
+        .expect_err("one view holds one embedding");
+
+        assert!(matches!(error, Error::MixedDimensions));
+    }
+
+    /// A vector tile is positioned in WGS84, so geometry with no CRS cannot be
+    /// placed on the map.
+    #[test]
+    fn a_selection_without_a_crs_is_rejected() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let root = Uri::for_test(&format!("file://{}", dir.path().display()));
+        let resolver = StorageResolver::new();
+        let selection = [Selected {
+            row: 0,
+            feature: point_feature(CoordinateFrame::Euclidean),
+        }];
+
+        let error = render_tileset(
+            &selection,
+            &ViewOptions::default(),
+            &destination(&root, &resolver),
+        )
+        .expect_err("a tile needs a CRS");
+
+        assert!(matches!(error, Error::NonCrs { .. }));
     }
 
     /// Every selection mode must agree on what row N is, and a filter must not

--- a/engine/runtime/feature-view/src/lib.rs
+++ b/engine/runtime/feature-view/src/lib.rs
@@ -1,8 +1,9 @@
 //! Renders a viewable form of the features a run leaves on an edge.
 //!
 //! The input is one JSONL file. The output is either a glb holding one picked
-//! feature, or a tileset for streaming a whole edge: 3D Tiles for 3D geometry,
-//! vector tiles for 2D. Rendered features carry no attributes, only
+//! feature, or a tileset for streaming a whole edge: 3D Tiles once any 3D
+//! geometry is present, vector tiles for an all-2D edge. Rendered features
+//! carry no attributes, only
 //! [`ROW_INDEX_PROPERTY`], so a click in a viewer resolves to a row in the table
 //! the file came from.
 
@@ -81,8 +82,6 @@ pub enum Error {
     Render(#[from] SinkError),
     #[error("A glTF view needs 3D geometry, and this row holds 2D geometry")]
     TwoDimensional,
-    #[error("A view renders one embedding, and this selection mixes 2D and 3D geometry")]
-    MixedDimensions,
     #[error("A 2D view is positioned in WGS84, so its geometry needs a CRS; found {frame}")]
     NonCrs { frame: String },
     #[error("Failed to write {path}: {source}")]
@@ -437,9 +436,7 @@ pub fn render_feature(
     destination: &Destination<'_>,
 ) -> Result<RenderedView> {
     reject_two_dimensional(std::slice::from_ref(selected))?;
-    let feature = selected
-        .feature
-        .with_attributes(row_index_attributes(selected.row));
+    let feature = lifted_feature(selected);
 
     let Some(glb) = build_glb(
         &feature,
@@ -465,30 +462,32 @@ pub fn render_feature(
 /// Render a whole selection into a tileset under `{prefix}/`: the view of an
 /// entire edge.
 ///
-/// The shape follows the geometry: 3D renders 3D Tiles, entered at
-/// `tileset.json`; 2D renders vector tiles, entered at `tilejson.json`. A
-/// selection mixing the two has no single shape and is rejected.
+/// The shape follows the geometry: any 3D geometry at all renders 3D Tiles,
+/// entered at `tileset.json`, with the selection's 2D geometry lifted into 3D;
+/// an all-2D selection renders vector tiles, entered at `tilejson.json`.
+///
+/// The 3D Tiles writer draws surfaces only, so a lifted point or line string is
+/// skipped rather than drawn; `rendered_features` counts what reached the
+/// output.
 pub fn render_tileset(
     selection: &[Selected],
     options: &ViewOptions,
     destination: &Destination<'_>,
 ) -> Result<RenderedView> {
-    match embedding(selection)? {
+    match embedding(selection) {
         Embedding::ThreeDimensional => render_3d_tiles(selection, options, destination),
         Embedding::TwoDimensional => render_vector_tiles(selection, options, destination),
     }
 }
 
-/// Render a 3D selection into a 3D Tiles tileset.
+/// Render a selection into a 3D Tiles tileset, lifting any 2D geometry it
+/// holds.
 fn render_3d_tiles(
     selection: &[Selected],
     options: &ViewOptions,
     destination: &Destination<'_>,
 ) -> Result<RenderedView> {
-    let features: Vec<Feature> = selection
-        .iter()
-        .map(|s| s.feature.with_attributes(row_index_attributes(s.row)))
-        .collect();
+    let features: Vec<Feature> = selection.iter().map(lifted_feature).collect();
 
     // Content glbs are handed over as they are built, so peak memory stays at
     // one tile rather than the whole tileset; collect only their paths.
@@ -577,6 +576,18 @@ fn render_vector_tiles(
     })
 }
 
+/// The feature as a 3D view renders it: the row index for its attributes, and
+/// any 2D geometry lifted into 3D at the elevation it lies at.
+fn lifted_feature(selected: &Selected) -> Feature {
+    let mut feature = selected
+        .feature
+        .with_attributes(row_index_attributes(selected.row));
+    if Seen::of(&feature.geometry).two_dimensional {
+        feature.set_geometry((*feature.geometry).clone().into_3d());
+    }
+    feature
+}
+
 /// The single-entry attribute set a rendered feature carries.
 fn row_index_attributes(row: usize) -> Attributes {
     let mut attributes = Attributes::new();
@@ -595,17 +606,18 @@ enum Embedding {
     ThreeDimensional,
 }
 
-/// The embedding every feature in `selection` shares. A selection carrying no
-/// geometry at all reads as 3D, which renders an empty 3D tileset.
-fn embedding(selection: &[Selected]) -> Result<Embedding> {
+/// The shape a global view of `selection` takes. Only an all-2D selection
+/// renders vector tiles: one 3D feature makes the whole selection a 3D tileset,
+/// with its 2D geometry lifted. A selection carrying no geometry at all reads as
+/// 3D, which renders an empty 3D tileset.
+fn embedding(selection: &[Selected]) -> Embedding {
     let mut seen = Seen::default();
     for selected in selection {
         seen.note(&selected.feature.geometry);
     }
     match (seen.two_dimensional, seen.three_dimensional) {
-        (true, true) => Err(Error::MixedDimensions),
-        (true, false) => Ok(Embedding::TwoDimensional),
-        (false, _) => Ok(Embedding::ThreeDimensional),
+        (true, false) => Embedding::TwoDimensional,
+        _ => Embedding::ThreeDimensional,
     }
 }
 
@@ -617,6 +629,12 @@ struct Seen {
 }
 
 impl Seen {
+    fn of(geometry: &Geometry) -> Self {
+        let mut seen = Seen::default();
+        seen.note(geometry);
+        seen
+    }
+
     fn note(&mut self, geometry: &Geometry) {
         match geometry {
             Geometry::None => {}
@@ -629,9 +647,10 @@ impl Seen {
     }
 }
 
-/// A glb holds one feature and renders 3D only, so 2D has no per-row view.
+/// A glb renders 3D only, so a purely 2D row has no per-row view. A row mixing
+/// the two renders, with its 2D geometry lifted.
 fn reject_two_dimensional(selection: &[Selected]) -> Result<()> {
-    match embedding(selection)? {
+    match embedding(selection) {
         Embedding::TwoDimensional => Err(Error::TwoDimensional),
         Embedding::ThreeDimensional => Ok(()),
     }
@@ -748,6 +767,26 @@ mod tests {
         render_tileset(selection, options, &destination(&root, &resolver)).expect("render")
     }
 
+    /// A closed square ring as 2D geometry, optionally at an elevation.
+    fn polygon_2d(elevation: Option<f64>) -> Geometry {
+        let [lat, lng] = TOKYO;
+        let ring = [
+            TOKYO,
+            [lat + 0.01, lng],
+            [lat + 0.01, lng + 0.01],
+            [lat, lng + 0.01],
+            TOKYO,
+        ];
+        let no_holes = Vec::<Vec<[f64; 2]>>::new();
+        let polygon = match elevation {
+            None => Polygon2D::from_rings(crs_2d(), ring, no_holes),
+            Some(elevation) => {
+                Polygon2D::from_rings_at_elevation(crs_2d(), ring, no_holes, elevation)
+            }
+        };
+        Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(Box::new(polygon)))
+    }
+
     fn point_feature(frame: CoordinateFrame) -> Feature {
         feature(
             "k",
@@ -762,23 +801,10 @@ mod tests {
             crs_2d(),
             [TOKYO, [lat + 0.01, lng + 0.01]],
         ));
-        let ring = [
-            TOKYO,
-            [lat + 0.01, lng],
-            [lat + 0.01, lng + 0.01],
-            [lat, lng + 0.01],
-            TOKYO,
-        ];
-        let polygon = Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings(
-            crs_2d(),
-            ring,
-            Vec::<Vec<[f64; 2]>>::new(),
-        )));
-
         [
             Geometry::Euclidean2D(Euclidean2DGeometry::Point(Point2D::new(crs_2d(), TOKYO))),
             Geometry::Euclidean2D(line),
-            Geometry::Euclidean2D(polygon),
+            polygon_2d(None),
         ]
         .into_iter()
         .enumerate()
@@ -937,32 +963,70 @@ mod tests {
         assert_eq!(ids, BTreeSet::from([0, 1, 2]));
     }
 
-    /// A mixed selection has no single shape, so it is refused rather than
-    /// silently rendering half of it.
+    /// One 3D feature makes the whole selection a 3D tileset, and the 2D
+    /// polygon alongside it is lifted rather than dropped or refused.
     #[test]
-    fn a_mixed_selection_is_rejected() {
+    fn a_mixed_selection_lifts_its_2d_geometry_into_the_3d_tileset() {
         let dir = tempfile::tempdir().expect("temp dir");
-        let root = Uri::for_test(&format!("file://{}", dir.path().display()));
-        let resolver = StorageResolver::new();
         let selection = [
             Selected {
                 row: 0,
-                feature: point_feature(crs_2d()),
+                feature: feature("k", polygon_2d(None)),
             },
             Selected {
                 row: 1,
                 feature: mesh_feature("k", 35.0),
             },
         ];
+        let view = tileset_to(dir.path(), &selection, &ViewOptions::default());
 
-        let error = render_tileset(
-            &selection,
-            &ViewOptions::default(),
-            &destination(&root, &resolver),
-        )
-        .expect_err("one view holds one embedding");
+        assert!(dir.path().join("out/tileset.json").exists());
+        assert!(!dir.path().join("out/tilejson.json").exists());
+        assert_eq!(
+            view.rendered_features, 2,
+            "the lifted polygon renders alongside the mesh"
+        );
+    }
 
-        assert!(matches!(error, Error::MixedDimensions));
+    /// A lifted polygon sits at the elevation its 2D leaf lies at, not at 0.
+    #[test]
+    fn a_lifted_polygon_keeps_its_elevation() {
+        let heights = |elevation: Option<f64>| {
+            let dir = tempfile::tempdir().expect("temp dir");
+            let selection = [
+                Selected {
+                    row: 0,
+                    feature: feature("k", polygon_2d(elevation)),
+                },
+                Selected {
+                    row: 1,
+                    feature: mesh_feature("k", 35.0),
+                },
+            ];
+            tileset_to(dir.path(), &selection, &ViewOptions::default());
+
+            let tileset: serde_json::Value = serde_json::from_slice(
+                &std::fs::read(dir.path().join("out/tileset.json")).expect("a tileset"),
+            )
+            .expect("the tileset parses");
+            let region = tileset["root"]["boundingVolume"]["region"]
+                .as_array()
+                .expect("a bounding region")
+                .clone();
+            (
+                region[4].as_f64().expect("a min height"),
+                region[5].as_f64().expect("a max height"),
+            )
+        };
+
+        // The mesh fixture sits at 10 m, so a polygon lifted to 250 m has to
+        // widen the region's top; one lifted to 0 has to widen its bottom.
+        let (_, high_max) = heights(Some(250.0));
+        assert!(high_max > 200.0, "the elevation reached the tileset");
+
+        let (flat_min, flat_max) = heights(None);
+        assert!(flat_min < 1.0, "an elevationless leaf lifts to 0");
+        assert!(flat_max < 200.0);
     }
 
     /// A vector tile is positioned in WGS84, so geometry with no CRS cannot be

--- a/engine/runtime/feature-view/src/lib.rs
+++ b/engine/runtime/feature-view/src/lib.rs
@@ -21,8 +21,7 @@ use reearth_flow_action_sink::file::cesium3dtiles::next::{
 use reearth_flow_action_sink::file::mvt::next::{build as build_tiles, TileFeature, TileOptions};
 use reearth_flow_action_sink::SinkOutput;
 use reearth_flow_common::uri::Uri;
-use reearth_flow_geometry::coordinate::CoordinateFrame;
-use reearth_flow_geometry::{Euclidean2DGeometry, Geometry};
+use reearth_flow_geometry::Geometry;
 use reearth_flow_storage::resolve::StorageResolver;
 use reearth_flow_types::{
     Attribute, AttributeValue, Attributes, Code, CodeType, CompiledCode, Feature,
@@ -82,8 +81,13 @@ pub enum Error {
     Render(#[from] SinkError),
     #[error("A glTF view needs 3D geometry, and this row holds 2D geometry")]
     TwoDimensional,
-    #[error("A 2D view is positioned in WGS84, so its geometry needs a CRS; found {frame}")]
-    NonCrs { frame: String },
+    #[error("Row {row} carried no geometry the view draws; nothing was written")]
+    RowUndrawable { row: usize },
+    #[error(
+        "None of the {selected} selected features carried geometry the view draws; nothing was \
+         written"
+    )]
+    NothingRendered { selected: usize },
     #[error("Failed to write {path}: {source}")]
     Write {
         path: String,
@@ -419,17 +423,20 @@ impl Destination<'_> {
 #[derive(Debug)]
 pub struct RenderedView {
     /// Selected features that carried renderable geometry; the rest are absent
-    /// from the output.
+    /// from the output. At least one: a render that draws nothing is an error.
     pub rendered_features: usize,
-    /// The entry point a viewer opens: the glb, or the tileset's
-    /// `tileset.json`.
-    pub entry_point: Option<Uri>,
+    /// The entry point a viewer opens: the glb, the tileset's `tileset.json`,
+    /// or the vector tiles' `tilejson.json`.
+    pub entry_point: Uri,
     /// Every file written, the entry point included.
     pub written: Vec<Uri>,
 }
 
 /// Render one feature into `{prefix}.glb`, untiled: the view behind clicking a
 /// table row.
+///
+/// Fails with [`Error::RowUndrawable`] when the row carries no geometry the
+/// writer draws, so that nothing is written.
 pub fn render_feature(
     selected: &Selected,
     options: &ViewOptions,
@@ -438,23 +445,17 @@ pub fn render_feature(
     reject_two_dimensional(std::slice::from_ref(selected))?;
     let feature = lifted_feature(selected);
 
-    let Some(glb) = build_glb(
+    let glb = build_glb(
         &feature,
         options.metadata_options(),
         options.render_options(),
     )?
-    else {
-        return Ok(RenderedView {
-            rendered_features: 0,
-            entry_point: None,
-            written: Vec::new(),
-        });
-    };
+    .ok_or(Error::RowUndrawable { row: selected.row })?;
 
     let uri = destination.write_suffixed(".glb", glb)?;
     Ok(RenderedView {
         rendered_features: 1,
-        entry_point: Some(uri.clone()),
+        entry_point: uri.clone(),
         written: vec![uri],
     })
 }
@@ -466,9 +467,10 @@ pub fn render_feature(
 /// entered at `tileset.json`, with the selection's 2D geometry lifted into 3D;
 /// an all-2D selection renders vector tiles, entered at `tilejson.json`.
 ///
-/// The 3D Tiles writer draws surfaces only, so a lifted point or line string is
-/// skipped rather than drawn; `rendered_features` counts what reached the
-/// output.
+/// Geometry the writer cannot place or draw is skipped rather than refused: a
+/// leaf naming no CRS, and for 3D Tiles anything but a surface. The render
+/// fails with [`Error::NothingRendered`] only when no selected feature was
+/// drawn, and then writes nothing. An empty selection renders an empty tileset.
 pub fn render_tileset(
     selection: &[Selected],
     options: &ViewOptions,
@@ -509,6 +511,8 @@ fn render_3d_tiles(
         },
     )?;
 
+    require_rendered(selection, built.rendered_features)?;
+
     let mut written = written.into_inner().unwrap_or_else(PoisonError::into_inner);
     for (relative_path, bytes) in built.subtrees {
         written.push(destination.write_under(&relative_path, bytes)?);
@@ -518,7 +522,7 @@ fn render_3d_tiles(
 
     Ok(RenderedView {
         rendered_features: built.rendered_features,
-        entry_point: Some(entry_point),
+        entry_point,
         written,
     })
 }
@@ -532,7 +536,6 @@ fn render_vector_tiles(
     options: &ViewOptions,
     destination: &Destination<'_>,
 ) -> Result<RenderedView> {
-    reject_non_crs(selection)?;
     let features: Vec<Feature> = selection
         .iter()
         .map(|s| s.feature.with_attributes(row_index_attributes(s.row)))
@@ -565,15 +568,28 @@ fn render_vector_tiles(
         },
     )?;
 
+    require_rendered(selection, built.rendered_features)?;
+
     let mut written = written.into_inner().unwrap_or_else(PoisonError::into_inner);
     let entry_point = destination.write_under("tilejson.json", built.tilejson.into_bytes())?;
     written.push(entry_point.clone());
 
     Ok(RenderedView {
         rendered_features: built.rendered_features,
-        entry_point: Some(entry_point),
+        entry_point,
         written,
     })
+}
+
+/// A non-empty selection that drew nothing is an error, so the tileset's
+/// entry point is never written for it.
+fn require_rendered(selection: &[Selected], rendered_features: usize) -> Result<()> {
+    if rendered_features == 0 && !selection.is_empty() {
+        return Err(Error::NothingRendered {
+            selected: selection.len(),
+        });
+    }
+    Ok(())
 }
 
 /// The feature as a 3D view renders it: the row index for its attributes, and
@@ -656,55 +672,18 @@ fn reject_two_dimensional(selection: &[Selected]) -> Result<()> {
     }
 }
 
-/// A vector tile is positioned in WGS84, so every 2D leaf has to name the CRS
-/// its coordinates are in.
-fn reject_non_crs(selection: &[Selected]) -> Result<()> {
-    selection
-        .iter()
-        .try_for_each(|s| check_frames(&s.feature.geometry))
-}
-
-fn check_frames(geometry: &Geometry) -> Result<()> {
-    match geometry {
-        Geometry::None | Geometry::Euclidean3D(_) => Ok(()),
-        Geometry::Euclidean2D(g) => check_frames_2d(g),
-        Geometry::GeometryCollection(collection) => {
-            collection.members().iter().try_for_each(check_frames)
-        }
-    }
-}
-
-fn check_frames_2d(g: &Euclidean2DGeometry) -> Result<()> {
-    let frame = match g {
-        Euclidean2DGeometry::Point(point) => point.frame(),
-        Euclidean2DGeometry::LineString(line_string) => line_string.frame(),
-        Euclidean2DGeometry::Polygon(polygon) => polygon.frame(),
-        Euclidean2DGeometry::PolygonMesh(mesh) => mesh.frame(),
-        Euclidean2DGeometry::TriangularMesh(mesh) => mesh.frame(),
-        Euclidean2DGeometry::Collection(collection) => {
-            return collection.members().iter().try_for_each(check_frames_2d)
-        }
-    };
-    match frame {
-        CoordinateFrame::Crs(_) => Ok(()),
-        other => Err(Error::NonCrs {
-            frame: format!("{other:?}"),
-        }),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
     use std::path::Path;
 
     use reearth_flow_geometry::collection::Collection3D;
-    use reearth_flow_geometry::coordinate::EpsgCode;
+    use reearth_flow_geometry::coordinate::{CoordinateFrame, EpsgCode};
     use reearth_flow_geometry::line_string::LineString2D;
-    use reearth_flow_geometry::point::Point2D;
+    use reearth_flow_geometry::point::{Point2D, Point3D};
     use reearth_flow_geometry::polygon::Polygon2D;
     use reearth_flow_geometry::triangular_mesh::TriangularMesh3D;
-    use reearth_flow_geometry::Euclidean3DGeometry;
+    use reearth_flow_geometry::{Euclidean2DGeometry, Euclidean3DGeometry};
     use tinymvt::vector_tile;
 
     use super::*;
@@ -928,12 +907,7 @@ mod tests {
         let view = tileset_to(dir.path(), &selection, &ViewOptions::default());
 
         assert_eq!(view.rendered_features, 3);
-        assert!(view
-            .entry_point
-            .as_ref()
-            .expect("a tilejson is written")
-            .as_str()
-            .ends_with("/out/tilejson.json"));
+        assert!(view.entry_point.as_str().ends_with("/out/tilejson.json"));
         assert!(dir.path().join("out/tilejson.json").exists());
         assert!(!dir.path().join("out/tileset.json").exists());
 
@@ -1029,26 +1003,80 @@ mod tests {
         assert!(flat_max < 200.0);
     }
 
-    /// A vector tile is positioned in WGS84, so geometry with no CRS cannot be
-    /// placed on the map.
+    /// A leaf naming no CRS cannot be placed on the map, so it is left out
+    /// while the rest of the selection renders.
     #[test]
-    fn a_selection_without_a_crs_is_rejected() {
+    fn a_feature_without_a_crs_is_skipped_not_refused() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let selection = [
+            Selected {
+                row: 0,
+                feature: point_feature(CoordinateFrame::Euclidean),
+            },
+            Selected {
+                row: 1,
+                feature: point_feature(crs_2d()),
+            },
+        ];
+        let view = tileset_to(dir.path(), &selection, &ViewOptions::default());
+
+        assert_eq!(view.rendered_features, 1);
+        let ids: BTreeSet<u64> = read_tiles(&view)
+            .iter()
+            .flat_map(|tile| &tile.layers)
+            .flat_map(|layer| &layer.features)
+            .filter_map(|feature| feature.id)
+            .collect();
+        assert_eq!(ids, BTreeSet::from([1]), "only the placeable row is tiled");
+    }
+
+    /// When nothing in the selection can be drawn the render is an error, and
+    /// no tileset is left behind for a viewer to open.
+    #[test]
+    fn a_selection_that_draws_nothing_is_an_error_and_writes_nothing() {
         let dir = tempfile::tempdir().expect("temp dir");
         let root = Uri::for_test(&format!("file://{}", dir.path().display()));
         let resolver = StorageResolver::new();
-        let selection = [Selected {
+        let render = |selection: &[Selected]| {
+            render_tileset(
+                selection,
+                &ViewOptions::default(),
+                &destination(&root, &resolver),
+            )
+            .expect_err("nothing to draw")
+        };
+
+        // 2D: the one leaf names no CRS.
+        let error = render(&[Selected {
             row: 0,
             feature: point_feature(CoordinateFrame::Euclidean),
-        }];
+        }]);
+        assert!(matches!(error, Error::NothingRendered { selected: 1 }));
+        assert!(!dir.path().join("out/tilejson.json").exists());
 
-        let error = render_tileset(
-            &selection,
-            &ViewOptions::default(),
-            &destination(&root, &resolver),
-        )
-        .expect_err("a tile needs a CRS");
+        // 3D: a point is not a surface, so the 3D Tiles writer draws nothing.
+        let error = render(&[Selected {
+            row: 0,
+            feature: feature(
+                "k",
+                Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
+                    CoordinateFrame::Crs(EpsgCode::new(4979)),
+                    [35.6, 139.7, 10.0],
+                ))),
+            ),
+        }]);
+        assert!(matches!(error, Error::NothingRendered { selected: 1 }));
+        assert!(!dir.path().join("out/tileset.json").exists());
+    }
 
-        assert!(matches!(error, Error::NonCrs { .. }));
+    /// An empty selection has nothing to fail on: it renders an empty tileset.
+    #[test]
+    fn an_empty_selection_renders_an_empty_tileset() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let view = tileset_to(dir.path(), &[], &ViewOptions::default());
+
+        assert_eq!(view.rendered_features, 0);
+        assert!(dir.path().join("out/tileset.json").exists());
     }
 
     /// Every selection mode must agree on what row N is, and a filter must not
@@ -1178,17 +1206,26 @@ mod tests {
             .any(|uri| uri.as_str().contains("/out/content/")));
     }
 
+    /// A row with nothing to draw is an error naming the row, and no glb is
+    /// left behind.
     #[test]
-    fn a_feature_without_geometry_writes_nothing() {
+    fn a_feature_without_geometry_is_an_error_and_writes_nothing() {
         let dir = tempfile::tempdir().expect("temp dir");
+        let root = Uri::for_test(&format!("file://{}", dir.path().display()));
+        let resolver = StorageResolver::new();
         let selected = Selected {
-            row: 0,
+            row: 3,
             feature: Feature::from(Attributes::new()),
         };
-        let view = feature_to(dir.path(), &selected, &ViewOptions::default());
 
-        assert_eq!(view.rendered_features, 0);
-        assert!(view.entry_point.is_none());
-        assert!(view.written.is_empty());
+        let error = render_feature(
+            &selected,
+            &ViewOptions::default(),
+            &destination(&root, &resolver),
+        )
+        .expect_err("nothing to draw");
+
+        assert!(matches!(error, Error::RowUndrawable { row: 3 }));
+        assert!(!dir.path().join("out.glb").exists());
     }
 }

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -534,7 +534,7 @@ impl Euclidean2DGeometry {
 
     /// The 3D counterpart of this geometry, with every coordinate placed at the
     /// elevation its leaf lies at, or at `0.0` where there is none.
-    pub(crate) fn into_3d(self) -> Euclidean3DGeometry {
+    pub fn into_3d(self) -> Euclidean3DGeometry {
         match self {
             Self::Point(g) => Euclidean3DGeometry::Point(g.into_3d()),
             Self::LineString(g) => Euclidean3DGeometry::LineString(g.into_3d()),
@@ -917,6 +917,88 @@ impl Geometry {
             Geometry::Euclidean3D(g) => Ok(Geometry::Euclidean2D(g.force_2d()?)),
             Geometry::GeometryCollection(c) => Ok(Geometry::GeometryCollection(c.force_2d()?)),
         }
+    }
+}
+
+impl Geometry {
+    /// Lift every 2D-embedded leaf into 3D, recursing into collection members.
+    /// A 3D leaf, and an absent geometry, pass through unchanged, so a
+    /// cross-dimensional collection comes back wholly 3D.
+    ///
+    /// See [`Euclidean2DGeometry::into_3d`] for the elevation each lifted
+    /// coordinate takes. The frame is untouched: a leaf in a 2D CRS keeps that
+    /// CRS, with its heights read as that CRS's ellipsoidal heights.
+    pub fn into_3d(self) -> Geometry {
+        match self {
+            Geometry::None => Geometry::None,
+            Geometry::Euclidean2D(g) => Geometry::Euclidean3D(g.into_3d()),
+            Geometry::Euclidean3D(g) => Geometry::Euclidean3D(g),
+            Geometry::GeometryCollection(c) => Geometry::GeometryCollection(c.into_3d()),
+        }
+    }
+}
+
+impl GeometryCollection {
+    /// Lift every member into 3D. Members may differ in coordinate frame, so
+    /// each is lifted on its own.
+    fn into_3d(self) -> GeometryCollection {
+        GeometryCollection {
+            members: self.members.into_iter().map(Geometry::into_3d).collect(),
+            attrs: self.attrs,
+        }
+    }
+}
+
+#[cfg(test)]
+mod into_3d_tests {
+    use super::*;
+    use coordinate::{CoordinateFrame, EpsgCode};
+    use line_string::{LineString2D, LineString3D};
+    use point::{Point2D, Point3D};
+
+    fn crs() -> CoordinateFrame {
+        CoordinateFrame::Crs(EpsgCode::new(4326))
+    }
+
+    /// A cross-dimensional collection comes back wholly 3D: the 2.5D member at
+    /// the elevation it lay at, the pure-2D member at 0, the 3D member as it was.
+    #[test]
+    fn a_cross_dimensional_collection_lifts_every_2d_member() {
+        let already_3d = Point3D::new(crs(), [35.0, 139.0, 7.0]);
+        let collection = Geometry::GeometryCollection(GeometryCollection::new([
+            Geometry::Euclidean2D(Euclidean2DGeometry::LineString(
+                LineString2D::from_coords_at_elevation(crs(), [[35.0, 139.0], [36.0, 140.0]], 25.0),
+            )),
+            Geometry::Euclidean2D(Euclidean2DGeometry::Point(Point2D::new(
+                crs(),
+                [35.0, 139.0],
+            ))),
+            Geometry::Euclidean3D(Euclidean3DGeometry::Point(already_3d.clone())),
+        ]));
+
+        let Geometry::GeometryCollection(lifted) = collection.into_3d() else {
+            panic!("a collection stays a collection");
+        };
+
+        assert_eq!(
+            lifted.members(),
+            [
+                Geometry::Euclidean3D(Euclidean3DGeometry::LineString(LineString3D::from_coords(
+                    crs(),
+                    [[35.0, 139.0, 25.0], [36.0, 140.0, 25.0]],
+                ))),
+                Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
+                    crs(),
+                    [35.0, 139.0, 0.0]
+                ))),
+                Geometry::Euclidean3D(Euclidean3DGeometry::Point(already_3d)),
+            ]
+        );
+    }
+
+    #[test]
+    fn an_absent_geometry_lifts_to_itself() {
+        assert_eq!(Geometry::None.into_3d(), Geometry::None);
     }
 }
 

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.170"
+version = "0.2.171"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.360"
+version = "0.1.361"
 edition = "2021"
 
 [features]

--- a/engine/tools/action-tracing-allowlist.txt
+++ b/engine/tools/action-tracing-allowlist.txt
@@ -34,7 +34,7 @@ runtime/action-sink/src/file/citygml.rs:6
 runtime/action-sink/src/file/csv.rs:2
 runtime/action-sink/src/file/geojson.rs:3
 runtime/action-sink/src/file/gltf.rs:1
-runtime/action-sink/src/file/mvt/next/extract.rs:6
+runtime/action-sink/src/file/mvt/next/extract.rs:5
 runtime/action-sink/src/file/mvt/next/slice.rs:2
 runtime/action-sink/src/file/mvt/pipeline.rs:4
 runtime/action-sink/src/file/mvt/sink.rs:10


### PR DESCRIPTION
# Overview
This PR implements 2D view for the intermediate data. It only supports new geometry. 

## Spec
- For 2D, there is no "local view" that shows the per-feature geometry, as the "global view", which shows the geometries of the whole intermediate data, is always light-weight.
- The geometry dimension is automatically detected from the data, and the view will be 3DTiles when at least one geometry is 3D and will be MVT otherwise. When 2D and 3D geometries are mixed, then the 2D geometry is forced to be 3D, with the elevation into account.
- Non-CRS geometry is not supported and is dropped on write. Non-renderable geometry, such CSGs, will be dropped as well. The drop is intended, because the dropping the feature just mean the no geometry for that feature is shown in the view, but the data itself remains in the table, so it's never a data loss. The writer does throw an error when all the features are either Non-CRS or non-renderable geometry.
- Same as 3DTiles output, the MVT tiles also carry feature ID, which is the row number for the tabular data, which would be useful for the geometry selection.

## Other fixes
- A parameter validation is added for MVT writer.
- the CLI API renames `view 3dtiles` to `view tiles` since now it might spit out MVT.