### PR TITLE
fix(ui): enhance share canvas workspace selection dropdown with scrollable content [FLOW-DEV-256]

### DIFF
--- a/ui/src/features/SharedCanvas/components/ImportDialog.tsx
+++ b/ui/src/features/SharedCanvas/components/ImportDialog.tsx
@@ -62,7 +62,7 @@ const ImportDialog: React.FC<Props> = ({
               <SelectTrigger className="w-full">
                 <SelectValue placeholder={t("Select a workspace")} />
               </SelectTrigger>
-              <SelectContent>
+              <SelectContent className="max-h-80 overflow-y-auto">
                 <SelectGroup>
                   <SelectLabel className="text-xs text-muted-foreground">
                     {t("Personal")}


### PR DESCRIPTION
# Overview
Updates the Shared Canvas import dialog’s workspace dropdown to constrain its height and allow scrolling when many workspaces are present.
## What I've done
- Add `max-h-80` + vertical overflow scrolling to the workspace `<SelectContent>` in the import dialog.
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
