### PR TITLE
feat(engine): run destination mesh code check on new geometry

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.168"
+version = "0.2.169"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "approx",
  "async-trait",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "Inflector",
  "approx",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4961,7 +4961,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5012,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "bytes",
  "clap",
@@ -5065,7 +5065,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-diagnostics"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5163,7 +5163,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5180,7 +5180,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "approx",
  "bvh",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5256,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5265,7 +5265,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5297,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5351,7 +5351,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5365,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "bytes",
  "futures",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "bytes",
  "futures",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5415,7 +5415,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5453,7 +5453,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "ahash",
  "bytes",
@@ -5489,7 +5489,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.545"
+version = "0.0.546"
 dependencies = [
  "async-trait",
  "axum",
@@ -8257,7 +8257,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.358"
+version = "0.1.359"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.545"
+version = "0.0.546"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/action-plateau-processor/src/common/destination_mesh_code_extractor.rs
+++ b/engine/runtime/action-plateau-processor/src/common/destination_mesh_code_extractor.rs
@@ -1,11 +1,24 @@
 use std::{cell::RefCell, collections::HashMap, sync::Arc};
 
+#[cfg(not(feature = "new-geometry"))]
 use reearth_flow_geometry::algorithm::{
     area2d::Area2D, bool_ops::BooleanOps, bounding_rect::BoundingRect,
 };
-use reearth_flow_geometry::types::{
-    coordinate::Coordinate2D, geometry::Geometry2D, polygon::Polygon2D, rect::Rect2D,
+#[cfg(not(feature = "new-geometry"))]
+use reearth_flow_geometry::types::{geometry::Geometry2D, polygon::Polygon2D};
+#[cfg(feature = "new-geometry")]
+use reearth_flow_geometry::{
+    collection::Collection2D,
+    coordinate::{CoordinateFrame, EpsgCode},
+    line_string::LineString2D,
+    ops::{reproject::transform_coords_3d, Aabb, BoundingBox, ReprojectionCache},
+    overlay::{overlay_2d, OverlayOp},
+    polygon::Polygon2D,
+    predicates::view::{flatten_2d, Leaf2D},
+    Euclidean2DGeometry, Geometry,
 };
+// The mesh grid is still described with the pre-migration rectangle types.
+use reearth_flow_geometry::types::{coordinate::Coordinate2D, rect::Rect2D};
 use reearth_flow_runtime::node::REJECTED_PORT;
 use reearth_flow_runtime::{
     errors::BoxedError,
@@ -15,9 +28,9 @@ use reearth_flow_runtime::{
     node::{Port, Processor, ProcessorFactory, FEATURES_PORT},
 };
 use reearth_flow_types::jpmesh::{JPMeshCode, JPMeshType};
-use reearth_flow_types::{
-    Attribute, AttributeValue, Code, CodeType, CompiledCode, Feature, GeometryValue,
-};
+#[cfg(not(feature = "new-geometry"))]
+use reearth_flow_types::GeometryValue;
+use reearth_flow_types::{Attribute, AttributeValue, Code, CodeType, CompiledCode, Feature};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Number;
@@ -30,6 +43,7 @@ use super::PlateauProfile;
 // Stores both forward (6697 -> target) and inverse (target -> 6697) projections.
 // Each thread maintains its own cache to ensure thread-safety without requiring
 // unsafe Send/Sync implementations on types containing proj::Proj.
+#[cfg(not(feature = "new-geometry"))]
 thread_local! {
     // Cache for forward projections: 6697 -> target EPSG
     static PROJ_TO_CACHE: RefCell<HashMap<String, proj::Proj>> = RefCell::new(HashMap::new());
@@ -173,6 +187,7 @@ pub struct DestinationMeshCodeExtractor {
     epsg_code_ast: CompiledCode,
 }
 
+#[cfg(not(feature = "new-geometry"))]
 /// Helper function to ensure proj instances exist in thread-local cache for the given EPSG code.
 fn ensure_proj_cached(epsg_code: &str) -> Result<(), BoxedError> {
     use std::collections::hash_map::Entry;
@@ -241,29 +256,7 @@ impl Processor for DestinationMeshCodeExtractor {
                     return Ok(());
                 };
 
-                let mut new_feature = feature.clone();
-                new_feature.attributes_mut().insert(
-                    Attribute::new(&self.meshcode_attr),
-                    AttributeValue::String(mesh_result.selected_mesh.to_number().to_string()),
-                );
-                new_feature.attributes_mut().insert(
-                    Attribute::new("_mesh_count"),
-                    AttributeValue::Number(Number::from(mesh_result.mesh_count)),
-                );
-                new_feature.attributes_mut().insert(
-                    Attribute::new("__area"),
-                    AttributeValue::Number(
-                        Number::from_f64(mesh_result.max_area).unwrap_or(Number::from(0)),
-                    ),
-                );
-                new_feature.attributes_mut().insert(
-                    Attribute::new("_meshcode_to_area"),
-                    AttributeValue::String(
-                        serde_json::to_string(&mesh_result.meshcode_to_area)
-                            .unwrap_or(String::new()),
-                    ),
-                );
-
+                let new_feature = self.with_mesh_attributes(feature, &mesh_result);
                 fw.send(ctx.new_with_feature_and_port(new_feature, FEATURES_PORT.clone()));
             }
             _ => {
@@ -273,7 +266,57 @@ impl Processor for DestinationMeshCodeExtractor {
         Ok(())
     }
 
-    #[cfg(not(feature = "new-geometry"))]
+    #[cfg(feature = "new-geometry")]
+    fn process(
+        &mut self,
+        ctx: ExecutorContext,
+        fw: &ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        let feature = &ctx.feature;
+        let epsg_code = self.evaluate_epsg_code(feature, ctx.variables.clone())?;
+        let epsg = epsg_code
+            .trim()
+            .parse::<u16>()
+            .map(EpsgCode::new)
+            .map_err(|e| {
+                PlateauProcessorError::DestinationMeshCodeExtractor(format!(
+                    "epsg_code expression ({epsg_code}) is not an EPSG code: {e}"
+                ))
+            })?;
+
+        // The footprint must already be a flat areal geometry in `epsg`: this
+        // action measures intersection areas in that projected space and never
+        // reprojects the feature itself.
+        let mesh_result = match feature.geometry.as_ref() {
+            Geometry::Euclidean2D(geometry) => {
+                match areal_operand(geometry, &CoordinateFrame::Crs(epsg)) {
+                    Some(area) => self.calculate_mesh(&area, epsg),
+                    None => Ok(None),
+                }
+            }
+            _ => Ok(None),
+        };
+        let mesh_result = match mesh_result {
+            Ok(Some(result)) => result,
+            Ok(None) => {
+                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+                return Ok(());
+            }
+            Err(e) => {
+                ctx.event_hub.warn_log(
+                    Some(ctx.error_span()),
+                    format!("mesh code extraction failed: {e}"),
+                );
+                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+                return Ok(());
+            }
+        };
+
+        let new_feature = self.with_mesh_attributes(feature, &mesh_result);
+        fw.send(ctx.new_with_feature_and_port(new_feature, FEATURES_PORT.clone()));
+        Ok(())
+    }
+
     fn finish(
         &mut self,
         _ctx: NodeContext,
@@ -328,6 +371,36 @@ impl DestinationMeshCodeExtractor {
         }
     }
 
+    /// A copy of the feature carrying the mesh result: the chosen mesh code,
+    /// how many meshes it spans, the area inside the chosen one, and the full
+    /// mesh-to-area mapping as JSON.
+    fn with_mesh_attributes(&self, feature: &Feature, result: &MeshCalculationResult) -> Feature {
+        let mut feature = feature.clone();
+        let attributes = feature.attributes_mut();
+        attributes.insert(
+            Attribute::new(&self.meshcode_attr),
+            AttributeValue::String(result.selected_mesh.to_number().to_string()),
+        );
+        attributes.insert(
+            Attribute::new("_mesh_count"),
+            AttributeValue::Number(Number::from(result.mesh_count)),
+        );
+        attributes.insert(
+            Attribute::new("__area"),
+            AttributeValue::Number(Number::from_f64(result.max_area).unwrap_or(Number::from(0))),
+        );
+        attributes.insert(
+            Attribute::new("_meshcode_to_area"),
+            AttributeValue::String(
+                serde_json::to_string(&result.meshcode_to_area).unwrap_or_default(),
+            ),
+        );
+        feature
+    }
+}
+
+#[cfg(not(feature = "new-geometry"))]
+impl DestinationMeshCodeExtractor {
     /// Calculate mesh code with detailed information for all required attributes
     /// Returns comprehensive mesh calculation result including count, areas, and mapping
     /// Uses thread-local cached proj instances for coordinate transformations
@@ -564,7 +637,229 @@ impl DestinationMeshCodeExtractor {
     }
 }
 
-#[cfg(test)]
+/// The geographic CRS the Japanese mesh grid is described in: the 2D horizontal
+/// counterpart of EPSG:6697, sharing its datum and its `[latitude, longitude]`
+/// axis order. [`JPMeshCode`], in contrast, works in `(x = longitude,
+/// y = latitude)`, so coordinates are swapped at every crossing between them.
+#[cfg(feature = "new-geometry")]
+const GEOGRAPHIC_EPSG: EpsgCode = EpsgCode::new(6668);
+
+/// How many pieces each edge of a mesh cell is cut into before it is projected.
+#[cfg(feature = "new-geometry")]
+const SEGMENTS_PER_EDGE: usize = 16;
+
+#[cfg(feature = "new-geometry")]
+thread_local! {
+    /// The live PROJ transforms, kept off the `Processor` (which must be
+    /// `Send + Sync + Clone`) because they wrap non-shareable PROJ pointers.
+    /// One per direction: a cache holds a single `(from, to)` pair, so sharing
+    /// one between the two directions would rebuild the transform every call.
+    static TO_GEOGRAPHIC: RefCell<ReprojectionCache> = RefCell::new(ReprojectionCache::new());
+    static FROM_GEOGRAPHIC: RefCell<ReprojectionCache> = RefCell::new(ReprojectionCache::new());
+}
+
+#[cfg(feature = "new-geometry")]
+impl DestinationMeshCodeExtractor {
+    /// The mesh the footprint belongs to, together with the per-mesh
+    /// intersection areas behind that choice. `None` when it meets no mesh.
+    ///
+    /// Areas are measured in `epsg`, the projected CRS the footprint is already
+    /// expressed in, so they come out in square metres.
+    fn calculate_mesh(
+        &self,
+        area: &Euclidean2DGeometry,
+        epsg: EpsgCode,
+    ) -> Result<Option<MeshCalculationResult>, BoxedError> {
+        let Ok(Aabb::D2 { min, max }) = area.bounding_box() else {
+            return Ok(None);
+        };
+        let bounds = geographic_bounds(min, max, epsg)?;
+        let frame = CoordinateFrame::Crs(epsg);
+
+        let mut max_area = 0.0f64;
+        let mut selected_mesh: Option<JPMeshCode> = None;
+        let mut selected_number = u64::MAX;
+        let mut meshcode_to_area = Vec::new();
+        let mut mesh_count = 0usize;
+
+        for mesh_code in JPMeshCode::from_inside_bounds(bounds, self.mesh_type) {
+            let mesh = mesh_face(&mesh_code.bounds(), epsg, &frame)?;
+            let mesh = Euclidean2DGeometry::Polygon(Box::new(mesh));
+            let number = mesh_code.to_number();
+            let pieces = overlay_2d(area, &mesh, OverlayOp::Intersection).map_err(|e| {
+                PlateauProcessorError::DestinationMeshCodeExtractor(format!(
+                    "Failed to intersect the footprint with mesh {number}: {e}"
+                ))
+            })?;
+            let intersection: f64 = pieces.iter().map(Polygon2D::area).sum();
+            // Two decimal places, as the PLATEAU specification reports them.
+            let area = (intersection * 100.0).round() / 100.0;
+            if area <= 0.0 {
+                continue;
+            }
+
+            mesh_count += 1;
+            meshcode_to_area.push(MeshCodeToArea {
+                mesh_code: number,
+                area,
+            });
+            // The largest area wins; the smaller mesh code breaks a tie.
+            if area > max_area || (area == max_area && number < selected_number) {
+                max_area = area;
+                selected_mesh = Some(mesh_code);
+                selected_number = number;
+            }
+        }
+
+        Ok(selected_mesh.map(|mesh| MeshCalculationResult {
+            selected_mesh: mesh,
+            mesh_count,
+            max_area,
+            meshcode_to_area,
+        }))
+    }
+}
+
+/// The geometry as an areal operand, or `None` when it is not one: an empty
+/// geometry, a leaf outside `frame`, a leaf raised to an elevation, or a leaf
+/// that encloses no area.
+#[cfg(feature = "new-geometry")]
+fn areal_operand(
+    geometry: &Euclidean2DGeometry,
+    frame: &CoordinateFrame,
+) -> Option<Euclidean2DGeometry> {
+    let mut leaves = Vec::new();
+    flatten_2d(geometry, &mut leaves);
+    if leaves.is_empty() {
+        return None;
+    }
+    for leaf in &leaves {
+        if leaf.frame() != frame || leaf_elevation(leaf).is_some() {
+            return None;
+        }
+        match leaf {
+            Leaf2D::Polygon(_) | Leaf2D::PolygonMesh(_) | Leaf2D::TriangularMesh(_) => {}
+            Leaf2D::Line(line) if is_closed_ring(line) => {}
+            _ => return None,
+        }
+    }
+    Some(as_faces(geometry))
+}
+
+/// The elevation the leaf lies at, if it carries one.
+#[cfg(feature = "new-geometry")]
+fn leaf_elevation(leaf: &Leaf2D<'_>) -> Option<f64> {
+    match leaf {
+        Leaf2D::Point(_) => None,
+        Leaf2D::Line(l) => l.elevation(),
+        Leaf2D::Polygon(p) => p.elevation(),
+        Leaf2D::PolygonMesh(m) => m.elevation(),
+        Leaf2D::TriangularMesh(m) => m.elevation(),
+    }
+}
+
+/// Whether the line string traces a ring: closed, and enclosing something.
+#[cfg(feature = "new-geometry")]
+fn is_closed_ring(line: &LineString2D) -> bool {
+    let coords = line.coords();
+    coords.len() >= 4 && coords.first() == coords.last()
+}
+
+/// The geometry with every closed line string replaced by the face it traces,
+/// leaving the other members as they are. Boolean overlay takes areal leaves
+/// only.
+#[cfg(feature = "new-geometry")]
+fn as_faces(geometry: &Euclidean2DGeometry) -> Euclidean2DGeometry {
+    match geometry {
+        Euclidean2DGeometry::LineString(line) => {
+            Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings(
+                line.frame().clone(),
+                line.coords().iter().copied(),
+                Vec::<Vec<[f64; 2]>>::new(),
+            )))
+        }
+        Euclidean2DGeometry::Collection(collection) => Euclidean2DGeometry::Collection(
+            Collection2D::new(collection.members().iter().map(as_faces)),
+        ),
+        other => other.clone(),
+    }
+}
+
+/// A projected bounding box carried back to the mesh grid's geographic space,
+/// as the `(longitude, latitude)` rectangle [`JPMeshCode`] expects.
+#[cfg(feature = "new-geometry")]
+fn geographic_bounds(
+    min: [f64; 2],
+    max: [f64; 2],
+    epsg: EpsgCode,
+) -> Result<Rect2D<f64>, BoxedError> {
+    let mut corners = [[min[0], min[1], 0.0], [max[0], max[1], 0.0]];
+    TO_GEOGRAPHIC
+        .with(|cache| {
+            transform_coords_3d(&mut cache.borrow_mut(), epsg, GEOGRAPHIC_EPSG, &mut corners)
+        })
+        .map_err(|e| {
+            PlateauProcessorError::DestinationMeshCodeExtractor(format!(
+                "Failed to transform the footprint bounds from EPSG:{epsg} to EPSG:{GEOGRAPHIC_EPSG}: {e}"
+            ))
+        })?;
+    Ok(Rect2D::new(
+        Coordinate2D::new_(corners[0][1], corners[0][0]),
+        Coordinate2D::new_(corners[1][1], corners[1][0]),
+    ))
+}
+
+/// One mesh cell as a face in `frame`, its edges subdivided before projection.
+///
+/// A cell is bounded by lines of constant latitude and longitude, which curve
+/// under a Transverse Mercator projection. Straight edges between the four
+/// corners would cut into the cell, so intermediate vertices are added while
+/// the ring is still geographic.
+#[cfg(feature = "new-geometry")]
+fn mesh_face(
+    bounds: &Rect2D<f64>,
+    epsg: EpsgCode,
+    frame: &CoordinateFrame,
+) -> Result<Polygon2D, BoxedError> {
+    let (min_lng, min_lat) = (bounds.min().x, bounds.min().y);
+    let (max_lng, max_lat) = (bounds.max().x, bounds.max().y);
+    let step = |i: usize| i as f64 / SEGMENTS_PER_EDGE as f64;
+
+    // South, east, north then west edge: counter-clockwise seen in
+    // (East, North). Vertices are held as [latitude, longitude], the geographic
+    // CRS's declared axis order, ready for the transform.
+    let mut ring = Vec::with_capacity(4 * SEGMENTS_PER_EDGE + 1);
+    for i in 0..SEGMENTS_PER_EDGE {
+        ring.push([min_lat, min_lng + step(i) * (max_lng - min_lng), 0.0]);
+    }
+    for i in 0..SEGMENTS_PER_EDGE {
+        ring.push([min_lat + step(i) * (max_lat - min_lat), max_lng, 0.0]);
+    }
+    for i in 0..SEGMENTS_PER_EDGE {
+        ring.push([max_lat, max_lng - step(i) * (max_lng - min_lng), 0.0]);
+    }
+    for i in 0..SEGMENTS_PER_EDGE {
+        ring.push([max_lat - step(i) * (max_lat - min_lat), min_lng, 0.0]);
+    }
+    ring.push(ring[0]);
+
+    FROM_GEOGRAPHIC
+        .with(|cache| {
+            transform_coords_3d(&mut cache.borrow_mut(), GEOGRAPHIC_EPSG, epsg, &mut ring)
+        })
+        .map_err(|e| {
+            PlateauProcessorError::DestinationMeshCodeExtractor(format!(
+                "Failed to transform a mesh cell from EPSG:{GEOGRAPHIC_EPSG} to EPSG:{epsg}: {e}"
+            ))
+        })?;
+
+    Ok(Polygon2D::from_rings(
+        frame.clone(),
+        ring.iter().map(|c| [c[0], c[1]]),
+        Vec::<Vec<[f64; 2]>>::new(),
+    ))
+}
+#[cfg(all(test, not(feature = "new-geometry")))]
 mod tests {
     use super::*;
 
@@ -605,5 +900,78 @@ mod tests {
             (rounded_area - EXPECTED_AREA).abs() < 0.0001,
             "Calculated area {rounded_area} should be close to expected area 9.1410"
         );
+    }
+}
+
+#[cfg(all(test, feature = "new-geometry"))]
+mod tests {
+    use super::*;
+
+    /// Real coordinates from the `Z-bldg-03_meshcode-extractor_01` fixture, as
+    /// `(longitude, latitude)`. Its expected CSV row is mesh 54377085 covering
+    /// 9.14 m², a value originally obtained from the original implementation.
+    const FOOTPRINT: [(f64, f64); 5] = [
+        (137.07022204628032, 36.65423985231743),
+        (137.07018801464667, 36.65426289610968),
+        (137.0701714804155, 36.654247021162256),
+        (137.07020551204704, 36.65422397737467),
+        (137.07022204628032, 36.65423985231743),
+    ];
+
+    const PRCS: EpsgCode = EpsgCode::new(6675);
+
+    /// A ring of `(longitude, latitude)` pairs as a footprint projected into
+    /// EPSG:6675, the shape the workflow hands this action.
+    fn footprint_in_prcs(ring: &[(f64, f64)]) -> Euclidean2DGeometry {
+        let mut coords: Vec<[f64; 3]> = ring.iter().map(|&(lng, lat)| [lat, lng, 0.0]).collect();
+        FROM_GEOGRAPHIC
+            .with(|cache| {
+                transform_coords_3d(&mut cache.borrow_mut(), GEOGRAPHIC_EPSG, PRCS, &mut coords)
+            })
+            .expect("projection into EPSG:6675");
+        Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings(
+            CoordinateFrame::Crs(PRCS),
+            coords.iter().map(|c| [c[0], c[1]]),
+            Vec::<Vec<[f64; 2]>>::new(),
+        )))
+    }
+
+    fn extractor() -> DestinationMeshCodeExtractor {
+        DestinationMeshCodeExtractor {
+            mesh_type: JPMeshType::Mesh1km,
+            meshcode_attr: default_meshcode_attr(),
+            epsg_code_ast: default_epsg_code().compile().unwrap(),
+        }
+    }
+
+    #[test]
+    fn coordinates_keep_each_crs_declared_axis_order() {
+        let geometry = footprint_in_prcs(&FOOTPRINT);
+        let Ok(Aabb::D2 { min, max }) = geometry.bounding_box() else {
+            panic!("the footprint has no 2D bounding box");
+        };
+        // EPSG:6675's origin is 36°N 137°10′E, so this footprint sits ~72.6 km
+        // north and ~8.6 km west of it, stored [northing, easting].
+        assert!((min[0] - 72_580.0).abs() < 200.0, "northing was {}", min[0]);
+        assert!((min[1] + 8_620.0).abs() < 200.0, "easting was {}", min[1]);
+
+        // Back in geographic space the rectangle is (longitude, latitude),
+        // which is what JPMeshCode reads.
+        let bounds = geographic_bounds(min, max, PRCS).expect("inverse projection");
+        assert!((bounds.min().x - 137.0701714804155).abs() < 1e-7);
+        assert!((bounds.min().y - 36.65422397737467).abs() < 1e-7);
+    }
+
+    #[test]
+    fn selects_the_mesh_the_footprint_lies_in() {
+        let result = extractor()
+            .calculate_mesh(&footprint_in_prcs(&FOOTPRINT), PRCS)
+            .expect("mesh calculation")
+            .expect("the footprint meets a mesh");
+
+        assert_eq!(result.selected_mesh.to_number(), 54377085);
+        assert_eq!(result.mesh_count, 1);
+        assert_eq!(result.max_area, 9.14);
+        assert_eq!(result.meshcode_to_area.len(), 1);
     }
 }

--- a/engine/runtime/action-plateau-processor/src/common/destination_mesh_code_extractor.rs
+++ b/engine/runtime/action-plateau-processor/src/common/destination_mesh_code_extractor.rs
@@ -749,13 +749,22 @@ fn areal_operand(
 
 /// A projected bounding box carried back to the mesh grid's geographic space,
 /// as the `(longitude, latitude)` rectangle [`JPMeshCode`] expects.
+///
+/// All four corners are transformed: the projection is not axis-aligned with
+/// the graticule, so two opposite corners alone would leave out the extremes
+/// reached by the other two.
 #[cfg(feature = "new-geometry")]
 fn geographic_bounds(
     min: [f64; 2],
     max: [f64; 2],
     epsg: EpsgCode,
 ) -> Result<Rect2D<f64>, BoxedError> {
-    let mut corners = [[min[0], min[1], 0.0], [max[0], max[1], 0.0]];
+    let mut corners = [
+        [min[0], min[1], 0.0],
+        [min[0], max[1], 0.0],
+        [max[0], min[1], 0.0],
+        [max[0], max[1], 0.0],
+    ];
     TO_GEOGRAPHIC
         .with(|cache| {
             transform_coords_3d(&mut cache.borrow_mut(), epsg, GEOGRAPHIC_EPSG, &mut corners)
@@ -765,9 +774,19 @@ fn geographic_bounds(
                 "Failed to transform the footprint bounds from EPSG:{epsg} to EPSG:{GEOGRAPHIC_EPSG}: {e}"
             ))
         })?;
+    let mut min_lng = f64::INFINITY;
+    let mut min_lat = f64::INFINITY;
+    let mut max_lng = f64::NEG_INFINITY;
+    let mut max_lat = f64::NEG_INFINITY;
+    for [lat, lng, _] in corners {
+        min_lng = min_lng.min(lng);
+        max_lng = max_lng.max(lng);
+        min_lat = min_lat.min(lat);
+        max_lat = max_lat.max(lat);
+    }
     Ok(Rect2D::new(
-        Coordinate2D::new_(corners[0][1], corners[0][0]),
-        Coordinate2D::new_(corners[1][1], corners[1][0]),
+        Coordinate2D::new_(min_lng, min_lat),
+        Coordinate2D::new_(max_lng, max_lat),
     ))
 }
 

--- a/engine/runtime/action-plateau-processor/src/common/destination_mesh_code_extractor.rs
+++ b/engine/runtime/action-plateau-processor/src/common/destination_mesh_code_extractor.rs
@@ -10,8 +10,7 @@ use reearth_flow_geometry::types::{geometry::Geometry2D, polygon::Polygon2D};
 use reearth_flow_geometry::{
     collection::Collection2D,
     coordinate::{CoordinateFrame, EpsgCode},
-    line_string::LineString2D,
-    ops::{reproject::transform_coords_3d, Aabb, BoundingBox, ReprojectionCache},
+    ops::{reproject::transform_coords_3d, Aabb, BoundingBox, Elevation, ReprojectionCache},
     overlay::{overlay_2d, OverlayOp},
     polygon::Polygon2D,
     predicates::view::{flatten_2d, Leaf2D},
@@ -734,35 +733,16 @@ fn areal_operand(
         return None;
     }
     for leaf in &leaves {
-        if leaf.frame() != frame || leaf_elevation(leaf).is_some() {
+        if leaf.frame() != frame || leaf.elevation().is_some() {
             return None;
         }
         match leaf {
             Leaf2D::Polygon(_) | Leaf2D::PolygonMesh(_) | Leaf2D::TriangularMesh(_) => {}
-            Leaf2D::Line(line) if is_closed_ring(line) => {}
+            Leaf2D::Line(line) if line.is_closed_ring() => {}
             _ => return None,
         }
     }
     Some(as_faces(geometry))
-}
-
-/// The elevation the leaf lies at, if it carries one.
-#[cfg(feature = "new-geometry")]
-fn leaf_elevation(leaf: &Leaf2D<'_>) -> Option<f64> {
-    match leaf {
-        Leaf2D::Point(_) => None,
-        Leaf2D::Line(l) => l.elevation(),
-        Leaf2D::Polygon(p) => p.elevation(),
-        Leaf2D::PolygonMesh(m) => m.elevation(),
-        Leaf2D::TriangularMesh(m) => m.elevation(),
-    }
-}
-
-/// Whether the line string traces a ring: closed, and enclosing something.
-#[cfg(feature = "new-geometry")]
-fn is_closed_ring(line: &LineString2D) -> bool {
-    let coords = line.coords();
-    coords.len() >= 4 && coords.first() == coords.last()
 }
 
 /// The geometry with every closed line string replaced by the face it traces,

--- a/engine/runtime/action-plateau-processor/src/common/destination_mesh_code_extractor.rs
+++ b/engine/runtime/action-plateau-processor/src/common/destination_mesh_code_extractor.rs
@@ -8,9 +8,11 @@ use reearth_flow_geometry::algorithm::{
 use reearth_flow_geometry::types::{geometry::Geometry2D, polygon::Polygon2D};
 #[cfg(feature = "new-geometry")]
 use reearth_flow_geometry::{
-    collection::Collection2D,
     coordinate::{CoordinateFrame, EpsgCode},
-    ops::{reproject::transform_coords_3d, Aabb, BoundingBox, Elevation, ReprojectionCache},
+    ops::{
+        reproject::transform_coords_3d, rings_as_faces_2d, Aabb, BoundingBox, Elevation,
+        ReprojectionCache,
+    },
     overlay::{overlay_2d, OverlayOp},
     polygon::Polygon2D,
     predicates::view::{flatten_2d, Leaf2D},
@@ -742,27 +744,7 @@ fn areal_operand(
             _ => return None,
         }
     }
-    Some(as_faces(geometry))
-}
-
-/// The geometry with every closed line string replaced by the face it traces,
-/// leaving the other members as they are. Boolean overlay takes areal leaves
-/// only.
-#[cfg(feature = "new-geometry")]
-fn as_faces(geometry: &Euclidean2DGeometry) -> Euclidean2DGeometry {
-    match geometry {
-        Euclidean2DGeometry::LineString(line) => {
-            Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings(
-                line.frame().clone(),
-                line.coords().iter().copied(),
-                Vec::<Vec<[f64; 2]>>::new(),
-            )))
-        }
-        Euclidean2DGeometry::Collection(collection) => Euclidean2DGeometry::Collection(
-            Collection2D::new(collection.members().iter().map(as_faces)),
-        ),
-        other => other.clone(),
-    }
+    Some(rings_as_faces_2d(geometry))
 }
 
 /// A projected bounding box carried back to the mesh grid's geographic space,

--- a/engine/runtime/action-processor/src/geometry/area_on_area_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/area_on_area_overlayer.rs
@@ -37,8 +37,7 @@ use reearth_flow_types::{Geometry, GeometryValue};
 use reearth_flow_geometry::{
     collection::Collection2D,
     coordinate::CoordinateFrame,
-    line_string::LineString2D,
-    ops::{Aabb, BoundingBox, Elevation},
+    ops::{rings_as_faces_2d, Aabb, BoundingBox, Elevation},
     overlay::{overlay_2d, snap_areal_operands_2d, OverlayOp},
     polygon::Polygon2D,
     predicates::view::{flatten_2d, Leaf2D},
@@ -730,37 +729,7 @@ fn read_working_area(disk_feats: &DiskBackedFeatures, i: usize) -> Option<Workin
     let Geometry::Euclidean2D(geom_2d) = geometry.as_ref() else {
         return None;
     };
-    Some(normalize_area(geom_2d))
-}
-
-/// The geometry with closed line strings replaced by the polygon faces they
-/// trace; every other member is kept verbatim.
-#[cfg(feature = "new-geometry")]
-fn normalize_area(geom: &Euclidean2DGeometry) -> Euclidean2DGeometry {
-    match geom {
-        Euclidean2DGeometry::LineString(line) if line.is_closed_ring() => {
-            Euclidean2DGeometry::Polygon(Box::new(ring_face(line)))
-        }
-        Euclidean2DGeometry::Collection(collection) => {
-            let members: Vec<_> = collection.members().iter().map(normalize_area).collect();
-            let attrs = collection.member_attributes().to_vec();
-            Euclidean2DGeometry::Collection(
-                Collection2D::with_attributes(members, attrs)
-                    .expect("member count is unchanged by normalization"),
-            )
-        }
-        other => other.clone(),
-    }
-}
-
-/// The polygon face a closed line string traces.
-#[cfg(feature = "new-geometry")]
-fn ring_face(line: &LineString2D) -> Polygon2D {
-    Polygon2D::from_rings(
-        line.frame().clone(),
-        line.coords().iter().copied(),
-        Vec::<Vec<[f64; 2]>>::new(),
-    )
+    Some(rings_as_faces_2d(geom_2d))
 }
 
 /// Constructed polygons as one working area.
@@ -1355,6 +1324,7 @@ mod tests {
 #[cfg(all(test, feature = "new-geometry"))]
 mod tests {
     use pretty_assertions::assert_eq;
+    use reearth_flow_geometry::line_string::LineString2D;
     use reearth_flow_geometry::triangular_mesh::TriangularMesh2D;
 
     use super::*;

--- a/engine/runtime/action-processor/src/geometry/area_on_area_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/area_on_area_overlayer.rs
@@ -38,7 +38,7 @@ use reearth_flow_geometry::{
     collection::Collection2D,
     coordinate::CoordinateFrame,
     line_string::LineString2D,
-    ops::{Aabb, BoundingBox},
+    ops::{Aabb, BoundingBox, Elevation},
     overlay::{overlay_2d, snap_areal_operands_2d, OverlayOp},
     polygon::Polygon2D,
     predicates::view::{flatten_2d, Leaf2D},
@@ -696,12 +696,12 @@ fn intake(geometry: &Geometry) -> Option<([f64; 4], &CoordinateFrame)> {
     flatten_2d(geom_2d, &mut leaves);
     let frame = leaves.first()?.frame();
     for leaf in &leaves {
-        if leaf.frame() != frame || leaf_elevation(leaf).is_some() {
+        if leaf.frame() != frame || leaf.elevation().is_some() {
             return None;
         }
         match leaf {
             Leaf2D::Polygon(_) | Leaf2D::PolygonMesh(_) | Leaf2D::TriangularMesh(_) => {}
-            Leaf2D::Line(line) if is_closed_ring(line) => {}
+            Leaf2D::Line(line) if line.is_closed_ring() => {}
             _ => return None,
         }
     }
@@ -709,13 +709,6 @@ fn intake(geometry: &Geometry) -> Option<([f64; 4], &CoordinateFrame)> {
         return None;
     };
     Some(([min[0], min[1], max[0], max[1]], frame))
-}
-
-/// Whether the line string traces a closed ring that can enclose area.
-#[cfg(feature = "new-geometry")]
-fn is_closed_ring(line: &LineString2D) -> bool {
-    let coords = line.coords();
-    coords.len() >= 4 && coords.first() == coords.last()
 }
 
 /// The stored feature `i`'s geometry as a working area, or `None` when it is
@@ -745,7 +738,7 @@ fn read_working_area(disk_feats: &DiskBackedFeatures, i: usize) -> Option<Workin
 #[cfg(feature = "new-geometry")]
 fn normalize_area(geom: &Euclidean2DGeometry) -> Euclidean2DGeometry {
     match geom {
-        Euclidean2DGeometry::LineString(line) if is_closed_ring(line) => {
+        Euclidean2DGeometry::LineString(line) if line.is_closed_ring() => {
             Euclidean2DGeometry::Polygon(Box::new(ring_face(line)))
         }
         Euclidean2DGeometry::Collection(collection) => {
@@ -931,18 +924,6 @@ impl OutputShaper {
     /// Install `area` as `feature`'s geometry.
     fn apply(&mut self, feature: &mut Feature, area: WorkingArea) {
         *feature.geometry_mut() = Geometry::Euclidean2D(area);
-    }
-}
-
-/// The elevation a 2D leaf lies at, or `None` when it is planar.
-#[cfg(feature = "new-geometry")]
-fn leaf_elevation(leaf: &Leaf2D<'_>) -> Option<f64> {
-    match leaf {
-        Leaf2D::Polygon(p) => p.elevation(),
-        Leaf2D::PolygonMesh(m) => m.elevation(),
-        Leaf2D::TriangularMesh(m) => m.elevation(),
-        Leaf2D::Line(l) => l.elevation(),
-        Leaf2D::Point(_) => None,
     }
 }
 
@@ -1690,7 +1671,7 @@ mod tests {
         let mut leaves = Vec::new();
         flatten_2d(geom, &mut leaves);
         assert!(!leaves.is_empty());
-        assert!(leaves.iter().all(|l| leaf_elevation(l).is_none()));
+        assert!(leaves.iter().all(|l| l.elevation().is_none()));
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/engine/runtime/action-processor/src/geometry/dissolver.rs
+++ b/engine/runtime/action-processor/src/geometry/dissolver.rs
@@ -31,6 +31,7 @@ use reearth_flow_types::{Geometry, GeometryValue};
 use reearth_flow_geometry::{
     collection::Collection2D,
     coordinate::CoordinateFrame,
+    ops::Elevation,
     overlay::dissolve_leaves,
     polygon::Polygon2D,
     predicates::view::{flatten_2d, Leaf2D},
@@ -572,24 +573,12 @@ fn accepts(geometry: &Geometry) -> bool {
     };
     leaves.iter().all(|leaf| {
         leaf.frame() == frame
-            && leaf_elevation(leaf).is_none()
+            && leaf.elevation().is_none()
             && matches!(
                 leaf,
                 Leaf2D::Polygon(_) | Leaf2D::PolygonMesh(_) | Leaf2D::TriangularMesh(_)
             )
     })
-}
-
-/// The elevation a 2D leaf lies at, or `None` when it is planar.
-#[cfg(feature = "new-geometry")]
-fn leaf_elevation(leaf: &Leaf2D<'_>) -> Option<f64> {
-    match leaf {
-        Leaf2D::Polygon(p) => p.elevation(),
-        Leaf2D::PolygonMesh(m) => m.elevation(),
-        Leaf2D::TriangularMesh(m) => m.elevation(),
-        Leaf2D::Line(l) => l.elevation(),
-        Leaf2D::Point(_) => None,
-    }
 }
 
 /// The group's representative feature: the one covering the most area. Ties go

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
@@ -4963,7 +4963,6 @@ graphs:
         expr:
           type: flowExpr
           value: attributes.get("LOD0-1のBuildingPart", 0)
-      # 図郭不正 is kept out of totalErrorCount, matching the original implementation.
       - newAttribute: totalErrorCount
         expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
@@ -3366,6 +3366,83 @@ graphs:
     action: Output Router
     with:
       routingPort: errorCountLod0SurfaceIntersection
+  - id: 1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d
+    name: DestinationMeshCodeExtractor
+    type: action
+    action: PLATEAU4.DestinationMeshCodeExtractor
+    with:
+      meshType: 3
+      epsgCode:
+        type: flowExpr
+        value: variables.get("prcs")
+      meshcodeAttr: meshcode
+  - id: 2b3c4d5e-6f7a-4b8c-9d0e-1f2a3b4c5d6e
+    name: MeshCodeTester
+    type: action
+    action: Feature Filter
+    with:
+      conditions:
+      - expr:
+          type: flowExpr
+          value: not attributes["gmlFilename"].starts_with(attributes["meshcode"])
+        outputPort: failed
+  - id: 3c4d5e6f-7a8b-4c9d-0e1f-2a3b4c5d6e8f
+    name: AttributeMapperIncorrectMeshCode
+    type: action
+    action: Attribute Mapper
+    with:
+      mappers:
+      - attribute: gmlFilename
+        valueAttribute: gmlFilename
+      - attribute: filename
+        valueAttribute: gmlFilename
+      - attribute: feature_type
+        valueAttribute: featureType
+      - attribute: lod
+        valueAttribute: lod
+      - attribute: gml_id
+        valueAttribute: gmlId
+      - attribute: meshcode
+        valueAttribute: meshcode
+      - attribute: meshcount
+        valueAttribute: _mesh_count
+      - attribute: mesh2area
+        valueAttribute: _meshcode_to_area
+  - id: 77e7f8a9-0b1c-2d3e-4f5a-6b7c8d9e0f1a
+    name: AttributeManagerIncorrectMeshCode
+    type: action
+    action: Attribute Manager
+    with:
+      operations:
+      - attribute: gmlFilename
+        method: remove
+  - id: 4d5e6f7a-8b9c-4d0e-1f2a-3b4c5d6e7f9a
+    name: FeatureWriterIncorrectMeshCode
+    type: action
+    action: Feature Writer
+    with:
+      format: csv
+      output:
+        type: string
+        value: 02_建築物_図郭不正.csv
+  - id: 11c1d2e3-4f5a-6b7c-8d9e-0f1a2b3c4d5e
+    name: IncorrectMeshCodeCounter
+    type: action
+    action: Statistics Calculator
+    with:
+      groupBy:
+      - gmlFilename
+      calculations:
+      - newAttribute: _num_incorrect_meshcode
+        expr:
+          type: flowExpr
+          value: '1'
+  - id: 22d2e3f4-5a6b-7c8d-9e0f-1a2b3c4d5e6f
+    name: ErrorCount-IncorrectMeshCode
+    type: action
+    action: Output Router
+    with:
+      routingPort: errorCountIncorrectMeshcode
   - id: 950407af-eec5-49ee-902c-2b41f31150d3
     name: SurfaceChecksLod1
     type: subGraph
@@ -3998,6 +4075,46 @@ graphs:
     to: 5e2c9b7a-8d4f-4b1e-9c6a-3f5d8b2e7c4a
     fromPort: features
     toPort: features
+  - id: cc3dd4ee-5ff6-4aa7-9bb8-2cc9dd0ee1cc
+    from: cc3dd4ee-5ff6-4aa7-9bb8-2cc9dd0ee1aa
+    to: 1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d
+    fromPort: features
+    toPort: features
+  - id: 3c4d5e6f-7a8b-4c9d-0e1f-2a3b4c5d6e7f
+    from: 1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d
+    to: 2b3c4d5e-6f7a-4b8c-9d0e-1f2a3b4c5d6e
+    fromPort: features
+    toPort: features
+  - id: 5e6f7a8b-9c0d-4e1f-2a3b-4c5d6e7f8a9b
+    from: 2b3c4d5e-6f7a-4b8c-9d0e-1f2a3b4c5d6e
+    to: 3c4d5e6f-7a8b-4c9d-0e1f-2a3b4c5d6e8f
+    fromPort: failed
+    toPort: features
+  - id: 6f7a8b9c-0d1e-4f2a-3b4c-5d6e7f8a9b0c
+    from: 3c4d5e6f-7a8b-4c9d-0e1f-2a3b4c5d6e8f
+    to: 77e7f8a9-0b1c-2d3e-4f5a-6b7c8d9e0f1a
+    fromPort: features
+    toPort: features
+  - id: 66d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
+    from: 77e7f8a9-0b1c-2d3e-4f5a-6b7c8d9e0f1a
+    to: 4d5e6f7a-8b9c-4d0e-1f2a-3b4c5d6e7f9a
+    fromPort: features
+    toPort: features
+  - id: 7a8b9c0d-1e2f-403b-4c5d-6e7f8a9b0c1d
+    from: 4d5e6f7a-8b9c-4d0e-1f2a-3b4c5d6e7f9a
+    to: 5e2c9b7a-8d4f-4b1e-9c6a-3f5d8b2e7c4a
+    fromPort: features
+    toPort: features
+  - id: 88f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
+    from: 3c4d5e6f-7a8b-4c9d-0e1f-2a3b4c5d6e8f
+    to: 11c1d2e3-4f5a-6b7c-8d9e-0f1a2b3c4d5e
+    fromPort: features
+    toPort: features
+  - id: 99a9b0c1-2d3e-4f5a-6b7c-8d9e0f1a2b3c
+    from: 11c1d2e3-4f5a-6b7c-8d9e-0f1a2b3c4d5e
+    to: 22d2e3f4-5a6b-7c8d-9e0f-1a2b3c4d5e6f
+    fromPort: features
+    toPort: features
   - id: 6a4ed27d-58b6-4021-ae4c-d919534e5fb3
     from: e9f2c5b8-3a7d-4c1e-8b6f-2d9a5c8e1b4f
     to: 950407af-eec5-49ee-902c-2b41f31150d3
@@ -4316,6 +4433,9 @@ graphs:
       port: features
     - id: errorCountLod4InvalidSurface
       nodeId: aabacbdc-3ede-4f5a-6b7c-8d9e0f1a2b3c
+      port: features
+    - id: errorCountIncorrectMeshcode
+      nodeId: 22d2e3f4-5a6b-7c8d-9e0f-1a2b3c4d5e6f
       port: features
     - id: errorCountLod2NotClosedSolid
       nodeId: 77c7d8e9-0f1a-2b3c-4d5e-6f7a8b9c0d1e
@@ -4843,6 +4963,7 @@ graphs:
         expr:
           type: flowExpr
           value: attributes.get("LOD0-1のBuildingPart", 0)
+      # 図郭不正 is kept out of totalErrorCount, matching the original implementation.
       - newAttribute: totalErrorCount
         expr:
           type: flowExpr
@@ -4875,7 +4996,6 @@ graphs:
               attributes.get("LOD4 立体の交差", 0),
               attributes.get("T-bldg-02エラー", 0),
               attributes.get("LOD0-1のBuildingPart", 0),
-              attributes.get("図郭不正", 0),
             ])
   - id: a6b7c8d9-0e1f-2a3b-4c5d-6e7f8a9b0c1d
     name: JSONSummaryWriter
@@ -5166,6 +5286,11 @@ graphs:
     from: e9f2c5b8-3a7d-4c1e-8b6f-2d9a5c8e1b4f
     to: 4712539b-5103-41ee-9359-0333eefb82ef
     fromPort: errorCountLod4SolidIssues
+    toPort: features
+  - id: f2a3b4c5-7d8e-9f0a-1b2c-3d4e5f6a7b8c
+    from: e9f2c5b8-3a7d-4c1e-8b6f-2d9a5c8e1b4f
+    to: 4712539b-5103-41ee-9359-0333eefb82ef
+    fromPort: errorCountIncorrectMeshcode
     toPort: features
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     from: e9f2c5b8-3a7d-4c1e-8b6f-2d9a5c8e1b4f

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/surface_validation.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/surface_validation.yml
@@ -248,8 +248,94 @@ nodes:
     with:
       routingPort: errorCountLod0SurfaceIntersection
 
-  # TODO: add the destination mesh code check (図郭不正) once
-  # DestinationMeshCodeExtractor supports this geometry model.
+  # ===== Z-bldg-03: destination mesh code (図郭不正) =====
+  # Taps the same 2D LOD0 footprints as the intersection check and computes the
+  # 1km mesh code the building actually falls in. A building whose GML filename
+  # does not start with that mesh code is a figure boundary error.
+  - id: 1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d
+    name: DestinationMeshCodeExtractor
+    type: action
+    action: PLATEAU4.DestinationMeshCodeExtractor
+    with:
+      meshType: 3
+      epsgCode:
+        type: flowExpr
+        value: variables.get("prcs")
+      meshcodeAttr: "meshcode"
+
+  - id: 2b3c4d5e-6f7a-4b8c-9d0e-1f2a3b4c5d6e
+    name: MeshCodeTester
+    type: action
+    action: Feature Filter
+    with:
+      conditions:
+        - expr:
+            type: flowExpr
+            value: not attributes["gmlFilename"].starts_with(attributes["meshcode"])
+          outputPort: failed
+
+  - id: 3c4d5e6f-7a8b-4c9d-0e1f-2a3b4c5d6e8f
+    name: AttributeMapperIncorrectMeshCode
+    type: action
+    action: Attribute Mapper
+    with:
+      mappers:
+        - attribute: gmlFilename
+          valueAttribute: gmlFilename
+        - attribute: filename
+          valueAttribute: gmlFilename
+        - attribute: feature_type
+          valueAttribute: featureType
+        - attribute: lod
+          valueAttribute: lod
+        - attribute: gml_id
+          valueAttribute: gmlId
+        - attribute: meshcode
+          valueAttribute: meshcode
+        - attribute: meshcount
+          valueAttribute: _mesh_count
+        - attribute: mesh2area
+          valueAttribute: _meshcode_to_area
+
+  # gmlFilename is only kept so the counter can group by it; it is not a CSV column.
+  - id: 77e7f8a9-0b1c-2d3e-4f5a-6b7c8d9e0f1a
+    name: AttributeManagerIncorrectMeshCode
+    type: action
+    action: Attribute Manager
+    with:
+      operations:
+        - attribute: gmlFilename
+          method: remove
+
+  - id: 4d5e6f7a-8b9c-4d0e-1f2a-3b4c5d6e7f9a
+    name: FeatureWriterIncorrectMeshCode
+    type: action
+    action: Feature Writer
+    with:
+      format: csv
+      output:
+        type: string
+        value: 02_建築物_図郭不正.csv
+
+  - id: 11c1d2e3-4f5a-6b7c-8d9e-0f1a2b3c4d5e
+    name: IncorrectMeshCodeCounter
+    type: action
+    action: Statistics Calculator
+    with:
+      groupBy:
+      - gmlFilename
+      calculations:
+        - newAttribute: _num_incorrect_meshcode
+          expr:
+            type: flowExpr
+            value: "1"
+
+  - id: 22d2e3f4-5a6b-7c8d-9e0f-1a2b3c4d5e6f
+    name: ErrorCount-IncorrectMeshCode
+    type: action
+    action: Output Router
+    with:
+      routingPort: errorCountIncorrectMeshcode
 
   # ===== LOD1 boundary surface checks =====
   - id: 950407af-eec5-49ee-902c-2b41f31150d3
@@ -949,6 +1035,51 @@ edges:
     fromPort: features
     toPort: features
 
+  # ----- Z-bldg-03 destination mesh code -----
+  # Tap the same 2D LOD0 footprints the intersection check works on.
+  - id: cc3dd4ee-5ff6-4aa7-9bb8-2cc9dd0ee1cc
+    from: cc3dd4ee-5ff6-4aa7-9bb8-2cc9dd0ee1aa
+    to: 1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d
+    fromPort: features
+    toPort: features
+  - id: 3c4d5e6f-7a8b-4c9d-0e1f-2a3b4c5d6e7f
+    from: 1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d
+    to: 2b3c4d5e-6f7a-4b8c-9d0e-1f2a3b4c5d6e
+    fromPort: features
+    toPort: features
+  # Filename/mesh-code mismatch -> attribute mapper -> CSV writer.
+  - id: 5e6f7a8b-9c0d-4e1f-2a3b-4c5d6e7f8a9b
+    from: 2b3c4d5e-6f7a-4b8c-9d0e-1f2a3b4c5d6e
+    to: 3c4d5e6f-7a8b-4c9d-0e1f-2a3b4c5d6e8f
+    fromPort: failed
+    toPort: features
+  - id: 6f7a8b9c-0d1e-4f2a-3b4c-5d6e7f8a9b0c
+    from: 3c4d5e6f-7a8b-4c9d-0e1f-2a3b4c5d6e8f
+    to: 77e7f8a9-0b1c-2d3e-4f5a-6b7c8d9e0f1a
+    fromPort: features
+    toPort: features
+  - id: 66d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
+    from: 77e7f8a9-0b1c-2d3e-4f5a-6b7c8d9e0f1a
+    to: 4d5e6f7a-8b9c-4d0e-1f2a-3b4c5d6e7f9a
+    fromPort: features
+    toPort: features
+  - id: 7a8b9c0d-1e2f-403b-4c5d-6e7f8a9b0c1d
+    from: 4d5e6f7a-8b9c-4d0e-1f2a-3b4c5d6e7f9a
+    to: 5e2c9b7a-8d4f-4b1e-9c6a-3f5d8b2e7c4a
+    fromPort: features
+    toPort: features
+  # Mapped rows -> per-file counter -> error count router.
+  - id: 88f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
+    from: 3c4d5e6f-7a8b-4c9d-0e1f-2a3b4c5d6e8f
+    to: 11c1d2e3-4f5a-6b7c-8d9e-0f1a2b3c4d5e
+    fromPort: features
+    toPort: features
+  - id: 99a9b0c1-2d3e-4f5a-6b7c-8d9e0f1a2b3c
+    from: 11c1d2e3-4f5a-6b7c-8d9e-0f1a2b3c4d5e
+    to: 22d2e3f4-5a6b-7c8d-9e0f-1a2b3c4d5e6f
+    fromPort: features
+    toPort: features
+
   # ----- LOD1 boundary surface checks -----
   - id: 6a4ed27d-58b6-4021-ae4c-d919534e5fb3
     from: e9f2c5b8-3a7d-4c1e-8b6f-2d9a5c8e1b4f
@@ -1275,6 +1406,9 @@ ports:
       port: features
     - id: errorCountLod4InvalidSurface
       nodeId: aabacbdc-3ede-4f5a-6b7c-8d9e0f1a2b3c
+      port: features
+    - id: errorCountIncorrectMeshcode
+      nodeId: 22d2e3f4-5a6b-7c8d-9e0f-1a2b3c4d5e6f
       port: features
     - id: errorCountLod2NotClosedSolid
       nodeId: 77c7d8e9-0f1a-2b3c-4d5e-6f7a8b9c0d1e

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/workflow.yml
@@ -562,6 +562,7 @@ graphs:
                 type: flowExpr
                 value: attributes.get("LOD0-1のBuildingPart", 0)
 
+            # 図郭不正 is kept out of totalErrorCount, matching the original implementation.
             - newAttribute: totalErrorCount
               expr:
                 type: flowExpr
@@ -594,7 +595,6 @@ graphs:
                     attributes.get("LOD4 立体の交差", 0),
                     attributes.get("T-bldg-02エラー", 0),
                     attributes.get("LOD0-1のBuildingPart", 0),
-                    attributes.get("図郭不正", 0),
                   ])
 
       # Phase 6: JSON output with converter
@@ -923,6 +923,12 @@ graphs:
         from: e9f2c5b8-3a7d-4c1e-8b6f-2d9a5c8e1b4f  # SurfaceValidation subgraph
         to: 4712539b-5103-41ee-9359-0333eefb82ef
         fromPort: errorCountLod4SolidIssues
+        toPort: features
+
+      - id: f2a3b4c5-7d8e-9f0a-1b2c-3d4e5f6a7b8c
+        from: e9f2c5b8-3a7d-4c1e-8b6f-2d9a5c8e1b4f  # SurfaceValidation subgraph
+        to: 4712539b-5103-41ee-9359-0333eefb82ef
+        fromPort: errorCountIncorrectMeshcode
         toPort: features
 
       - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau6/02-bldg/building_checks.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau6/02-bldg/building_checks.yml
@@ -1175,8 +1175,7 @@ nodes:
           expr:
             type: flowExpr
             value: attributes.get("_num_lod3_solid_issues", 0)
-        # TODO: wire to the Z-bldg-03 mesh-code pipeline once
-        # DestinationMeshCodeExtractor supports this geometry model.
+        # Wired to the Z-bldg-03 mesh-code pipeline (IncorrectMeshCodeCounter).
         - attribute: "図郭不正"
           expr:
             type: flowExpr
@@ -1310,6 +1309,7 @@ nodes:
           expr:
             type: flowExpr
             value: attributes.get("LOD0-1のBuildingPart", 0)
+        # 図郭不正 is kept out of totalErrorCount, matching the original implementation.
         - newAttribute: "totalErrorCount"
           expr:
             type: flowExpr
@@ -1333,7 +1333,6 @@ nodes:
               + attributes.get("LOD3 非水密立体", 0)
               + attributes.get("LOD2 立体のエラー", 0)
               + attributes.get("LOD3 立体のエラー", 0)
-              + attributes.get("図郭不正", 0)
               + attributes.get("LOD0-1のBuildingPart", 0)
               + attributes.get("LOD1 立体の交差", 0)
               + attributes.get("LOD2 立体の交差", 0)
@@ -2995,8 +2994,136 @@ nodes:
   # BuildingPart, the gml:ids it shares a boundary polygon with.
   # PLATEAU6.TransitiveLinkResolver consumes that link list and reads no
   # geometry itself, so it is the producer that is still missing.
-  # TODO: add the destination mesh code check (図郭不正) once
-  # DestinationMeshCodeExtractor supports this geometry model.
+
+  # --- Z-bldg-03 mesh-code (figure boundary) pipeline ---
+  # Taps the reprojected LOD0 footprints (already forced to 2D by TwoDimensionForcer)
+  # and computes the Japanese standard 1km mesh code the building actually falls in.
+  # A building whose GML filename does not start with that mesh code is a figure
+  # boundary error (図郭不正). Mirrors the plateau4 surface_validation.yml wiring.
+  - id: c1b00070-0000-4000-8000-000000000070
+    name: DestinationMeshCodeExtractor
+    type: action
+    action: PLATEAU6.DestinationMeshCodeExtractor
+    with:
+      meshType: 3
+      epsgCode:
+        type: flowExpr
+        value: variables.get("prcs")
+      meshcodeAttr: "meshcode"
+
+  - id: c1b00071-0000-4000-8000-000000000071
+    name: MeshCodeTester
+    type: action
+    action: Feature Filter
+    with:
+      conditions:
+        - expr:
+            type: flowExpr
+            value: not attributes["name"].starts_with(attributes["meshcode"])
+          outputPort: failed
+
+  - id: c1b00072-0000-4000-8000-000000000072
+    name: AttributeMapperIncorrectMeshCode
+    type: action
+    action: Attribute Mapper
+    with:
+      mappers:
+        - attribute: feature_type
+          valueAttribute: __citygml_feature_type
+        - attribute: meshcount
+          valueAttribute: _mesh_count
+        - attribute: lod
+          valueAttribute: lod
+        - attribute: meshcode
+          valueAttribute: meshcode
+        - attribute: filename
+          valueAttribute: name
+        - attribute: mesh2area
+          valueAttribute: _meshcode_to_area
+        - attribute: gml_id
+          valueAttribute: __citygml_gml_id
+
+  - id: c1b00073-0000-4000-8000-000000000073
+    name: FeatureWriterIncorrectMeshCode
+    type: action
+    action: Feature Writer
+    with:
+      format: csv
+      output:
+        type: string
+        value: 02_建築物_図郭不正.csv
+
+  # GeoJSON error-detail output for the same check. The geometry is the 2D LOD0
+  # footprint the mesh code was computed from.
+  - id: c1b00076-0000-4000-8000-000000000076
+    name: AttributeMapperIncorrectMeshCodeGeoJson
+    type: action
+    action: Attribute Mapper
+    with:
+      mappers:
+        - attribute: check
+          expr:
+            type: string
+            value: 図郭不正
+        - attribute: issue
+          expr:
+            type: string
+            value: IncorrectMeshCode
+        - attribute: filename
+          valueAttribute: name
+        - attribute: featureType
+          valueAttribute: __citygml_feature_type
+        - attribute: gmlId
+          valueAttribute: __citygml_gml_id
+        - attribute: parentGmlId
+          valueAttribute: __citygml_parent_gml_id
+        - attribute: rootGmlId
+          valueAttribute: __citygml_root_gml_id
+        - attribute: lod
+          valueAttribute: lod
+        - attribute: meshCode
+          valueAttribute: meshcode
+        - attribute: meshCount
+          valueAttribute: _mesh_count
+        - attribute: meshToArea
+          valueAttribute: _meshcode_to_area
+
+  - id: c1b00077-0000-4000-8000-000000000077
+    name: FeatureGeoJsonWriterIncorrectMeshCode
+    type: action
+    action: Feature GeoJSON Writer
+    with:
+      output:
+        type: string
+        value: error_geometry/02_建築物_図郭不正.geojson
+      writeCrs: true
+
+  # Count 図郭不正 rows per file for the summary column.
+  - id: c1b00074-0000-4000-8000-000000000074
+    name: IncorrectMeshCodeCounter
+    type: action
+    action: Statistics Calculator
+    with:
+      groupBy:
+        - name
+      calculations:
+        - newAttribute: _num_incorrect_meshcode
+          expr:
+            type: flowExpr
+            value: "1"
+
+  # Join the per-file 図郭不正 count onto each file feature.
+  - id: c1b00075-0000-4000-8000-000000000075
+    name: IncorrectMeshCodeSummaryMerger
+    type: action
+    action: Feature Merger
+    with:
+      requestorAttributeValue:
+        type: flowExpr
+        value: attributes["name"]
+      supplierAttributeValue:
+        type: flowExpr
+        value: attributes["name"]
 
   # ========== Z-bldg-04: LOD0/LOD1 BuildingPart ==========
   # A BuildingPart is only allowed to carry LOD2+ geometry. LOD0/LOD1 BuildingParts
@@ -4436,15 +4563,15 @@ edges:
     to: c1b00057-0000-4000-8000-000000000057
     fromPort: features
     toPort: supplier
-  # Unmatched-xlink summary merger output -> Z-bldg-04 summary merger (requestor).
+  # Unmatched-xlink summary merger output -> mesh-code summary merger (requestor).
   - id: c1b0e05b-0000-4000-8000-00000000005b
     from: c1b00057-0000-4000-8000-000000000057
-    to: c1b00083-0000-4000-8000-000000000083
+    to: c1b00075-0000-4000-8000-000000000075
     fromPort: merged
     toPort: requestor
   - id: c1b0e05c-0000-4000-8000-00000000005c
     from: c1b00057-0000-4000-8000-000000000057
-    to: c1b00083-0000-4000-8000-000000000083
+    to: c1b00075-0000-4000-8000-000000000075
     fromPort: unmerged
     toPort: requestor
 
@@ -4461,6 +4588,74 @@ edges:
     to: c1b00061-0000-4000-8000-000000000061
     fromPort: buildingPart
     toPort: features
+
+  # --- Z-bldg-03 mesh-code pipeline edges ---
+  # Tap the reprojected 2D LOD0 footprints from TwoDimensionForcer.
+  - id: c1b0e070-0000-4000-8000-000000000070
+    from: d65886fc-2d62-448c-8b2e-16841e3c4887
+    to: c1b00070-0000-4000-8000-000000000070
+    fromPort: features
+    toPort: features
+  # Extractor -> mesh-code tester.
+  - id: c1b0e071-0000-4000-8000-000000000071
+    from: c1b00070-0000-4000-8000-000000000070
+    to: c1b00071-0000-4000-8000-000000000071
+    fromPort: features
+    toPort: features
+  # Filename/mesh-code mismatch -> attribute mapper -> CSV writer.
+  - id: c1b0e072-0000-4000-8000-000000000072
+    from: c1b00071-0000-4000-8000-000000000071
+    to: c1b00072-0000-4000-8000-000000000072
+    fromPort: failed
+    toPort: features
+  - id: c1b0e073-0000-4000-8000-000000000073
+    from: c1b00072-0000-4000-8000-000000000072
+    to: c1b00073-0000-4000-8000-000000000073
+    fromPort: features
+    toPort: features
+  - id: c1b0e074-0000-4000-8000-000000000074
+    from: c1b00073-0000-4000-8000-000000000073
+    to: 3730412c-8a45-417c-a669-fa10fec80028
+    fromPort: features
+    toPort: features
+  # The same mismatches -> GeoJSON mapper -> GeoJSON writer.
+  - id: c1b0e079-0000-4000-8000-000000000079
+    from: c1b00071-0000-4000-8000-000000000071
+    to: c1b00076-0000-4000-8000-000000000076
+    fromPort: failed
+    toPort: features
+  - id: c1b0e07a-0000-4000-8000-00000000007a
+    from: c1b00076-0000-4000-8000-000000000076
+    to: c1b00077-0000-4000-8000-000000000077
+    fromPort: features
+    toPort: features
+  - id: c1b0e07b-0000-4000-8000-00000000007b
+    from: c1b00077-0000-4000-8000-000000000077
+    to: 3730412c-8a45-417c-a669-fa10fec80028
+    fromPort: features
+    toPort: features
+  # Mismatched features -> counter -> mesh-code summary merger (supplier).
+  - id: c1b0e075-0000-4000-8000-000000000075
+    from: c1b00071-0000-4000-8000-000000000071
+    to: c1b00074-0000-4000-8000-000000000074
+    fromPort: failed
+    toPort: features
+  - id: c1b0e076-0000-4000-8000-000000000076
+    from: c1b00074-0000-4000-8000-000000000074
+    to: c1b00075-0000-4000-8000-000000000075
+    fromPort: features
+    toPort: supplier
+  # Mesh-code summary merger output -> Z-bldg-04 summary merger (requestor).
+  - id: c1b0e077-0000-4000-8000-000000000077
+    from: c1b00075-0000-4000-8000-000000000075
+    to: c1b00083-0000-4000-8000-000000000083
+    fromPort: merged
+    toPort: requestor
+  - id: c1b0e078-0000-4000-8000-000000000078
+    from: c1b00075-0000-4000-8000-000000000075
+    to: c1b00083-0000-4000-8000-000000000083
+    fromPort: unmerged
+    toPort: requestor
 
   # --- Z-bldg-04 LOD0/LOD1 BuildingPart pipeline edges ---
   # LOD0 / LOD1 BuildingParts from the dedicated LodSplitter -> counter.

--- a/engine/runtime/geometry/src/line_string/mod.rs
+++ b/engine/runtime/geometry/src/line_string/mod.rs
@@ -62,6 +62,12 @@ impl LineString2D {
     pub fn elevation(&self) -> Option<f64> {
         self.z
     }
+
+    /// Whether the chain traces a ring: closed, and enclosing something.
+    #[inline]
+    pub fn is_closed_ring(&self) -> bool {
+        self.coords.len() >= 4 && self.coords.first() == self.coords.last()
+    }
 }
 
 impl LineString3D {

--- a/engine/runtime/geometry/src/line_string/mod.rs
+++ b/engine/runtime/geometry/src/line_string/mod.rs
@@ -66,7 +66,7 @@ impl LineString2D {
     /// Whether the chain traces a ring: closed, and enclosing something.
     #[inline]
     pub fn is_closed_ring(&self) -> bool {
-        self.coords.len() >= 4 && self.coords.first() == self.coords.last()
+        is_closed_ring(&self.coords)
     }
 }
 
@@ -82,6 +82,13 @@ impl LineString3D {
     pub fn coords(&self) -> &[[f64; 3]] {
         &self.coords
     }
+}
+
+/// Whether a chain is a closed ring. A chain of three or fewer encloses no
+/// area even when its ends meet.
+#[inline]
+pub(crate) fn is_closed_ring<const N: usize>(coords: &[[f64; N]]) -> bool {
+    coords.len() >= 4 && coords.first() == coords.last()
 }
 
 crate::unsupported!(LineString2D: Triangulate);

--- a/engine/runtime/geometry/src/line_string/ops.rs
+++ b/engine/runtime/geometry/src/line_string/ops.rs
@@ -186,7 +186,8 @@ impl LineString2D {
     }
 }
 
-use crate::ops::coerce::{closes_a_ring, unchanged};
+use super::is_closed_ring;
+use crate::ops::coerce::unchanged;
 use crate::ops::triangulation::Cache;
 use crate::ops::{Coerce, CoercionTarget};
 use crate::polygon::{Polygon2D, Polygon3D};
@@ -201,7 +202,7 @@ impl Coerce for LineString2D {
             // A curve already is one, and bounds no area to tessellate.
             CoercionTarget::LineString | CoercionTarget::TriangularMesh => Err(unchanged::<Self>()),
             CoercionTarget::Polygon => {
-                if !closes_a_ring(&self.coords) {
+                if !is_closed_ring(&self.coords) {
                     return Err(unchanged::<Self>());
                 }
                 let ring = Vec::from(std::mem::take(&mut self.coords));
@@ -233,7 +234,7 @@ impl Coerce for LineString3D {
             // A curve already is one, and bounds no area to tessellate.
             CoercionTarget::LineString | CoercionTarget::TriangularMesh => Err(unchanged::<Self>()),
             CoercionTarget::Polygon => {
-                if !closes_a_ring(&self.coords) {
+                if !is_closed_ring(&self.coords) {
                     return Err(unchanged::<Self>());
                 }
                 let ring = Vec::from(std::mem::take(&mut self.coords));

--- a/engine/runtime/geometry/src/ops/coerce.rs
+++ b/engine/runtime/geometry/src/ops/coerce.rs
@@ -186,12 +186,6 @@ pub(crate) fn push_face_lines_3d(face: &Polygon3D, out: &mut Vec<Euclidean3DGeom
     }
 }
 
-/// Whether a chain closes a ring. A chain of three or fewer encloses no area
-/// even when its ends meet.
-pub(crate) fn closes_a_ring<const N: usize>(coords: &[[f64; N]]) -> bool {
-    coords.len() >= 4 && coords.first() == coords.last()
-}
-
 /// One triangle as a ring, closed by repeating its first vertex — the form the
 /// polygon constructors expect.
 pub(crate) fn triangle_ring<const N: usize>(

--- a/engine/runtime/geometry/src/ops/coerce.rs
+++ b/engine/runtime/geometry/src/ops/coerce.rs
@@ -69,6 +69,46 @@ impl<T: Coerce + ?Sized> Coerce for Box<T> {
     }
 }
 
+/// The geometry with every closed chain replaced by the face it traces, and
+/// every other member left as it is. Collections recurse, keeping their
+/// per-member attributes.
+///
+/// The lenient sibling of [`Coerce`] with [`CoercionTarget::Polygon`]: a
+/// surface or a volume stays whole here, where the coercion decomposes a
+/// surface into the faces it is built from. Coordinates are carried over
+/// verbatim, and a chain that bounds no area is left a chain.
+pub fn rings_as_faces_2d(geometry: &Euclidean2DGeometry) -> Euclidean2DGeometry {
+    let mut faces = geometry.clone();
+    coerce_rings_2d(&mut faces);
+    faces
+}
+
+/// [`rings_as_faces_2d`], in place.
+fn coerce_rings_2d(geometry: &mut Euclidean2DGeometry) {
+    match geometry {
+        Euclidean2DGeometry::LineString(line) if line.is_closed_ring() => {
+            let ring = line.coords().iter().copied();
+            let no_holes = Vec::<Vec<[f64; 2]>>::new();
+            let face = match line.elevation() {
+                None => Polygon2D::from_rings(line.frame().clone(), ring, no_holes),
+                Some(elevation) => Polygon2D::from_rings_at_elevation(
+                    line.frame().clone(),
+                    ring,
+                    no_holes,
+                    elevation,
+                ),
+            };
+            *geometry = Euclidean2DGeometry::Polygon(Box::new(face));
+        }
+        Euclidean2DGeometry::Collection(collection) => {
+            for member in collection.members_mut() {
+                coerce_rings_2d(member);
+            }
+        }
+        _ => {}
+    }
+}
+
 pub(crate) fn unchanged<T: ?Sized>() -> UnsupportedOperation {
     UnsupportedOperation {
         geometry: core::any::type_name::<T>(),
@@ -174,7 +214,7 @@ mod tests {
     use crate::csg::Csg;
     use crate::point::Point3D;
     use crate::point_cloud::PointCloud;
-    use crate::polygon_mesh::{PolygonMesh3D, PolygonMesh3DData};
+    use crate::polygon_mesh::{PolygonMesh2D, PolygonMesh3D, PolygonMesh3DData};
     use crate::solid::Solid;
     use crate::triangular_mesh::TriangularMesh3D;
     use crate::GeometryCollection;
@@ -536,5 +576,95 @@ mod tests {
         };
         assert_eq!(out.members().len(), 2);
         assert_eq!(out.member_attributes(), attrs.as_slice());
+    }
+
+    fn chain_2d(coords: impl IntoIterator<Item = [f64; 2]>) -> Euclidean2DGeometry {
+        Euclidean2DGeometry::LineString(LineString2D::from_coords(
+            CoordinateFrame::Euclidean,
+            coords,
+        ))
+    }
+
+    #[test]
+    fn rings_as_faces_2d_replaces_a_closed_chain_with_the_face_it_traces() {
+        let Euclidean2DGeometry::Polygon(face) = rings_as_faces_2d(&chain_2d(SQUARE_2D)) else {
+            panic!("expected a face");
+        };
+        assert_eq!(face.exterior(), SQUARE_2D);
+        assert!(face.interiors().next().is_none());
+    }
+
+    #[test]
+    fn rings_as_faces_2d_leaves_a_chain_that_bounds_no_area() {
+        let open = chain_2d(SQUARE_2D.into_iter().take(4));
+        assert_eq!(rings_as_faces_2d(&open), open);
+        let triangle_ends_meeting = chain_2d([[0.0, 0.0], [4.0, 0.0], [0.0, 0.0]]);
+        assert_eq!(
+            rings_as_faces_2d(&triangle_ends_meeting),
+            triangle_ends_meeting
+        );
+    }
+
+    #[test]
+    fn rings_as_faces_2d_keeps_a_surface_whole() {
+        // Where `CoercionTarget::Polygon` would decompose it into its two faces.
+        let mesh = Euclidean2DGeometry::PolygonMesh(Box::new(
+            PolygonMesh2D::from_parts(
+                CoordinateFrame::Euclidean,
+                vec![
+                    [0.0, 0.0],
+                    [2.0, 0.0],
+                    [2.0, 2.0],
+                    [0.0, 2.0],
+                    [4.0, 0.0],
+                    [4.0, 2.0],
+                ],
+                vec![vec![0u32, 1, 2, 3], vec![1, 4, 5, 2]],
+            )
+            .unwrap(),
+        ));
+        assert_eq!(rings_as_faces_2d(&mesh), mesh);
+    }
+
+    #[test]
+    fn rings_as_faces_2d_recurses_and_keeps_per_member_attributes() {
+        let attrs = vec![
+            Attributes::from([(Attribute::new("lod"), AttributeValue::Number(0.into()))]),
+            Attributes::from([(Attribute::new("lod"), AttributeValue::Number(1.into()))]),
+        ];
+        let inner = Euclidean2DGeometry::Collection(Collection2D::new([chain_2d(SQUARE_2D)]));
+        let collection = Collection2D::with_attributes(
+            vec![inner, chain_2d(SQUARE_2D.into_iter().take(4))],
+            attrs.clone(),
+        )
+        .unwrap();
+
+        let Euclidean2DGeometry::Collection(out) =
+            rings_as_faces_2d(&Euclidean2DGeometry::Collection(collection))
+        else {
+            panic!("expected a collection");
+        };
+        assert_eq!(out.member_attributes(), attrs.as_slice());
+        let [Euclidean2DGeometry::Collection(nested), open] = out.members() else {
+            panic!("expected a nested collection beside the open chain");
+        };
+        assert!(matches!(
+            nested.members(),
+            [Euclidean2DGeometry::Polygon(_)]
+        ));
+        assert!(matches!(open, Euclidean2DGeometry::LineString(_)));
+    }
+
+    #[test]
+    fn rings_as_faces_2d_carries_an_elevation_across() {
+        let ring = Euclidean2DGeometry::LineString(LineString2D::from_coords_at_elevation(
+            CoordinateFrame::Euclidean,
+            SQUARE_2D,
+            3.0,
+        ));
+        let Euclidean2DGeometry::Polygon(face) = rings_as_faces_2d(&ring) else {
+            panic!("expected a face");
+        };
+        assert_eq!(face.elevation(), Some(3.0));
     }
 }

--- a/engine/runtime/geometry/src/ops/mod.rs
+++ b/engine/runtime/geometry/src/ops/mod.rs
@@ -32,7 +32,7 @@ pub(crate) use boundary::{
     container_boundary, surface_boundary_2d, surface_boundary_3d, BoundaryEdges,
 };
 pub use boundary::{Boundary, ExtractBoundary};
-pub use coerce::{Coerce, CoercionTarget};
+pub use coerce::{rings_as_faces_2d, Coerce, CoercionTarget};
 #[cfg(feature = "new-geometry")]
 pub use elevation::Elevation;
 #[cfg(feature = "new-geometry")]

--- a/engine/runtime/geometry/src/predicates/relate/graph/geometry_graph.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/geometry_graph.rs
@@ -1,3 +1,4 @@
+use crate::line_string::is_closed_ring;
 use crate::predicates::kernel::{orient2d, CoordPos, Orientation};
 use crate::predicates::relate::operand::RelateOperand;
 use crate::predicates::view::Leaf2D;
@@ -306,9 +307,7 @@ enum WindingOrder {
 /// The winding order of a closed ring, by robust orientation at its
 /// lexicographically least vertex. `None` for open or degenerate rings.
 fn ring_winding_order(ring: &[[f64; 2]]) -> Option<WindingOrder> {
-    // If the ring has at most 3 coords, it is either not closed, or is at
-    // most two distinct points. Either way, the winding is unspecified.
-    if ring.len() < 4 || ring.first() != ring.last() {
+    if !is_closed_ring(ring) {
         return None;
     }
     let least = ring

--- a/engine/runtime/geometry/src/predicates/view.rs
+++ b/engine/runtime/geometry/src/predicates/view.rs
@@ -19,6 +19,8 @@
 use super::kernel::{self, Orientation};
 use crate::coordinate::CoordinateFrame;
 use crate::line_string::LineString2D;
+#[cfg(feature = "new-geometry")]
+use crate::ops::Elevation;
 use crate::ops::{Aabb, BoundingBox};
 use crate::point::Point2D;
 use crate::polygon::{Polygon2D, Polygon3D};
@@ -401,6 +403,20 @@ impl<'a> Leaf2D<'a> {
             Leaf2D::TriangularMesh(m) => m.bounding_box(),
         }
         .ok()
+    }
+}
+
+#[cfg(feature = "new-geometry")]
+impl Elevation for Leaf2D<'_> {
+    /// The elevation the leaf lies at, or `None` when it is planar.
+    fn elevation(&self) -> Option<f64> {
+        match self {
+            Leaf2D::Point(p) => p.elevation(),
+            Leaf2D::Line(l) => l.elevation(),
+            Leaf2D::Polygon(p) => p.elevation(),
+            Leaf2D::PolygonMesh(m) => m.elevation(),
+            Leaf2D::TriangularMesh(m) => m.elevation(),
+        }
     }
 }
 

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-03_meshcode-extractor_01/udx/bldg/54377084_bldg_6697_op.gml
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-03_meshcode-extractor_01/udx/bldg/54377084_bldg_6697_op.gml
@@ -46,6 +46,45 @@ http://www.opengis.net/citygml/appearance/2.0 http://schemas.opengis.net/citygml
 					</gml:surfaceMember>
 				</gml:MultiSurface>
 			</bldg:lod0RoofEdge>
+			<uro:buildingIDAttribute>
+				<uro:BuildingIDAttribute>
+					<uro:buildingID>16211-bldg-1</uro:buildingID>
+					<uro:prefecture codeSpace="../../codelists/Common_localPublicAuthorities.xml">16</uro:prefecture>
+					<uro:city codeSpace="../../codelists/Common_localPublicAuthorities.xml">16211</uro:city>
+				</uro:BuildingIDAttribute>
+			</uro:buildingIDAttribute>
+			<uro:buildingDetailAttribute>
+				<uro:BuildingDetailAttribute>
+					<uro:totalFloorArea uom="m2">76.2</uro:totalFloorArea>
+					<uro:buildingFootprintArea uom="m2">76.2</uro:buildingFootprintArea>
+					<uro:buildingRoofEdgeArea uom="m2">58.7</uro:buildingRoofEdgeArea>
+					<uro:buildingStructureType codeSpace="../../codelists/BuildingDetailAttribute_buildingStructureType.xml">611</uro:buildingStructureType>
+					<uro:fireproofStructureType codeSpace="../../codelists/BuildingDetailAttribute_fireproofStructureType.xml">1011</uro:fireproofStructureType>
+					<uro:landUseType codeSpace="../../codelists/Common_landUseType.xml">211</uro:landUseType>
+					<uro:detailedUsage codeSpace="../../codelists/BuildingDetailAttribute_detailedUsage.xml">4111</uro:detailedUsage>
+					<uro:buildingHeight uom="m">-9999</uro:buildingHeight>
+					<uro:surveyYear>2020</uro:surveyYear>
+				</uro:BuildingDetailAttribute>
+			</uro:buildingDetailAttribute>
+			<uro:bldgDataQualityAttribute>
+				<uro:DataQualityAttribute>
+					<uro:geometrySrcDescLod0 codeSpace="../../codelists/DataQualityAttribute_geometrySrcDesc.xml">000</uro:geometrySrcDescLod0>
+					<uro:geometrySrcDescLod1 codeSpace="../../codelists/DataQualityAttribute_geometrySrcDesc.xml">000</uro:geometrySrcDescLod1>
+					<uro:thematicSrcDesc codeSpace="../../codelists/DataQualityAttribute_thematicSrcDesc.xml">100</uro:thematicSrcDesc>
+					<uro:thematicSrcDesc codeSpace="../../codelists/DataQualityAttribute_thematicSrcDesc.xml">201</uro:thematicSrcDesc>
+					<uro:thematicSrcDesc codeSpace="../../codelists/DataQualityAttribute_thematicSrcDesc.xml">000</uro:thematicSrcDesc>
+					<uro:lod1HeightType codeSpace="../../codelists/DataQualityAttribute_lod1HeightType.xml">2</uro:lod1HeightType>
+					<uro:publicSurveyDataQualityAttribute>
+						<uro:PublicSurveyDataQualityAttribute>
+							<uro:srcScaleLod0 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_srcScale.xml">1</uro:srcScaleLod0>
+							<uro:srcScaleLod1 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_srcScale.xml">1</uro:srcScaleLod1>
+							<uro:publicSurveySrcDescLod0 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_publicSurveySrcDesc.xml">023</uro:publicSurveySrcDescLod0>
+							<uro:publicSurveySrcDescLod1 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_publicSurveySrcDesc.xml">023</uro:publicSurveySrcDescLod1>
+							<uro:publicSurveySrcDescLod1 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_publicSurveySrcDesc.xml">003</uro:publicSurveySrcDescLod1>
+						</uro:PublicSurveyDataQualityAttribute>
+					</uro:publicSurveyDataQualityAttribute>
+				</uro:DataQualityAttribute>
+			</uro:bldgDataQualityAttribute>
 
 		</bldg:Building>
 	</core:cityObjectMember>

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-03_meshcode-extractor_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-03_meshcode-extractor_01/workflow_test.json
@@ -1,6 +1,5 @@
 {
   "description": "Test PLATEAU4.DestinationMeshCodeExtractor",
-  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {
@@ -49,5 +48,5 @@
       ]
     }
   },
-  "expectResultOkFile": false
+  "expectResultOkFile": true
 }

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-03_meshcode-extractor_02/02_建築物_図郭不正.csv
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-03_meshcode-extractor_02/02_建築物_図郭不正.csv
@@ -1,2 +1,2 @@
 "mesh2area","meshcode","filename","meshcount","feature_type","lod","gml_id"
-"[{""mesh_code"":54377095,""area"":743948.68},{""mesh_code"":54377096,""area"":0.01}]",54377095,"54377094_bldg_6697_op.gml",2,"bldg:Building",0,"bldg_cross_mesh_test_building"
+"[{""mesh_code"":54377095,""area"":743948.68},{""mesh_code"":54377096,""area"":0.01}]",54377095,"54377094_bldg_6697_op.gml",2,"bldg:Building",0,"bldg_b7a7ca6b-6667-4733-9e4f-7dc4b1bef9c6"

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-03_meshcode-extractor_02/udx/bldg/54377094_bldg_6697_op.gml
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-03_meshcode-extractor_02/udx/bldg/54377094_bldg_6697_op.gml
@@ -20,7 +20,7 @@ http://www.opengis.net/citygml/appearance/2.0 http://schemas.opengis.net/citygml
 
 	<!-- Building that spans across two 1km meshes -->
 	<core:cityObjectMember>
-		<bldg:Building gml:id="bldg_cross_mesh_test_building">
+		<bldg:Building gml:id="bldg_b7a7ca6b-6667-4733-9e4f-7dc4b1bef9c6">
 			<core:creationDate>2025-03-21</core:creationDate>
 			<bldg:class codeSpace="../../codelists/Building_class.xml">3001</bldg:class>
 			<bldg:usage codeSpace="../../codelists/Building_usage.xml">461</bldg:usage>
@@ -37,9 +37,9 @@ http://www.opengis.net/citygml/appearance/2.0 http://schemas.opengis.net/citygml
 								<gml:LinearRing>
 									<gml:posList>
                                         36.658333333 137.0650 0
-                                        36.665833333 137.0650 0
-                                        36.665833333 137.0750 0
                                         36.658333333 137.0750 0
+                                        36.665833333 137.0750 0
+                                        36.665833333 137.0650 0
                                         36.658333333 137.0650 0
                                     </gml:posList>
 								</gml:LinearRing>
@@ -48,6 +48,45 @@ http://www.opengis.net/citygml/appearance/2.0 http://schemas.opengis.net/citygml
 					</gml:surfaceMember>
 				</gml:MultiSurface>
 			</bldg:lod0RoofEdge>
+			<uro:buildingIDAttribute>
+				<uro:BuildingIDAttribute>
+					<uro:buildingID>16211-bldg-1</uro:buildingID>
+					<uro:prefecture codeSpace="../../codelists/Common_localPublicAuthorities.xml">16</uro:prefecture>
+					<uro:city codeSpace="../../codelists/Common_localPublicAuthorities.xml">16211</uro:city>
+				</uro:BuildingIDAttribute>
+			</uro:buildingIDAttribute>
+			<uro:buildingDetailAttribute>
+				<uro:BuildingDetailAttribute>
+					<uro:totalFloorArea uom="m2">76.2</uro:totalFloorArea>
+					<uro:buildingFootprintArea uom="m2">76.2</uro:buildingFootprintArea>
+					<uro:buildingRoofEdgeArea uom="m2">58.7</uro:buildingRoofEdgeArea>
+					<uro:buildingStructureType codeSpace="../../codelists/BuildingDetailAttribute_buildingStructureType.xml">611</uro:buildingStructureType>
+					<uro:fireproofStructureType codeSpace="../../codelists/BuildingDetailAttribute_fireproofStructureType.xml">1011</uro:fireproofStructureType>
+					<uro:landUseType codeSpace="../../codelists/Common_landUseType.xml">211</uro:landUseType>
+					<uro:detailedUsage codeSpace="../../codelists/BuildingDetailAttribute_detailedUsage.xml">4111</uro:detailedUsage>
+					<uro:buildingHeight uom="m">-9999</uro:buildingHeight>
+					<uro:surveyYear>2020</uro:surveyYear>
+				</uro:BuildingDetailAttribute>
+			</uro:buildingDetailAttribute>
+			<uro:bldgDataQualityAttribute>
+				<uro:DataQualityAttribute>
+					<uro:geometrySrcDescLod0 codeSpace="../../codelists/DataQualityAttribute_geometrySrcDesc.xml">000</uro:geometrySrcDescLod0>
+					<uro:geometrySrcDescLod1 codeSpace="../../codelists/DataQualityAttribute_geometrySrcDesc.xml">000</uro:geometrySrcDescLod1>
+					<uro:thematicSrcDesc codeSpace="../../codelists/DataQualityAttribute_thematicSrcDesc.xml">100</uro:thematicSrcDesc>
+					<uro:thematicSrcDesc codeSpace="../../codelists/DataQualityAttribute_thematicSrcDesc.xml">201</uro:thematicSrcDesc>
+					<uro:thematicSrcDesc codeSpace="../../codelists/DataQualityAttribute_thematicSrcDesc.xml">000</uro:thematicSrcDesc>
+					<uro:lod1HeightType codeSpace="../../codelists/DataQualityAttribute_lod1HeightType.xml">2</uro:lod1HeightType>
+					<uro:publicSurveyDataQualityAttribute>
+						<uro:PublicSurveyDataQualityAttribute>
+							<uro:srcScaleLod0 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_srcScale.xml">1</uro:srcScaleLod0>
+							<uro:srcScaleLod1 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_srcScale.xml">1</uro:srcScaleLod1>
+							<uro:publicSurveySrcDescLod0 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_publicSurveySrcDesc.xml">023</uro:publicSurveySrcDescLod0>
+							<uro:publicSurveySrcDescLod1 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_publicSurveySrcDesc.xml">023</uro:publicSurveySrcDescLod1>
+							<uro:publicSurveySrcDescLod1 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_publicSurveySrcDesc.xml">003</uro:publicSurveySrcDescLod1>
+						</uro:PublicSurveyDataQualityAttribute>
+					</uro:publicSurveyDataQualityAttribute>
+				</uro:DataQualityAttribute>
+			</uro:bldgDataQualityAttribute>
 		</bldg:Building>
 	</core:cityObjectMember>
 

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-03_meshcode-extractor_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-03_meshcode-extractor_02/workflow_test.json
@@ -1,6 +1,5 @@
 {
   "description": "Test PLATEAU4.DestinationMeshCodeExtractor",
-  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {
@@ -49,5 +48,5 @@
       ]
     }
   },
-  "expectResultOkFile": false
+  "expectResultOkFile": true
 }

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-03_meshcode-extractor_03/02_建築物_図郭不正.csv
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-03_meshcode-extractor_03/02_建築物_図郭不正.csv
@@ -1,4 +1,4 @@
 "mesh2area","lod","feature_type","meshcode","filename","meshcount","gml_id"
-"[{""mesh_code"":54377095,""area"":2066.41},{""mesh_code"":54377096,""area"":2066.41},{""mesh_code"":55370005,""area"":4132.78},{""mesh_code"":55370006,""area"":4132.78}]",0,"bldg:Building",55370005,"equal_area_cross_mesh.gml",4,"bldg_equal_area_cross_mesh"
-"[{""mesh_code"":54377095,""area"":3174.0},{""mesh_code"":54377096,""area"":3174.0}]",0,"bldg:Building",54377095,"equal_area_cross_mesh.gml",2,"bldg_circular_equal_area"
-"[{""mesh_code"":54377096,""area"":1239.85},{""mesh_code"":55370006,""area"":1239.84}]",0,"bldg:Building",54377096,"equal_area_cross_mesh.gml",2,"bldg_lat_boundary_equal"
+"[{""mesh_code"":54377095,""area"":2066.41},{""mesh_code"":54377096,""area"":2066.41},{""mesh_code"":55370005,""area"":4132.78},{""mesh_code"":55370006,""area"":4132.78}]",0,"bldg:Building",55370005,"equal_area_cross_mesh.gml",4,"bldg_5a56023c-0e19-4333-b840-ac0647de7a9b"
+"[{""mesh_code"":54377095,""area"":3174.0},{""mesh_code"":54377096,""area"":3174.0}]",0,"bldg:Building",54377095,"equal_area_cross_mesh.gml",2,"bldg_0f775683-636e-4948-8aa8-bd8db6921f0b"
+"[{""mesh_code"":54377096,""area"":1239.85},{""mesh_code"":55370006,""area"":1239.84}]",0,"bldg:Building",54377096,"equal_area_cross_mesh.gml",2,"bldg_3682cf30-a7cd-40f5-ba9f-7146698e1590"

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-03_meshcode-extractor_03/udx/bldg/equal_area_cross_mesh.gml
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-03_meshcode-extractor_03/udx/bldg/equal_area_cross_mesh.gml
@@ -21,7 +21,7 @@ http://www.opengis.net/citygml/appearance/2.0 http://schemas.opengis.net/citygml
 	<!-- Building with exactly equal areas in two adjacent 1km meshes -->
 	<!-- Mesh boundary at 137.075 longitude (multiple of 0.0125 degree intervals) -->
 	<core:cityObjectMember>
-		<bldg:Building gml:id="bldg_equal_area_cross_mesh">
+		<bldg:Building gml:id="bldg_5a56023c-0e19-4333-b840-ac0647de7a9b">
 			<core:creationDate>2025-03-21</core:creationDate>
 			<bldg:class codeSpace="../../codelists/Building_class.xml">3001</bldg:class>
 			<bldg:usage codeSpace="../../codelists/Building_usage.xml">422</bldg:usage>
@@ -49,12 +49,51 @@ http://www.opengis.net/citygml/appearance/2.0 http://schemas.opengis.net/citygml
 					</gml:surfaceMember>
 				</gml:MultiSurface>
 			</bldg:lod0RoofEdge>
+			<uro:buildingIDAttribute>
+				<uro:BuildingIDAttribute>
+					<uro:buildingID>16211-bldg-1</uro:buildingID>
+					<uro:prefecture codeSpace="../../codelists/Common_localPublicAuthorities.xml">16</uro:prefecture>
+					<uro:city codeSpace="../../codelists/Common_localPublicAuthorities.xml">16211</uro:city>
+				</uro:BuildingIDAttribute>
+			</uro:buildingIDAttribute>
+			<uro:buildingDetailAttribute>
+				<uro:BuildingDetailAttribute>
+					<uro:totalFloorArea uom="m2">76.2</uro:totalFloorArea>
+					<uro:buildingFootprintArea uom="m2">76.2</uro:buildingFootprintArea>
+					<uro:buildingRoofEdgeArea uom="m2">58.7</uro:buildingRoofEdgeArea>
+					<uro:buildingStructureType codeSpace="../../codelists/BuildingDetailAttribute_buildingStructureType.xml">611</uro:buildingStructureType>
+					<uro:fireproofStructureType codeSpace="../../codelists/BuildingDetailAttribute_fireproofStructureType.xml">1011</uro:fireproofStructureType>
+					<uro:landUseType codeSpace="../../codelists/Common_landUseType.xml">211</uro:landUseType>
+					<uro:detailedUsage codeSpace="../../codelists/BuildingDetailAttribute_detailedUsage.xml">4111</uro:detailedUsage>
+					<uro:buildingHeight uom="m">-9999</uro:buildingHeight>
+					<uro:surveyYear>2020</uro:surveyYear>
+				</uro:BuildingDetailAttribute>
+			</uro:buildingDetailAttribute>
+			<uro:bldgDataQualityAttribute>
+				<uro:DataQualityAttribute>
+					<uro:geometrySrcDescLod0 codeSpace="../../codelists/DataQualityAttribute_geometrySrcDesc.xml">000</uro:geometrySrcDescLod0>
+					<uro:geometrySrcDescLod1 codeSpace="../../codelists/DataQualityAttribute_geometrySrcDesc.xml">000</uro:geometrySrcDescLod1>
+					<uro:thematicSrcDesc codeSpace="../../codelists/DataQualityAttribute_thematicSrcDesc.xml">100</uro:thematicSrcDesc>
+					<uro:thematicSrcDesc codeSpace="../../codelists/DataQualityAttribute_thematicSrcDesc.xml">201</uro:thematicSrcDesc>
+					<uro:thematicSrcDesc codeSpace="../../codelists/DataQualityAttribute_thematicSrcDesc.xml">000</uro:thematicSrcDesc>
+					<uro:lod1HeightType codeSpace="../../codelists/DataQualityAttribute_lod1HeightType.xml">2</uro:lod1HeightType>
+					<uro:publicSurveyDataQualityAttribute>
+						<uro:PublicSurveyDataQualityAttribute>
+							<uro:srcScaleLod0 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_srcScale.xml">1</uro:srcScaleLod0>
+							<uro:srcScaleLod1 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_srcScale.xml">1</uro:srcScaleLod1>
+							<uro:publicSurveySrcDescLod0 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_publicSurveySrcDesc.xml">023</uro:publicSurveySrcDescLod0>
+							<uro:publicSurveySrcDescLod1 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_publicSurveySrcDesc.xml">023</uro:publicSurveySrcDescLod1>
+							<uro:publicSurveySrcDescLod1 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_publicSurveySrcDesc.xml">003</uro:publicSurveySrcDescLod1>
+						</uro:PublicSurveyDataQualityAttribute>
+					</uro:publicSurveyDataQualityAttribute>
+				</uro:DataQualityAttribute>
+			</uro:bldgDataQualityAttribute>
 		</bldg:Building>
 	</core:cityObjectMember>
 
 	<!-- Circular building precisely centered on mesh boundary for perfect equal division -->
 	<core:cityObjectMember>
-		<bldg:Building gml:id="bldg_circular_equal_area">
+		<bldg:Building gml:id="bldg_0f775683-636e-4948-8aa8-bd8db6921f0b">
 			<core:creationDate>2025-03-21</core:creationDate>
 			<bldg:class codeSpace="../../codelists/Building_class.xml">3001</bldg:class>
 			<bldg:usage codeSpace="../../codelists/Building_usage.xml">431</bldg:usage>
@@ -72,17 +111,17 @@ http://www.opengis.net/citygml/appearance/2.0 http://schemas.opengis.net/citygml
 									<!-- Approximated circle centered exactly on longitude boundary 137.075 -->
 									<gml:posList>
                                         36.660 137.0745 0
-                                        36.66025 137.07465 0
-                                        36.66041421 137.07480 0
-                                        36.66050 137.075 0
-                                        36.66041421 137.0752 0
-                                        36.66025 137.07535 0
-                                        36.660 137.0755 0
-                                        36.65975 137.07535 0
-                                        36.65958579 137.0752 0
-                                        36.6595 137.075 0
-                                        36.65958579 137.07480 0
                                         36.65975 137.07465 0
+                                        36.65958579 137.07480 0
+                                        36.6595 137.075 0
+                                        36.65958579 137.0752 0
+                                        36.65975 137.07535 0
+                                        36.660 137.0755 0
+                                        36.66025 137.07535 0
+                                        36.66041421 137.0752 0
+                                        36.66050 137.075 0
+                                        36.66041421 137.07480 0
+                                        36.66025 137.07465 0
                                         36.660 137.0745 0
                                     </gml:posList>
 								</gml:LinearRing>
@@ -91,13 +130,52 @@ http://www.opengis.net/citygml/appearance/2.0 http://schemas.opengis.net/citygml
 					</gml:surfaceMember>
 				</gml:MultiSurface>
 			</bldg:lod0RoofEdge>
+			<uro:buildingIDAttribute>
+				<uro:BuildingIDAttribute>
+					<uro:buildingID>16211-bldg-2</uro:buildingID>
+					<uro:prefecture codeSpace="../../codelists/Common_localPublicAuthorities.xml">16</uro:prefecture>
+					<uro:city codeSpace="../../codelists/Common_localPublicAuthorities.xml">16211</uro:city>
+				</uro:BuildingIDAttribute>
+			</uro:buildingIDAttribute>
+			<uro:buildingDetailAttribute>
+				<uro:BuildingDetailAttribute>
+					<uro:totalFloorArea uom="m2">76.2</uro:totalFloorArea>
+					<uro:buildingFootprintArea uom="m2">76.2</uro:buildingFootprintArea>
+					<uro:buildingRoofEdgeArea uom="m2">58.7</uro:buildingRoofEdgeArea>
+					<uro:buildingStructureType codeSpace="../../codelists/BuildingDetailAttribute_buildingStructureType.xml">611</uro:buildingStructureType>
+					<uro:fireproofStructureType codeSpace="../../codelists/BuildingDetailAttribute_fireproofStructureType.xml">1011</uro:fireproofStructureType>
+					<uro:landUseType codeSpace="../../codelists/Common_landUseType.xml">211</uro:landUseType>
+					<uro:detailedUsage codeSpace="../../codelists/BuildingDetailAttribute_detailedUsage.xml">4111</uro:detailedUsage>
+					<uro:buildingHeight uom="m">-9999</uro:buildingHeight>
+					<uro:surveyYear>2020</uro:surveyYear>
+				</uro:BuildingDetailAttribute>
+			</uro:buildingDetailAttribute>
+			<uro:bldgDataQualityAttribute>
+				<uro:DataQualityAttribute>
+					<uro:geometrySrcDescLod0 codeSpace="../../codelists/DataQualityAttribute_geometrySrcDesc.xml">000</uro:geometrySrcDescLod0>
+					<uro:geometrySrcDescLod1 codeSpace="../../codelists/DataQualityAttribute_geometrySrcDesc.xml">000</uro:geometrySrcDescLod1>
+					<uro:thematicSrcDesc codeSpace="../../codelists/DataQualityAttribute_thematicSrcDesc.xml">100</uro:thematicSrcDesc>
+					<uro:thematicSrcDesc codeSpace="../../codelists/DataQualityAttribute_thematicSrcDesc.xml">201</uro:thematicSrcDesc>
+					<uro:thematicSrcDesc codeSpace="../../codelists/DataQualityAttribute_thematicSrcDesc.xml">000</uro:thematicSrcDesc>
+					<uro:lod1HeightType codeSpace="../../codelists/DataQualityAttribute_lod1HeightType.xml">2</uro:lod1HeightType>
+					<uro:publicSurveyDataQualityAttribute>
+						<uro:PublicSurveyDataQualityAttribute>
+							<uro:srcScaleLod0 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_srcScale.xml">1</uro:srcScaleLod0>
+							<uro:srcScaleLod1 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_srcScale.xml">1</uro:srcScaleLod1>
+							<uro:publicSurveySrcDescLod0 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_publicSurveySrcDesc.xml">023</uro:publicSurveySrcDescLod0>
+							<uro:publicSurveySrcDescLod1 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_publicSurveySrcDesc.xml">023</uro:publicSurveySrcDescLod1>
+							<uro:publicSurveySrcDescLod1 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_publicSurveySrcDesc.xml">003</uro:publicSurveySrcDescLod1>
+						</uro:PublicSurveyDataQualityAttribute>
+					</uro:publicSurveyDataQualityAttribute>
+				</uro:DataQualityAttribute>
+			</uro:bldgDataQualityAttribute>
 		</bldg:Building>
 	</core:cityObjectMember>
 
 	<!-- Rectangular building crossing latitude mesh boundary -->
 	<!-- Mesh boundary at 36.666666667 latitude (multiple of 0.008333333 degree intervals) -->
 	<core:cityObjectMember>
-		<bldg:Building gml:id="bldg_lat_boundary_equal">
+		<bldg:Building gml:id="bldg_3682cf30-a7cd-40f5-ba9f-7146698e1590">
 			<core:creationDate>2025-03-21</core:creationDate>
 			<bldg:class codeSpace="../../codelists/Building_class.xml">3002</bldg:class>
 			<bldg:usage codeSpace="../../codelists/Building_usage.xml">452</bldg:usage>
@@ -113,11 +191,11 @@ http://www.opengis.net/citygml/appearance/2.0 http://schemas.opengis.net/citygml
 							<gml:exterior>
 								<gml:LinearRing>
 									<gml:posList>
-                                        36.66625 137.0751 0
-                                        36.66708333333 137.0751 0
-                                        36.66708333333 137.0754 0
-                                        36.66625 137.0754 0
-                                        36.66625 137.0751 0
+                                        36.66625 137.0757 0
+                                        36.66625 137.0760 0
+                                        36.66708333333 137.0760 0
+                                        36.66708333333 137.0757 0
+                                        36.66625 137.0757 0
                                     </gml:posList>
 								</gml:LinearRing>
 							</gml:exterior>
@@ -125,6 +203,45 @@ http://www.opengis.net/citygml/appearance/2.0 http://schemas.opengis.net/citygml
 					</gml:surfaceMember>
 				</gml:MultiSurface>
 			</bldg:lod0RoofEdge>
+			<uro:buildingIDAttribute>
+				<uro:BuildingIDAttribute>
+					<uro:buildingID>16211-bldg-3</uro:buildingID>
+					<uro:prefecture codeSpace="../../codelists/Common_localPublicAuthorities.xml">16</uro:prefecture>
+					<uro:city codeSpace="../../codelists/Common_localPublicAuthorities.xml">16211</uro:city>
+				</uro:BuildingIDAttribute>
+			</uro:buildingIDAttribute>
+			<uro:buildingDetailAttribute>
+				<uro:BuildingDetailAttribute>
+					<uro:totalFloorArea uom="m2">76.2</uro:totalFloorArea>
+					<uro:buildingFootprintArea uom="m2">76.2</uro:buildingFootprintArea>
+					<uro:buildingRoofEdgeArea uom="m2">58.7</uro:buildingRoofEdgeArea>
+					<uro:buildingStructureType codeSpace="../../codelists/BuildingDetailAttribute_buildingStructureType.xml">611</uro:buildingStructureType>
+					<uro:fireproofStructureType codeSpace="../../codelists/BuildingDetailAttribute_fireproofStructureType.xml">1011</uro:fireproofStructureType>
+					<uro:landUseType codeSpace="../../codelists/Common_landUseType.xml">211</uro:landUseType>
+					<uro:detailedUsage codeSpace="../../codelists/BuildingDetailAttribute_detailedUsage.xml">4111</uro:detailedUsage>
+					<uro:buildingHeight uom="m">-9999</uro:buildingHeight>
+					<uro:surveyYear>2020</uro:surveyYear>
+				</uro:BuildingDetailAttribute>
+			</uro:buildingDetailAttribute>
+			<uro:bldgDataQualityAttribute>
+				<uro:DataQualityAttribute>
+					<uro:geometrySrcDescLod0 codeSpace="../../codelists/DataQualityAttribute_geometrySrcDesc.xml">000</uro:geometrySrcDescLod0>
+					<uro:geometrySrcDescLod1 codeSpace="../../codelists/DataQualityAttribute_geometrySrcDesc.xml">000</uro:geometrySrcDescLod1>
+					<uro:thematicSrcDesc codeSpace="../../codelists/DataQualityAttribute_thematicSrcDesc.xml">100</uro:thematicSrcDesc>
+					<uro:thematicSrcDesc codeSpace="../../codelists/DataQualityAttribute_thematicSrcDesc.xml">201</uro:thematicSrcDesc>
+					<uro:thematicSrcDesc codeSpace="../../codelists/DataQualityAttribute_thematicSrcDesc.xml">000</uro:thematicSrcDesc>
+					<uro:lod1HeightType codeSpace="../../codelists/DataQualityAttribute_lod1HeightType.xml">2</uro:lod1HeightType>
+					<uro:publicSurveyDataQualityAttribute>
+						<uro:PublicSurveyDataQualityAttribute>
+							<uro:srcScaleLod0 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_srcScale.xml">1</uro:srcScaleLod0>
+							<uro:srcScaleLod1 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_srcScale.xml">1</uro:srcScaleLod1>
+							<uro:publicSurveySrcDescLod0 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_publicSurveySrcDesc.xml">023</uro:publicSurveySrcDescLod0>
+							<uro:publicSurveySrcDescLod1 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_publicSurveySrcDesc.xml">023</uro:publicSurveySrcDescLod1>
+							<uro:publicSurveySrcDescLod1 codeSpace="../../codelists/PublicSurveyDataQualityAttribute_publicSurveySrcDesc.xml">003</uro:publicSurveySrcDescLod1>
+						</uro:PublicSurveyDataQualityAttribute>
+					</uro:publicSurveyDataQualityAttribute>
+				</uro:DataQualityAttribute>
+			</uro:bldgDataQualityAttribute>
 		</bldg:Building>
 	</core:cityObjectMember>
 

--- a/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-03_meshcode-extractor_03/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau4/02-bldg/Z-bldg-03_meshcode-extractor_03/workflow_test.json
@@ -1,6 +1,5 @@
 {
   "description": "Test PLATEAU4.DestinationMeshCodeExtractor with cross-mesh features having equal areas - should select mesh with smaller mesh code",
-  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau4/02-bldg/workflow.yml",
   "workflowVariables": [
     {
@@ -49,5 +48,5 @@
       ]
     }
   },
-  "expectResultOkFile": false
+  "expectResultOkFile": true
 }

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-03_meshcode-extractor_01/udx/bldg/54377084_bldg_6697_op.gml
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-03_meshcode-extractor_01/udx/bldg/54377084_bldg_6697_op.gml
@@ -26,9 +26,10 @@ urn:oasis:names:tc:ciq:xal:3 ../../schemas/citygml/xAL/3.0/xAL.xsd">
 	</gml:boundedBy>
 	<core:cityObjectMember>
 		<bldg:Building gml:id="bldg_b3f078de-02e4-11f0-9961-18ece7a5508c">
-			<core:creationDate>2025-03-21</core:creationDate>
+			<core:creationDate>2025-03-21T00:00:00</core:creationDate>
 			<bldg:class>3001</bldg:class>
 			<bldg:usage>461</bldg:usage>
+			<con:dateOfConstruction>2020-04-01</con:dateOfConstruction>
 			<con:height>
 				<con:Height>
 					<con:highReference>highestRoofEdge</con:highReference>
@@ -37,6 +38,8 @@ urn:oasis:names:tc:ciq:xal:3 ../../schemas/citygml/xAL/3.0/xAL.xsd">
 					<con:value uom="m">8.4</con:value>
 				</con:Height>
 			</con:height>
+			<bldg:storeysAboveGround>2</bldg:storeysAboveGround>
+			<bldg:storeysBelowGround>0</bldg:storeysBelowGround>
 			<core:lod0MultiSurface>
 				<gml:MultiSurface gml:id="ms_lod0_bldg_b3f078de">
 					<gml:surfaceMember>
@@ -50,6 +53,45 @@ urn:oasis:names:tc:ciq:xal:3 ../../schemas/citygml/xAL/3.0/xAL.xsd">
 					</gml:surfaceMember>
 				</gml:MultiSurface>
 			</core:lod0MultiSurface>
+			<bldg:adeOfAbstractBuilding>
+				<uro:BuildingIDAttribute>
+					<uro:buildingID>16211-bldg-1</uro:buildingID>
+					<uro:prefecture>16</uro:prefecture>
+					<uro:city>16211</uro:city>
+				</uro:BuildingIDAttribute>
+			</bldg:adeOfAbstractBuilding>
+			<bldg:adeOfAbstractBuilding>
+				<uro:BuildingDetailAttribute>
+					<uro:totalFloorArea uom="m2">76.2</uro:totalFloorArea>
+					<uro:buildingFootprintArea uom="m2">76.2</uro:buildingFootprintArea>
+					<uro:buildingRoofEdgeArea uom="m2">58.7</uro:buildingRoofEdgeArea>
+					<uro:buildingStructureType>611</uro:buildingStructureType>
+					<uro:fireproofStructureType>1011</uro:fireproofStructureType>
+					<uro:landUseType>211</uro:landUseType>
+					<uro:detailedUsage>4111</uro:detailedUsage>
+					<uro:buildingHeight uom="m">8.6</uro:buildingHeight>
+					<uro:surveyYear>2020-01-01</uro:surveyYear>
+				</uro:BuildingDetailAttribute>
+			</bldg:adeOfAbstractBuilding>
+			<core:adeOfAbstractCityObject>
+				<urc:DataQualityAttribute>
+					<urc:geometrySrcDescLod0>000</urc:geometrySrcDescLod0>
+					<urc:geometrySrcDescLod1>000</urc:geometrySrcDescLod1>
+					<urc:thematicSrcDesc>100</urc:thematicSrcDesc>
+					<urc:thematicSrcDesc>201</urc:thematicSrcDesc>
+					<urc:thematicSrcDesc>000</urc:thematicSrcDesc>
+					<urc:lod1HeightType>2</urc:lod1HeightType>
+					<urc:publicSurveyDataQualityAttribute>
+						<urc:PublicSurveyDataQualityAttribute>
+							<urc:srcScaleLod0>1</urc:srcScaleLod0>
+							<urc:srcScaleLod1>1</urc:srcScaleLod1>
+							<urc:publicSurveySrcDescLod0>023</urc:publicSurveySrcDescLod0>
+							<urc:publicSurveySrcDescLod1>023</urc:publicSurveySrcDescLod1>
+							<urc:publicSurveySrcDescLod1>003</urc:publicSurveySrcDescLod1>
+						</urc:PublicSurveyDataQualityAttribute>
+					</urc:publicSurveyDataQualityAttribute>
+				</urc:DataQualityAttribute>
+			</core:adeOfAbstractCityObject>
 		</bldg:Building>
 	</core:cityObjectMember>
 </core:CityModel>

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-03_meshcode-extractor_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-03_meshcode-extractor_01/workflow_test.json
@@ -1,6 +1,5 @@
 {
   "description": "Test Z-bldg-03 (図郭不正 / meshcode) for plateau6",
-  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {
@@ -49,5 +48,5 @@
       ]
     }
   },
-  "expectResultOkFile": false
+  "expectResultOkFile": true
 }

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-03_meshcode-extractor_02/02_建築物_図郭不正.csv
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-03_meshcode-extractor_02/02_建築物_図郭不正.csv
@@ -1,2 +1,2 @@
 "mesh2area","meshcode","filename","meshcount","feature_type","lod","gml_id"
-"[{""mesh_code"":54377095,""area"":743948.68},{""mesh_code"":54377096,""area"":0.01}]",54377095,"54377094_bldg_6697_op.gml",2,"bldg:Building",0,"bldg_cross_mesh_test_building"
+"[{""mesh_code"":54377095,""area"":743948.68},{""mesh_code"":54377096,""area"":0.01}]",54377095,"54377094_bldg_6697_op.gml",2,"bldg:Building",0,"bldg_b7a7ca6b-6667-4733-9e4f-7dc4b1bef9c6"

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-03_meshcode-extractor_02/udx/bldg/54377094_bldg_6697_op.gml
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-03_meshcode-extractor_02/udx/bldg/54377094_bldg_6697_op.gml
@@ -25,10 +25,11 @@ urn:oasis:names:tc:ciq:xal:3 ../../schemas/citygml/xAL/3.0/xAL.xsd">
 		</gml:Envelope>
 	</gml:boundedBy>
 	<core:cityObjectMember>
-		<bldg:Building gml:id="bldg_cross_mesh_test_building">
-			<core:creationDate>2025-03-21</core:creationDate>
+		<bldg:Building gml:id="bldg_b7a7ca6b-6667-4733-9e4f-7dc4b1bef9c6">
+			<core:creationDate>2025-03-21T00:00:00</core:creationDate>
 			<bldg:class>3001</bldg:class>
 			<bldg:usage>461</bldg:usage>
+			<con:dateOfConstruction>2020-04-01</con:dateOfConstruction>
 			<con:height>
 				<con:Height>
 					<con:highReference>highestRoofEdge</con:highReference>
@@ -37,19 +38,60 @@ urn:oasis:names:tc:ciq:xal:3 ../../schemas/citygml/xAL/3.0/xAL.xsd">
 					<con:value uom="m">15.0</con:value>
 				</con:Height>
 			</con:height>
+			<bldg:storeysAboveGround>2</bldg:storeysAboveGround>
+			<bldg:storeysBelowGround>0</bldg:storeysBelowGround>
 			<core:lod0MultiSurface>
-				<gml:MultiSurface gml:id="ms_lod0_bldg_cross_mesh_test_building">
+				<gml:MultiSurface gml:id="ms_lod0_bldg_b7a7ca6b-6667-4733-9e4f-7dc4b1bef9c6">
 					<gml:surfaceMember>
-						<gml:Polygon gml:id="poly_lod0_bldg_cross_mesh_test_building">
+						<gml:Polygon gml:id="poly_lod0_bldg_b7a7ca6b-6667-4733-9e4f-7dc4b1bef9c6">
 							<gml:exterior>
 								<gml:LinearRing>
-									<gml:posList>36.658333333 137.0650 0 36.665833333 137.0650 0 36.665833333 137.0750 0 36.658333333 137.0750 0 36.658333333 137.0650 0</gml:posList>
+									<gml:posList>36.658333333 137.0650 0 36.658333333 137.0750 0 36.665833333 137.0750 0 36.665833333 137.0650 0 36.658333333 137.0650 0</gml:posList>
 								</gml:LinearRing>
 							</gml:exterior>
 						</gml:Polygon>
 					</gml:surfaceMember>
 				</gml:MultiSurface>
 			</core:lod0MultiSurface>
+			<bldg:adeOfAbstractBuilding>
+				<uro:BuildingIDAttribute>
+					<uro:buildingID>16211-bldg-1</uro:buildingID>
+					<uro:prefecture>16</uro:prefecture>
+					<uro:city>16211</uro:city>
+				</uro:BuildingIDAttribute>
+			</bldg:adeOfAbstractBuilding>
+			<bldg:adeOfAbstractBuilding>
+				<uro:BuildingDetailAttribute>
+					<uro:totalFloorArea uom="m2">76.2</uro:totalFloorArea>
+					<uro:buildingFootprintArea uom="m2">76.2</uro:buildingFootprintArea>
+					<uro:buildingRoofEdgeArea uom="m2">58.7</uro:buildingRoofEdgeArea>
+					<uro:buildingStructureType>611</uro:buildingStructureType>
+					<uro:fireproofStructureType>1011</uro:fireproofStructureType>
+					<uro:landUseType>211</uro:landUseType>
+					<uro:detailedUsage>4111</uro:detailedUsage>
+					<uro:buildingHeight uom="m">8.6</uro:buildingHeight>
+					<uro:surveyYear>2020-01-01</uro:surveyYear>
+				</uro:BuildingDetailAttribute>
+			</bldg:adeOfAbstractBuilding>
+			<core:adeOfAbstractCityObject>
+				<urc:DataQualityAttribute>
+					<urc:geometrySrcDescLod0>000</urc:geometrySrcDescLod0>
+					<urc:geometrySrcDescLod1>000</urc:geometrySrcDescLod1>
+					<urc:thematicSrcDesc>100</urc:thematicSrcDesc>
+					<urc:thematicSrcDesc>201</urc:thematicSrcDesc>
+					<urc:thematicSrcDesc>000</urc:thematicSrcDesc>
+					<urc:lod1HeightType>2</urc:lod1HeightType>
+					<urc:publicSurveyDataQualityAttribute>
+						<urc:PublicSurveyDataQualityAttribute>
+							<urc:srcScaleLod0>1</urc:srcScaleLod0>
+							<urc:srcScaleLod1>1</urc:srcScaleLod1>
+							<urc:publicSurveySrcDescLod0>023</urc:publicSurveySrcDescLod0>
+							<urc:publicSurveySrcDescLod1>023</urc:publicSurveySrcDescLod1>
+							<urc:publicSurveySrcDescLod1>003</urc:publicSurveySrcDescLod1>
+						</urc:PublicSurveyDataQualityAttribute>
+					</urc:publicSurveyDataQualityAttribute>
+				</urc:DataQualityAttribute>
+			</core:adeOfAbstractCityObject>
 		</bldg:Building>
 	</core:cityObjectMember>
 </core:CityModel>

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-03_meshcode-extractor_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-03_meshcode-extractor_02/workflow_test.json
@@ -1,6 +1,5 @@
 {
   "description": "Test Z-bldg-03 (図郭不正 / meshcode) for plateau6 (crosses mesh boundary)",
-  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {
@@ -49,5 +48,5 @@
       ]
     }
   },
-  "expectResultOkFile": false
+  "expectResultOkFile": true
 }

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-03_meshcode-extractor_03/02_建築物_図郭不正.csv
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-03_meshcode-extractor_03/02_建築物_図郭不正.csv
@@ -1,4 +1,4 @@
 "mesh2area","lod","feature_type","meshcode","filename","meshcount","gml_id"
-"[{""mesh_code"":54377095,""area"":2066.41},{""mesh_code"":54377096,""area"":2066.41},{""mesh_code"":55370005,""area"":4132.78},{""mesh_code"":55370006,""area"":4132.78}]",0,"bldg:Building",55370005,"equal_area_cross_mesh.gml",4,"bldg_equal_area_cross_mesh"
-"[{""mesh_code"":54377095,""area"":3174.0},{""mesh_code"":54377096,""area"":3174.0}]",0,"bldg:Building",54377095,"equal_area_cross_mesh.gml",2,"bldg_circular_equal_area"
-"[{""mesh_code"":54377096,""area"":1239.85},{""mesh_code"":55370006,""area"":1239.84}]",0,"bldg:Building",54377096,"equal_area_cross_mesh.gml",2,"bldg_lat_boundary_equal"
+"[{""mesh_code"":54377095,""area"":2066.41},{""mesh_code"":54377096,""area"":2066.41},{""mesh_code"":55370005,""area"":4132.78},{""mesh_code"":55370006,""area"":4132.78}]",0,"bldg:Building",55370005,"equal_area_cross_mesh.gml",4,"bldg_5a56023c-0e19-4333-b840-ac0647de7a9b"
+"[{""mesh_code"":54377095,""area"":3174.0},{""mesh_code"":54377096,""area"":3174.0}]",0,"bldg:Building",54377095,"equal_area_cross_mesh.gml",2,"bldg_0f775683-636e-4948-8aa8-bd8db6921f0b"
+"[{""mesh_code"":54377096,""area"":1239.85},{""mesh_code"":55370006,""area"":1239.84}]",0,"bldg:Building",54377096,"equal_area_cross_mesh.gml",2,"bldg_3682cf30-a7cd-40f5-ba9f-7146698e1590"

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-03_meshcode-extractor_03/udx/bldg/equal_area_cross_mesh.gml
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-03_meshcode-extractor_03/udx/bldg/equal_area_cross_mesh.gml
@@ -28,10 +28,11 @@ urn:oasis:names:tc:ciq:xal:3 ../../schemas/citygml/xAL/3.0/xAL.xsd">
 	<!-- Building with exactly equal areas in two adjacent 1km meshes -->
 	<!-- Mesh boundary at 137.075 longitude (multiple of 0.0125 degree intervals) -->
 	<core:cityObjectMember>
-		<bldg:Building gml:id="bldg_equal_area_cross_mesh">
-			<core:creationDate>2025-03-21</core:creationDate>
+		<bldg:Building gml:id="bldg_5a56023c-0e19-4333-b840-ac0647de7a9b">
+			<core:creationDate>2025-03-21T00:00:00</core:creationDate>
 			<bldg:class>3001</bldg:class>
 			<bldg:usage>422</bldg:usage>
+			<con:dateOfConstruction>2020-04-01</con:dateOfConstruction>
 			<con:height>
 				<con:Height>
 					<con:highReference>highestRoofEdge</con:highReference>
@@ -40,10 +41,12 @@ urn:oasis:names:tc:ciq:xal:3 ../../schemas/citygml/xAL/3.0/xAL.xsd">
 					<con:value uom="m">12.0</con:value>
 				</con:Height>
 			</con:height>
+			<bldg:storeysAboveGround>2</bldg:storeysAboveGround>
+			<bldg:storeysBelowGround>0</bldg:storeysBelowGround>
 			<core:lod0MultiSurface>
-				<gml:MultiSurface gml:id="ms_lod0_bldg_equal_area_cross_mesh">
+				<gml:MultiSurface gml:id="ms_lod0_bldg_5a56023c-0e19-4333-b840-ac0647de7a9b">
 					<gml:surfaceMember>
-						<gml:Polygon gml:id="poly_lod0_bldg_equal_area_cross_mesh">
+						<gml:Polygon gml:id="poly_lod0_bldg_5a56023c-0e19-4333-b840-ac0647de7a9b">
 							<gml:exterior>
 								<gml:LinearRing>
 									<gml:posList>36.66625 137.0745 0 36.66625 137.0755 0 36.66750 137.0755 0 36.66750 137.0745 0 36.66625 137.0745 0</gml:posList>
@@ -53,15 +56,55 @@ urn:oasis:names:tc:ciq:xal:3 ../../schemas/citygml/xAL/3.0/xAL.xsd">
 					</gml:surfaceMember>
 				</gml:MultiSurface>
 			</core:lod0MultiSurface>
+			<bldg:adeOfAbstractBuilding>
+				<uro:BuildingIDAttribute>
+					<uro:buildingID>16211-bldg-1</uro:buildingID>
+					<uro:prefecture>16</uro:prefecture>
+					<uro:city>16211</uro:city>
+				</uro:BuildingIDAttribute>
+			</bldg:adeOfAbstractBuilding>
+			<bldg:adeOfAbstractBuilding>
+				<uro:BuildingDetailAttribute>
+					<uro:totalFloorArea uom="m2">76.2</uro:totalFloorArea>
+					<uro:buildingFootprintArea uom="m2">76.2</uro:buildingFootprintArea>
+					<uro:buildingRoofEdgeArea uom="m2">58.7</uro:buildingRoofEdgeArea>
+					<uro:buildingStructureType>611</uro:buildingStructureType>
+					<uro:fireproofStructureType>1011</uro:fireproofStructureType>
+					<uro:landUseType>211</uro:landUseType>
+					<uro:detailedUsage>4111</uro:detailedUsage>
+					<uro:buildingHeight uom="m">8.6</uro:buildingHeight>
+					<uro:surveyYear>2020-01-01</uro:surveyYear>
+				</uro:BuildingDetailAttribute>
+			</bldg:adeOfAbstractBuilding>
+			<core:adeOfAbstractCityObject>
+				<urc:DataQualityAttribute>
+					<urc:geometrySrcDescLod0>000</urc:geometrySrcDescLod0>
+					<urc:geometrySrcDescLod1>000</urc:geometrySrcDescLod1>
+					<urc:thematicSrcDesc>100</urc:thematicSrcDesc>
+					<urc:thematicSrcDesc>201</urc:thematicSrcDesc>
+					<urc:thematicSrcDesc>000</urc:thematicSrcDesc>
+					<urc:lod1HeightType>2</urc:lod1HeightType>
+					<urc:publicSurveyDataQualityAttribute>
+						<urc:PublicSurveyDataQualityAttribute>
+							<urc:srcScaleLod0>1</urc:srcScaleLod0>
+							<urc:srcScaleLod1>1</urc:srcScaleLod1>
+							<urc:publicSurveySrcDescLod0>023</urc:publicSurveySrcDescLod0>
+							<urc:publicSurveySrcDescLod1>023</urc:publicSurveySrcDescLod1>
+							<urc:publicSurveySrcDescLod1>003</urc:publicSurveySrcDescLod1>
+						</urc:PublicSurveyDataQualityAttribute>
+					</urc:publicSurveyDataQualityAttribute>
+				</urc:DataQualityAttribute>
+			</core:adeOfAbstractCityObject>
 		</bldg:Building>
 	</core:cityObjectMember>
 
 	<!-- Circular building precisely centered on mesh boundary for perfect equal division -->
 	<core:cityObjectMember>
-		<bldg:Building gml:id="bldg_circular_equal_area">
-			<core:creationDate>2025-03-21</core:creationDate>
+		<bldg:Building gml:id="bldg_0f775683-636e-4948-8aa8-bd8db6921f0b">
+			<core:creationDate>2025-03-21T00:00:00</core:creationDate>
 			<bldg:class>3001</bldg:class>
 			<bldg:usage>431</bldg:usage>
+			<con:dateOfConstruction>2020-04-01</con:dateOfConstruction>
 			<con:height>
 				<con:Height>
 					<con:highReference>highestRoofEdge</con:highReference>
@@ -70,30 +113,72 @@ urn:oasis:names:tc:ciq:xal:3 ../../schemas/citygml/xAL/3.0/xAL.xsd">
 					<con:value uom="m">8.0</con:value>
 				</con:Height>
 			</con:height>
+			<bldg:storeysAboveGround>2</bldg:storeysAboveGround>
+			<bldg:storeysBelowGround>0</bldg:storeysBelowGround>
 			<core:lod0MultiSurface>
-				<gml:MultiSurface gml:id="ms_lod0_bldg_circular_equal_area">
+				<gml:MultiSurface gml:id="ms_lod0_bldg_0f775683-636e-4948-8aa8-bd8db6921f0b">
 					<gml:surfaceMember>
-						<gml:Polygon gml:id="poly_lod0_bldg_circular_equal_area">
+						<gml:Polygon gml:id="poly_lod0_bldg_0f775683-636e-4948-8aa8-bd8db6921f0b">
 							<gml:exterior>
 								<gml:LinearRing>
 									<!-- Approximated circle centered exactly on longitude boundary 137.075 -->
-									<gml:posList>36.660 137.0745 0 36.66025 137.07465 0 36.66041421 137.07480 0 36.66050 137.075 0 36.66041421 137.0752 0 36.66025 137.07535 0 36.660 137.0755 0 36.65975 137.07535 0 36.65958579 137.0752 0 36.6595 137.075 0 36.65958579 137.07480 0 36.65975 137.07465 0 36.660 137.0745 0</gml:posList>
+									<gml:posList>36.660 137.0745 0 36.65975 137.07465 0 36.65958579 137.07480 0 36.6595 137.075 0 36.65958579 137.0752 0 36.65975 137.07535 0 36.660 137.0755 0 36.66025 137.07535 0 36.66041421 137.0752 0 36.66050 137.075 0 36.66041421 137.07480 0 36.66025 137.07465 0 36.660 137.0745 0</gml:posList>
 								</gml:LinearRing>
 							</gml:exterior>
 						</gml:Polygon>
 					</gml:surfaceMember>
 				</gml:MultiSurface>
 			</core:lod0MultiSurface>
+			<bldg:adeOfAbstractBuilding>
+				<uro:BuildingIDAttribute>
+					<uro:buildingID>16211-bldg-2</uro:buildingID>
+					<uro:prefecture>16</uro:prefecture>
+					<uro:city>16211</uro:city>
+				</uro:BuildingIDAttribute>
+			</bldg:adeOfAbstractBuilding>
+			<bldg:adeOfAbstractBuilding>
+				<uro:BuildingDetailAttribute>
+					<uro:totalFloorArea uom="m2">76.2</uro:totalFloorArea>
+					<uro:buildingFootprintArea uom="m2">76.2</uro:buildingFootprintArea>
+					<uro:buildingRoofEdgeArea uom="m2">58.7</uro:buildingRoofEdgeArea>
+					<uro:buildingStructureType>611</uro:buildingStructureType>
+					<uro:fireproofStructureType>1011</uro:fireproofStructureType>
+					<uro:landUseType>211</uro:landUseType>
+					<uro:detailedUsage>4111</uro:detailedUsage>
+					<uro:buildingHeight uom="m">8.6</uro:buildingHeight>
+					<uro:surveyYear>2020-01-01</uro:surveyYear>
+				</uro:BuildingDetailAttribute>
+			</bldg:adeOfAbstractBuilding>
+			<core:adeOfAbstractCityObject>
+				<urc:DataQualityAttribute>
+					<urc:geometrySrcDescLod0>000</urc:geometrySrcDescLod0>
+					<urc:geometrySrcDescLod1>000</urc:geometrySrcDescLod1>
+					<urc:thematicSrcDesc>100</urc:thematicSrcDesc>
+					<urc:thematicSrcDesc>201</urc:thematicSrcDesc>
+					<urc:thematicSrcDesc>000</urc:thematicSrcDesc>
+					<urc:lod1HeightType>2</urc:lod1HeightType>
+					<urc:publicSurveyDataQualityAttribute>
+						<urc:PublicSurveyDataQualityAttribute>
+							<urc:srcScaleLod0>1</urc:srcScaleLod0>
+							<urc:srcScaleLod1>1</urc:srcScaleLod1>
+							<urc:publicSurveySrcDescLod0>023</urc:publicSurveySrcDescLod0>
+							<urc:publicSurveySrcDescLod1>023</urc:publicSurveySrcDescLod1>
+							<urc:publicSurveySrcDescLod1>003</urc:publicSurveySrcDescLod1>
+						</urc:PublicSurveyDataQualityAttribute>
+					</urc:publicSurveyDataQualityAttribute>
+				</urc:DataQualityAttribute>
+			</core:adeOfAbstractCityObject>
 		</bldg:Building>
 	</core:cityObjectMember>
 
 	<!-- Rectangular building crossing latitude mesh boundary -->
 	<!-- Mesh boundary at 36.666666667 latitude (multiple of 0.008333333 degree intervals) -->
 	<core:cityObjectMember>
-		<bldg:Building gml:id="bldg_lat_boundary_equal">
-			<core:creationDate>2025-03-21</core:creationDate>
+		<bldg:Building gml:id="bldg_3682cf30-a7cd-40f5-ba9f-7146698e1590">
+			<core:creationDate>2025-03-21T00:00:00</core:creationDate>
 			<bldg:class>3002</bldg:class>
 			<bldg:usage>452</bldg:usage>
+			<con:dateOfConstruction>2020-04-01</con:dateOfConstruction>
 			<con:height>
 				<con:Height>
 					<con:highReference>highestRoofEdge</con:highReference>
@@ -102,19 +187,60 @@ urn:oasis:names:tc:ciq:xal:3 ../../schemas/citygml/xAL/3.0/xAL.xsd">
 					<con:value uom="m">10.5</con:value>
 				</con:Height>
 			</con:height>
+			<bldg:storeysAboveGround>2</bldg:storeysAboveGround>
+			<bldg:storeysBelowGround>0</bldg:storeysBelowGround>
 			<core:lod0MultiSurface>
-				<gml:MultiSurface gml:id="ms_lod0_bldg_lat_boundary_equal">
+				<gml:MultiSurface gml:id="ms_lod0_bldg_3682cf30-a7cd-40f5-ba9f-7146698e1590">
 					<gml:surfaceMember>
-						<gml:Polygon gml:id="poly_lod0_bldg_lat_boundary_equal">
+						<gml:Polygon gml:id="poly_lod0_bldg_3682cf30-a7cd-40f5-ba9f-7146698e1590">
 							<gml:exterior>
 								<gml:LinearRing>
-									<gml:posList>36.66625 137.0751 0 36.66708333333 137.0751 0 36.66708333333 137.0754 0 36.66625 137.0754 0 36.66625 137.0751 0</gml:posList>
+									<gml:posList>36.66625 137.0757 0 36.66625 137.0760 0 36.66708333333 137.0760 0 36.66708333333 137.0757 0 36.66625 137.0757 0</gml:posList>
 								</gml:LinearRing>
 							</gml:exterior>
 						</gml:Polygon>
 					</gml:surfaceMember>
 				</gml:MultiSurface>
 			</core:lod0MultiSurface>
+			<bldg:adeOfAbstractBuilding>
+				<uro:BuildingIDAttribute>
+					<uro:buildingID>16211-bldg-3</uro:buildingID>
+					<uro:prefecture>16</uro:prefecture>
+					<uro:city>16211</uro:city>
+				</uro:BuildingIDAttribute>
+			</bldg:adeOfAbstractBuilding>
+			<bldg:adeOfAbstractBuilding>
+				<uro:BuildingDetailAttribute>
+					<uro:totalFloorArea uom="m2">76.2</uro:totalFloorArea>
+					<uro:buildingFootprintArea uom="m2">76.2</uro:buildingFootprintArea>
+					<uro:buildingRoofEdgeArea uom="m2">58.7</uro:buildingRoofEdgeArea>
+					<uro:buildingStructureType>611</uro:buildingStructureType>
+					<uro:fireproofStructureType>1011</uro:fireproofStructureType>
+					<uro:landUseType>211</uro:landUseType>
+					<uro:detailedUsage>4111</uro:detailedUsage>
+					<uro:buildingHeight uom="m">8.6</uro:buildingHeight>
+					<uro:surveyYear>2020-01-01</uro:surveyYear>
+				</uro:BuildingDetailAttribute>
+			</bldg:adeOfAbstractBuilding>
+			<core:adeOfAbstractCityObject>
+				<urc:DataQualityAttribute>
+					<urc:geometrySrcDescLod0>000</urc:geometrySrcDescLod0>
+					<urc:geometrySrcDescLod1>000</urc:geometrySrcDescLod1>
+					<urc:thematicSrcDesc>100</urc:thematicSrcDesc>
+					<urc:thematicSrcDesc>201</urc:thematicSrcDesc>
+					<urc:thematicSrcDesc>000</urc:thematicSrcDesc>
+					<urc:lod1HeightType>2</urc:lod1HeightType>
+					<urc:publicSurveyDataQualityAttribute>
+						<urc:PublicSurveyDataQualityAttribute>
+							<urc:srcScaleLod0>1</urc:srcScaleLod0>
+							<urc:srcScaleLod1>1</urc:srcScaleLod1>
+							<urc:publicSurveySrcDescLod0>023</urc:publicSurveySrcDescLod0>
+							<urc:publicSurveySrcDescLod1>023</urc:publicSurveySrcDescLod1>
+							<urc:publicSurveySrcDescLod1>003</urc:publicSurveySrcDescLod1>
+						</urc:PublicSurveyDataQualityAttribute>
+					</urc:publicSurveyDataQualityAttribute>
+				</urc:DataQualityAttribute>
+			</core:adeOfAbstractCityObject>
 		</bldg:Building>
 	</core:cityObjectMember>
 

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-03_meshcode-extractor_03/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/Z-bldg-03_meshcode-extractor_03/workflow_test.json
@@ -1,6 +1,5 @@
 {
   "description": "Test Z-bldg-03 (図郭不正 / meshcode) for plateau6 (equal-area cross-mesh tie-break)",
-  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {
@@ -49,5 +48,5 @@
       ]
     }
   },
-  "expectResultOkFile": false
+  "expectResultOkFile": true
 }

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.168"
+version = "0.2.169"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.358"
+version = "0.1.359"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
# Overview

The Z-bldg-03 figure-boundary check (図郭不正) now runs under `new-geometry`, and is wired into the plateau4 and plateau6 02-bldg quality-check workflows, so buildings stored in the wrong mesh file are reported again.

## What I've done

- Implement the mesh-code extraction for the new geometry model, and wire the check into plateau4 and plateau6 02-bldg.
- Emit the CSV in both generations, plus GeoJSON error detail in plateau6.
- Drop 図郭不正 from `totalErrorCount` in both generations, matching the original implementation.
- Share ring-to-face normalization, the ring-closure predicate, and leaf elevation in the geometry crate.

## What I haven't done

- No GeoJSON error-detail output for this check in plateau4.

## How I tested

The three Z-bldg-03 workflow tests per generation no longer skip `new-geometry`; unit tests cover mesh selection and CRS axis order against the fixture's expected 9.14 m². Their `gml:id` values moved to UUID form, which is why the expected CSVs changed.

## Screenshot

## Which point I want you to review particularly

- Each mesh cell edge is cut into 16 segments before projection — whether that is enough for areas reported to two decimals.

## Memo

- Cell edges follow constant latitude/longitude, which curve under Transverse Mercator, so straight corner-to-corner edges would cut into the cell.
- EPSG:6668 serves as the 2D geographic counterpart of EPSG:6697; coordinates swap between its `[lat, lng]` order and `JPMeshCode`'s `(lng, lat)`.
- The action assumes the footprint already arrives projected in `epsgCode` and never reprojects the feature itself.