### PR TITLE
fix(engine): report an unassignable mesh code through the diagnostics lane

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.169"
+version = "0.2.170"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "approx",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "Inflector",
  "approx",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5024,7 +5024,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "bytes",
  "clap",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5110,7 +5110,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-diagnostics"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5123,7 +5123,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5181,7 +5181,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "approx",
  "bvh",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5257,7 +5257,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5335,7 +5335,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5352,7 +5352,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5366,7 +5366,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "bytes",
  "futures",
@@ -5383,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "bytes",
  "futures",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5454,7 +5454,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "ahash",
  "bytes",
@@ -5490,7 +5490,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "async-trait",
  "axum",
@@ -8258,7 +8258,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.359"
+version = "0.1.360"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4794,6 +4794,7 @@ dependencies = [
  "rayon",
  "reearth-flow-action-log",
  "reearth-flow-common",
+ "reearth-flow-diagnostics",
  "reearth-flow-geometry",
  "reearth-flow-runtime",
  "reearth-flow-state",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.547"
+version = "0.0.548"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/action-plateau-processor/Cargo.toml
+++ b/engine/runtime/action-plateau-processor/Cargo.toml
@@ -23,6 +23,7 @@ new-geometry = [
 [dependencies]
 reearth-flow-action-log.workspace = true
 reearth-flow-common.workspace = true
+reearth-flow-diagnostics.workspace = true
 reearth-flow-geometry.workspace = true
 reearth-flow-runtime.workspace = true
 reearth-flow-state.workspace = true

--- a/engine/runtime/action-plateau-processor/src/common/destination_mesh_code_extractor.rs
+++ b/engine/runtime/action-plateau-processor/src/common/destination_mesh_code_extractor.rs
@@ -1,5 +1,7 @@
 use std::{cell::RefCell, collections::HashMap, sync::Arc};
 
+#[cfg(feature = "new-geometry")]
+use reearth_flow_diagnostics::{DiagnosticDraft, ErrorCode};
 #[cfg(not(feature = "new-geometry"))]
 use reearth_flow_geometry::algorithm::{
     area2d::Area2D, bool_ops::BooleanOps, bounding_rect::BoundingRect,
@@ -304,11 +306,13 @@ impl Processor for DestinationMeshCodeExtractor {
                 return Ok(());
             }
             Err(e) => {
-                ctx.event_hub.warn_log(
-                    Some(ctx.error_span()),
-                    format!("mesh code extraction failed: {e}"),
-                );
-                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+                // `warn`, not `report`: the feature is already routed to
+                // `rejected`, so leaving the drop to a resolved disposition
+                // would double-count it.
+                ctx.warn(DiagnosticDraft::new(ErrorCode::PlateauMeshCodeUnassignable));
+                let mut rejected = feature.clone();
+                rejected.insert("_meshcode_error", AttributeValue::String(e.to_string()));
+                fw.send(ctx.new_with_feature_and_port(rejected, REJECTED_PORT.clone()));
                 return Ok(());
             }
         };

--- a/engine/schema/error-codes.json
+++ b/engine/schema/error-codes.json
@@ -200,6 +200,13 @@
     "message": "node failed with an unclassified error"
   },
   {
+    "code": "plateau.mesh_code_unassignable",
+    "category": "geometry",
+    "defaultDisposition": "warn_drop",
+    "message": "skipped feature whose destination mesh code could not be computed",
+    "help": "Destination Mesh Code Extractor measures how much of a footprint falls in each mesh cell, in the coordinate system given by `epsgCode`. A feature is skipped when that system cannot be transformed to or from geographic coordinates, or when the footprint could not be intersected with a mesh cell. Read the `_meshcode_error` attribute on the skipped feature for the specific cause."
+  },
+  {
     "code": "raster.image_save_failed",
     "category": "io",
     "defaultDisposition": "warn_drop",

--- a/engine/schema/error-codes/plateau.toml
+++ b/engine/schema/error-codes/plateau.toml
@@ -1,0 +1,6 @@
+[[codes]]
+code = "plateau.mesh_code_unassignable"
+category = "geometry"
+default_disposition = "warn_drop"
+message = "skipped feature whose destination mesh code could not be computed"
+help = "Destination Mesh Code Extractor measures how much of a footprint falls in each mesh cell, in the coordinate system given by `epsgCode`. A feature is skipped when that system cannot be transformed to or from geographic coordinates, or when the footprint could not be intersected with a mesh cell. Read the `_meshcode_error` attribute on the skipped feature for the specific cause."

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.169"
+version = "0.2.170"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.359"
+version = "0.1.360"
 edition = "2021"
 
 [features]

--- a/engine/tools/action-tracing-allowlist.txt
+++ b/engine/tools/action-tracing-allowlist.txt
@@ -1,4 +1,3 @@
-runtime/action-plateau-processor/src/common/destination_mesh_code_extractor.rs:1
 runtime/action-plateau-processor/src/common/domain_of_definition_validator.rs:1
 runtime/action-plateau-processor/src/plateau4/attribute_flattener/processor.rs:5
 runtime/action-plateau-processor/src/plateau4/unshared_edge_detector.rs:1


### PR DESCRIPTION
# Overview

Follow-up to #2456. On new geometry, Destination Mesh Code Extractor logged a failed mesh-code computation as a plain warning, so the skip never reached the diagnostics lane. It now raises `plateau.mesh_code_unassignable` and attaches the cause to the rejected feature as `_meshcode_error`.

## How I tested

`cargo make clippy` / `cargo make test`, with and without `new-geometry`.

## Memo

`ctx.warn()`, not `ctx.report()`: the feature already goes to the action's own `rejected` port, so a resolved disposition would double-count the drop. `default_disposition` is inert, same as `grid.toml`.