### PR TITLE
ci(engine): move the Cargo.toml version check to the end of the lint job

### DIFF
--- a/.github/workflows/ci_engine.yml
+++ b/.github/workflows/ci_engine.yml
@@ -29,6 +29,7 @@ jobs:
     name: lint (clippy / fmt / taplo)
     runs-on: blacksmith-4vcpu-ubuntu-2204
     steps:
+      # --- setup ---
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
@@ -40,6 +41,28 @@ jobs:
         with:
           rust-components: clippy, rustfmt
           tools: cargo-make,taplo-cli
+
+      # --- format ---
+      - name: rustfmt
+        run: cargo make format -- --check
+      - name: taplo
+        run: cargo make format-taplo -- --check
+
+      # --- lint ---
+      # `cargo make clippy` builds `new-geometry`, whose `ktx2-rw` dep compiles
+      # KTX-Software from source.
+      - uses: ./.github/actions/install-ktx-toolchain
+      - name: cargo check and clippy
+        run: cargo make clippy
+
+      # --- repo-specific checks ---
+      - name: Check geodetic grid NOTICE.md is up to date
+        run: cargo make proj-grids-notice -- --check
+      - name: Check action tracing call sites
+        run: cargo make check-action-tracing
+
+      # --- version check ---
+      # Keep this last; add new steps above it.
       - name: Compare version with previous commit
         if: ${{ !(github.ref == 'refs/heads/main') }}
         run: |
@@ -76,22 +99,6 @@ jobs:
             echo "       - 'cargo set-version --bump patch'  # For bug fixes"
             exit 1
           fi
-      # `cargo make clippy` builds `new-geometry`, whose `ktx2-rw` dep compiles
-      # KTX-Software from source.
-      - uses: ./.github/actions/install-ktx-toolchain
-      # NOTE: `cargo make check` was previously a separate step. It is a
-      # strict subset of `cargo make clippy` (clippy implies check), so it is
-      # not run here.
-      - name: clippy
-        run: cargo make clippy
-      - name: Check action tracing call sites
-        run: cargo make check-action-tracing
-      - name: rustfmt
-        run: cargo make format -- --check
-      - name: taplo
-        run: cargo make format-taplo -- --check
-      - name: proj-grids attribution notice
-        run: cargo make proj-grids-notice -- --check
 
   validate-generated:
     name: validate generated files (schema + cms workflows)


### PR DESCRIPTION
## Overview

Reorder the engine lint job so the version-bump check runs last, after formatting, clippy, and the repo-specific checks.

## What I've done

- Move the `Cargo.toml` version comparison step to the end of the lint job
- Group the remaining steps by purpose (setup / format / lint / repo-specific checks) with comments

## What I haven't done

- No change to what any step actually runs

## How I tested

CI on this branch.

## Screenshot

## Which point I want you to review particularly

## Memo

The version check fails on any PR that forgets a version bump, which previously masked real lint and format failures. Putting it last means the actual code problems surface first.