### PR TITLE
feat(engine): wire L-bldg-02 BuildingPart connectivity into plateau6 QC

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.169"
+version = "0.2.170"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "approx",
  "async-trait",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "Inflector",
  "approx",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4961,7 +4961,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5012,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "bytes",
  "clap",
@@ -5065,7 +5065,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-diagnostics"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5163,7 +5163,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "bytes",
  "reearth-flow-action-sink",
@@ -5180,7 +5180,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "approx",
  "bvh",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5256,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5265,7 +5265,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5297,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5351,7 +5351,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5365,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "bytes",
  "futures",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "bytes",
  "futures",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5415,7 +5415,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5453,7 +5453,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "ahash",
  "bytes",
@@ -5489,7 +5489,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.547"
+version = "0.0.548"
 dependencies = [
  "async-trait",
  "axum",
@@ -8257,7 +8257,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.359"
+version = "0.1.360"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.547"
+version = "0.0.548"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau6/02-bldg/building_checks.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau6/02-bldg/building_checks.yml
@@ -1100,9 +1100,8 @@ nodes:
           expr:
             type: flowExpr
             value: attributes.get("_num_invalid_building_id_format", 0)
-        # TODO: wire to the L-bldg-02 BuildingPart-connectivity pipeline once an
-        # upstream action can record, per BuildingPart, the gml:ids it shares a
-        # boundary polygon with.
+        # Wired to the L-bldg-02 BuildingPart-connectivity pipeline
+        # (CountLbldg02Errors).
         - attribute: "L-bldg-02 エラー"
           expr:
             type: flowExpr
@@ -2989,11 +2988,139 @@ nodes:
     type: subGraph
     subGraphId: b1000000-0000-4000-8000-000000000000
 
-  # TODO: add the L-bldg-02 check (LOD2/LOD3 BuildingPart connectivity) once an
-  # upstream action can pair up near-identical polygons and record, per
-  # BuildingPart, the gml:ids it shares a boundary polygon with.
-  # PLATEAU6.TransitiveLinkResolver consumes that link list and reads no
-  # geometry itself, so it is the producer that is still missing.
+  # --- L-bldg-02: LOD2/LOD3 BuildingPart connectivity ---
+  # Two BuildingParts of one Building are connected when they share a boundary
+  # surface. The chain below takes each part apart into its surfaces, pairs the
+  # surfaces that occupy the same space, and hands the resulting part-to-part
+  # links to the resolver, which decides whether the Building's parts hang
+  # together. CityGML 3.0 has no LOD4, so only lod2 and lod3 feed this chain.
+  - id: c1b00090-0000-4000-8000-000000000090
+    name: BuildingPartSurfaceCoercer
+    type: action
+    action: Geometry Coercer
+    with:
+      targetType: polygon
+
+  - id: c1b00091-0000-4000-8000-000000000091
+    name: BuildingPartSurfaceSplitter
+    type: action
+    action: Geometry Splitter
+
+  # Surfaces occupying the same space name each other's BuildingPart. The
+  # tolerance is one millimetre in the plane rectangular CS the geometry has been
+  # reprojected into, which absorbs rounding without joining distinct surfaces.
+  # The rejected port stays unconnected: the coercer above guarantees polygons,
+  # so nothing reaches it.
+  - id: c1b00092-0000-4000-8000-000000000092
+    name: BuildingPartSurfaceIdentifier
+    type: action
+    action: Geometry Identifier
+    with:
+      tolerance: 0.001
+      groupBy:
+        - index
+        - name
+        - __citygml_parent_gml_id
+        - lod
+      idAttribute: __citygml_gml_id
+      matchedIdsAttribute: _shared_part_ids
+
+  - id: c1b00093-0000-4000-8000-000000000093
+    name: TransitiveLinkResolver
+    type: action
+    action: PLATEAU6.TransitiveLinkResolver
+    with:
+      idAttribute: __citygml_gml_id
+      linkedIdsAttribute: _shared_part_ids
+      groupBy:
+        - index
+        - name
+        - __citygml_parent_gml_id
+        - lod
+
+  # Every surface of a BuildingPart carries the same verdict; keep one per part.
+  - id: c1b00094-0000-4000-8000-000000000094
+    name: DeduplicateBuildingParts
+    type: action
+    action: Feature Duplicate Filter
+    with:
+      filterBy:
+        - index
+        - name
+        - __citygml_parent_gml_id
+        - lod
+        - __citygml_gml_id
+
+  # A part whose Building's parts do not all hang together is the error.
+  - id: c1b00095-0000-4000-8000-000000000095
+    name: FilterNonFullStatus
+    type: action
+    action: Feature Filter
+    with:
+      conditions:
+        - expr:
+            type: flowExpr
+            value: attributes["_status"] != "full"
+          outputPort: filtered
+
+  - id: c1b00096-0000-4000-8000-000000000096
+    name: CountLbldg02Errors
+    type: action
+    action: Statistics Calculator
+    with:
+      groupBy:
+        - name
+      calculations:
+        - newAttribute: _num_lbldg02_error
+          expr:
+            type: flowExpr
+            value: "1"
+
+  - id: c1b00097-0000-4000-8000-000000000097
+    name: AttributeMapperLbldg02Output
+    type: action
+    action: Attribute Mapper
+    with:
+      mappers:
+        - attribute: Index
+          valueAttribute: index
+        - attribute: Filename
+          valueAttribute: name
+        - attribute: Building.gml_id
+          valueAttribute: __citygml_parent_gml_id
+        - attribute: BuildingPart.gml_id
+          valueAttribute: __citygml_gml_id
+        - attribute: lod
+          valueAttribute: lod
+        - attribute: status
+          valueAttribute: _status
+        - attribute: connected_id
+          valueAttribute: _connected_id
+        - attribute: connected_parts
+          valueAttribute: _connected_parts
+
+  - id: c1b00098-0000-4000-8000-000000000098
+    name: FeatureWriterLbldg02Errors
+    type: action
+    action: Feature Writer
+    with:
+      format: csv
+      output:
+        type: string
+        value: 02_建築物_L-bldg-02エラー.csv
+
+  # Join the per-file L-bldg-02 error count onto each file feature.
+  - id: c1b00099-0000-4000-8000-000000000099
+    name: Lbldg02SummaryMerger
+    type: action
+    action: Feature Merger
+    with:
+      requestorAttributeValue:
+        type: flowExpr
+        value: attributes["name"]
+      supplierAttributeValue:
+        type: flowExpr
+        value: attributes["name"]
 
   # --- Z-bldg-03 mesh-code (figure boundary) pipeline ---
   # Taps the reprojected LOD0 footprints (already forced to 2D by TwoDimensionForcer)
@@ -4691,14 +4818,90 @@ edges:
     to: c1b00083-0000-4000-8000-000000000083
     fromPort: features
     toPort: supplier
-  # Z-bldg-04 summary merger output -> building summary mapper.
+  # Z-bldg-04 summary merger output -> L-bldg-02 summary merger (requestor).
   - id: c1b0e086-0000-4000-8000-000000000086
     from: c1b00083-0000-4000-8000-000000000083
+    to: c1b00099-0000-4000-8000-000000000099
+    fromPort: merged
+    toPort: requestor
+  - id: c1b0e087-0000-4000-8000-000000000087
+    from: c1b00083-0000-4000-8000-000000000083
+    to: c1b00099-0000-4000-8000-000000000099
+    fromPort: unmerged
+    toPort: requestor
+
+  # --- L-bldg-02 BuildingPart connectivity edges ---
+  # LOD2 / LOD3 BuildingParts from the dedicated LodSplitter -> surface coercer.
+  - id: c1b0e090-0000-4000-8000-000000000090
+    from: c1b00061-0000-4000-8000-000000000061
+    to: c1b00090-0000-4000-8000-000000000090
+    fromPort: lod2
+    toPort: features
+  - id: c1b0e091-0000-4000-8000-000000000091
+    from: c1b00061-0000-4000-8000-000000000061
+    to: c1b00090-0000-4000-8000-000000000090
+    fromPort: lod3
+    toPort: features
+  - id: c1b0e092-0000-4000-8000-000000000092
+    from: c1b00090-0000-4000-8000-000000000090
+    to: c1b00091-0000-4000-8000-000000000091
+    fromPort: features
+    toPort: features
+  - id: c1b0e093-0000-4000-8000-000000000093
+    from: c1b00091-0000-4000-8000-000000000091
+    to: c1b00092-0000-4000-8000-000000000092
+    fromPort: features
+    toPort: features
+  - id: c1b0e094-0000-4000-8000-000000000094
+    from: c1b00092-0000-4000-8000-000000000092
+    to: c1b00093-0000-4000-8000-000000000093
+    fromPort: features
+    toPort: features
+  - id: c1b0e095-0000-4000-8000-000000000095
+    from: c1b00093-0000-4000-8000-000000000093
+    to: c1b00094-0000-4000-8000-000000000094
+    fromPort: features
+    toPort: features
+  - id: c1b0e096-0000-4000-8000-000000000096
+    from: c1b00094-0000-4000-8000-000000000094
+    to: c1b00095-0000-4000-8000-000000000095
+    fromPort: features
+    toPort: features
+  # Non-full parts -> counter and CSV writer.
+  - id: c1b0e097-0000-4000-8000-000000000097
+    from: c1b00095-0000-4000-8000-000000000095
+    to: c1b00096-0000-4000-8000-000000000096
+    fromPort: filtered
+    toPort: features
+  - id: c1b0e098-0000-4000-8000-000000000098
+    from: c1b00095-0000-4000-8000-000000000095
+    to: c1b00097-0000-4000-8000-000000000097
+    fromPort: filtered
+    toPort: features
+  - id: c1b0e099-0000-4000-8000-000000000099
+    from: c1b00097-0000-4000-8000-000000000097
+    to: c1b00098-0000-4000-8000-000000000098
+    fromPort: features
+    toPort: features
+  - id: c1b0e09a-0000-4000-8000-00000000009a
+    from: c1b00098-0000-4000-8000-000000000098
+    to: 3730412c-8a45-417c-a669-fa10fec80028
+    fromPort: features
+    toPort: features
+  # Counter.default (per-file total) -> L-bldg-02 summary merger (supplier).
+  - id: c1b0e09b-0000-4000-8000-00000000009b
+    from: c1b00096-0000-4000-8000-000000000096
+    to: c1b00099-0000-4000-8000-000000000099
+    fromPort: features
+    toPort: supplier
+  # L-bldg-02 summary merger output -> building summary mapper.
+  - id: c1b0e09c-0000-4000-8000-00000000009c
+    from: c1b00099-0000-4000-8000-000000000099
     to: 428129b3-ad69-4a18-bf99-25492d41ba26
     fromPort: merged
     toPort: features
-  - id: c1b0e087-0000-4000-8000-000000000087
-    from: c1b00083-0000-4000-8000-000000000083
+  - id: c1b0e09d-0000-4000-8000-00000000009d
+    from: c1b00099-0000-4000-8000-000000000099
     to: 428129b3-ad69-4a18-bf99-25492d41ba26
     fromPort: unmerged
     toPort: features

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L-bldg-02_01/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L-bldg-02_01/workflow_test.json
@@ -1,6 +1,5 @@
 {
   "description": "Test L-bldg-02 for plateau6: single isolated LOD2 BuildingPart (status='alone')",
-  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L-bldg-02_02/workflow_test.json
+++ b/engine/testing/data/testcases/quality-check/plateau6/02-bldg/L-bldg-02_02/workflow_test.json
@@ -1,6 +1,5 @@
 {
   "description": "Test L-bldg-02 for plateau6: three LOD2 BuildingParts, two connected (partial) and one isolated (alone)",
-  "skipNewGeometry": true,
   "workflowPath": "quality-check/plateau6/02-bldg/workflow.yml",
   "workflowVariables": [
     {

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.169"
+version = "0.2.170"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.359"
+version = "0.1.360"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
# Overview

Adds the L-bldg-02 check (LOD2/LOD3 `BuildingPart` connectivity) to the plateau6 building QC workflow, which was the last placeholder in the 02-bldg summary.

## What I've done

- Wired the surface-pairing chain and emit `02_建築物_L-bldg-02エラー.csv`.
- Removed `skipNewGeometry` from the two existing L-bldg-02 test cases.

## What I haven't done

- Only `lod2` and `lod3` feed the chain — CityGML 3.0 has no LOD4, unlike plateau4's LOD2-4 coverage.

## How I tested

`cargo test -p workflow-tests --features new-geometry l_bldg_02` — 4 tests pass (plateau4 and plateau6, `alone` and `partial` cases).

## Screenshot

## Which point I want you to review particularly

- The `groupBy` sets on `Geometry Identifier` / `TransitiveLinkResolver` / `Feature Duplicate Filter`: they must key on the parent Building and lod, not the part.

## Memo

- Both required actions (`Geometry Identifier`'s `matchedIdsAttribute`, `PLATEAU6.TransitiveLinkResolver`) already existed; this is workflow wiring only.
- The chain follows plateau4's `building_part_validation.yml`, translated to new-geometry attribute names (`__citygml_gml_id`, `__citygml_parent_gml_id`, `index`, `name`).
- The 1 mm tolerance is in the plane rectangular CS the geometry is reprojected into, so it absorbs rounding without joining distinct surfaces.