### PR TITLE
fix(engine): nested attribute type should align attribute type

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4212,7 +4212,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.171"
+version = "0.2.172"
 dependencies = [
  "bytes",
  "glam 0.30.10",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "futures",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "approx",
  "async-trait",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "Inflector",
  "approx",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4961,7 +4961,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -5012,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "bytes",
  "clap",
@@ -5065,7 +5065,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "approx",
  "async-recursion",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-diagnostics"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5163,7 +5163,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-feature-view"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "bytes",
  "prost",
@@ -5182,7 +5182,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "approx",
  "bvh",
@@ -5223,7 +5223,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5258,7 +5258,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5299,7 +5299,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5367,7 +5367,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "bytes",
  "futures",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "bytes",
  "futures",
@@ -5403,7 +5403,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5417,7 +5417,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5455,7 +5455,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "ahash",
  "bytes",
@@ -5491,7 +5491,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.549"
+version = "0.0.550"
 dependencies = [
  "async-trait",
  "axum",
@@ -8259,7 +8259,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.361"
+version = "0.1.362"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.549"
+version = "0.0.550"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/action-plateau-processor/src/common/building_usage_attribute_validator.rs
+++ b/engine/runtime/action-plateau-processor/src/common/building_usage_attribute_validator.rs
@@ -34,7 +34,7 @@ use reearth_flow_runtime::{
     node::{Port, Processor, ProcessorFactory, FEATURES_PORT},
 };
 use reearth_flow_storage::resolve::StorageResolver;
-use reearth_flow_types::{Attribute, AttributeValue, Code, CompiledCode, Feature};
+use reearth_flow_types::{Attribute, AttributeValue, Attributes, Code, CompiledCode, Feature};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -293,7 +293,7 @@ impl BuildingUsageAttributeValidator {
 /// Builds the L-bldg-04,05 violation messages for a `uro:BuildingDetailAttribute`
 /// map: one message per derived attribute present without its parent.
 pub(crate) fn usage_violation_messages(
-    building_detail_attr: &HashMap<String, AttributeValue>,
+    building_detail_attr: &Attributes,
     survey_year: &str,
 ) -> Vec<String> {
     USAGE_ATTRIBUTES

--- a/engine/runtime/action-plateau-processor/src/common/domain_of_definition_validator.rs
+++ b/engine/runtime/action-plateau-processor/src/common/domain_of_definition_validator.rs
@@ -625,8 +625,13 @@ fn process_feature(
             response
                 .invalid_feature_types
                 .iter()
-                .map(|(k, v)| (k.clone(), AttributeValue::Number(Number::from(*v))))
-                .collect::<HashMap<_, _>>(),
+                .map(|(k, v)| {
+                    (
+                        Attribute::new(k.as_str()),
+                        AttributeValue::Number(Number::from(*v)),
+                    )
+                })
+                .collect::<Attributes>(),
         ),
     );
     result_feature.insert(

--- a/engine/runtime/action-plateau-processor/src/common/missing_attribute_detector.rs
+++ b/engine/runtime/action-plateau-processor/src/common/missing_attribute_detector.rs
@@ -259,47 +259,47 @@ impl MissingAttributeDetector {
             feature.insert(
                 "dataFileData".to_string(),
                 AttributeValue::Array(vec![
-                    AttributeValue::Map(HashMap::from([
+                    AttributeValue::Map(Attributes::from([
                         (
-                            "name".to_string(),
+                            Attribute::new("name"),
                             AttributeValue::String("C05_必須属性等の欠落_Error".to_string()),
                         ),
                         (
-                            "count".to_string(),
+                            Attribute::new("count"),
                             AttributeValue::Number(serde_json::value::Number::from(
                                 buffer.required_counter,
                             )),
                         ),
                     ])),
-                    AttributeValue::Map(HashMap::from([
+                    AttributeValue::Map(Attributes::from([
                         (
-                            "name".to_string(),
+                            Attribute::new("name"),
                             AttributeValue::String("C06_現われない属性等".to_string()),
                         ),
                         (
-                            "count".to_string(),
+                            Attribute::new("count"),
                             AttributeValue::Number(serde_json::value::Number::from(target_counter)),
                         ),
                     ])),
-                    AttributeValue::Map(HashMap::from([
+                    AttributeValue::Map(Attributes::from([
                         (
-                            "name".to_string(),
+                            Attribute::new("name"),
                             AttributeValue::String("C07_品質属性".to_string()),
                         ),
                         (
-                            "count".to_string(),
+                            Attribute::new("count"),
                             AttributeValue::Number(serde_json::value::Number::from(
                                 buffer.c07_counter,
                             )),
                         ),
                     ])),
-                    AttributeValue::Map(HashMap::from([
+                    AttributeValue::Map(Attributes::from([
                         (
-                            "name".to_string(),
+                            Attribute::new("name"),
                             AttributeValue::String("C08_公共測量品質属性".to_string()),
                         ),
                         (
-                            "count".to_string(),
+                            Attribute::new("count"),
                             AttributeValue::Number(serde_json::value::Number::from(
                                 buffer.c08_counter,
                             )),
@@ -998,13 +998,13 @@ mod tests {
             _ => panic!("Expected dataFileData to be an array"),
         };
 
-        let expected = AttributeValue::Map(HashMap::from([
+        let expected = AttributeValue::Map(Attributes::from([
             (
-                "name".to_string(),
+                Attribute::new("name"),
                 AttributeValue::String("C06_現われない属性等".to_string()),
             ),
             (
-                "count".to_string(),
+                Attribute::new("count"),
                 AttributeValue::Number(serde_json::Number::from(1)),
             ),
         ]));
@@ -1313,7 +1313,7 @@ mod tests {
         let object_list = ObjectList::new(object_list_types);
 
         let object_list_map =
-            HashMap::from([(package.to_string(), AttributeValue::from(object_list))]);
+            Attributes::from([(Attribute::new(package), AttributeValue::from(object_list))]);
 
         attributes.insert(
             Attribute::new("objectList"),

--- a/engine/runtime/action-plateau-processor/src/common/object_list_extractor.rs
+++ b/engine/runtime/action-plateau-processor/src/common/object_list_extractor.rs
@@ -10,7 +10,7 @@ use reearth_flow_runtime::{
     forwarder::ProcessorChannelForwarder,
     node::{Port, Processor, ProcessorFactory, FEATURES_PORT},
 };
-use reearth_flow_types::{Attribute, AttributeValue};
+use reearth_flow_types::{Attribute, AttributeValue, Attributes};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -139,7 +139,7 @@ impl Processor for ObjectListExtractor {
                     .into_iter()
                     .map(|(prefix, feature_types)| {
                         (
-                            prefix.clone(),
+                            Attribute::new(prefix.as_str()),
                             AttributeValue::Array(
                                 feature_types
                                     .iter()
@@ -149,7 +149,7 @@ impl Processor for ObjectListExtractor {
                             ),
                         )
                     })
-                    .collect::<HashMap<String, AttributeValue>>(),
+                    .collect::<Attributes>(),
             ),
         );
         feature.insert(
@@ -157,8 +157,10 @@ impl Processor for ObjectListExtractor {
             AttributeValue::Map(
                 object_list
                     .into_iter()
-                    .map(|(prefix, object_list)| (prefix.clone(), object_list.into()))
-                    .collect::<HashMap<String, AttributeValue>>(),
+                    .map(|(prefix, object_list)| {
+                        (Attribute::new(prefix.as_str()), object_list.into())
+                    })
+                    .collect::<Attributes>(),
             ),
         );
         fw.send(ctx.new_with_feature_and_port(feature, FEATURES_PORT.clone()));

--- a/engine/runtime/action-plateau-processor/src/common/solid_intersection_test_pair_creator.rs
+++ b/engine/runtime/action-plateau-processor/src/common/solid_intersection_test_pair_creator.rs
@@ -189,7 +189,7 @@ impl Processor for SolidIntersectionTestPairCreator {
             .iter()
             .filter_map(|item| {
                 if let AttributeValue::Map(map) = item {
-                    map.get(&self.gml_id_attribute).and_then(|v| {
+                    map.get(self.gml_id_attribute.as_str()).and_then(|v| {
                         if let AttributeValue::String(s) = v {
                             Some(s.clone())
                         } else {
@@ -210,15 +210,12 @@ impl Processor for SolidIntersectionTestPairCreator {
         // Cache features for later lookup - extract feature data from the list
         for item in list {
             if let AttributeValue::Map(map) = item {
-                if let Some(AttributeValue::String(gml_id)) = map.get(&self.gml_id_attribute) {
+                if let Some(AttributeValue::String(gml_id)) =
+                    map.get(self.gml_id_attribute.as_str())
+                {
                     if !self.feature_cache.contains_key(gml_id) {
                         // Create a feature from the map data
-                        let mut cached_feature = Feature::new_with_attributes(Default::default());
-                        for (key, value) in map {
-                            cached_feature
-                                .attributes_mut()
-                                .insert(Attribute::new(key), value.clone());
-                        }
+                        let cached_feature = Feature::new_with_attributes(map.clone());
                         // Copy geometry from the original overlay feature (it's the intersection area)
                         // Note: For solid intersection test, we need the original solid geometries,
                         // which should be stored in the list item attributes or retrieved separately

--- a/engine/runtime/action-plateau-processor/src/object_list.rs
+++ b/engine/runtime/action-plateau-processor/src/object_list.rs
@@ -6,7 +6,7 @@ use std::{
 use bytes::Bytes;
 use calamine::{RangeDeserializerBuilder, Reader, Xlsx};
 use once_cell::sync::Lazy;
-use reearth_flow_types::AttributeValue;
+use reearth_flow_types::{Attribute, AttributeValue, Attributes};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -138,7 +138,7 @@ impl From<FeatureTypes> for AttributeValue {
             .iter()
             .map(|(k, v)| {
                 (
-                    k.clone(),
+                    Attribute::new(k.as_str()),
                     AttributeValue::Array(
                         v.iter()
                             .map(|s| AttributeValue::String(s.clone()))
@@ -146,7 +146,7 @@ impl From<FeatureTypes> for AttributeValue {
                     ),
                 )
             })
-            .collect::<HashMap<String, AttributeValue>>();
+            .collect::<Attributes>();
         AttributeValue::Map(map)
     }
 }
@@ -182,7 +182,7 @@ impl From<AttributeValue> for ObjectListMap {
             .as_map()
             .map(|map| {
                 map.iter()
-                    .map(|(k, v)| (k.clone(), ObjectList::from(v.clone())))
+                    .map(|(k, v)| (k.to_string(), ObjectList::from(v.clone())))
                     .collect::<HashMap<String, ObjectList>>()
             })
             .unwrap_or_default();
@@ -221,7 +221,7 @@ impl From<AttributeValue> for ObjectList {
             .as_map()
             .map(|map| {
                 map.iter()
-                    .map(|(k, v)| (k.clone(), v.clone().into()))
+                    .map(|(k, v)| (k.to_string(), v.clone().into()))
                     .collect::<HashMap<String, ObjectListValue>>()
             })
             .unwrap_or_default();
@@ -234,8 +234,8 @@ impl From<ObjectList> for AttributeValue {
         let map = value
             .0
             .iter()
-            .map(|(k, v)| (k.clone(), v.clone().into()))
-            .collect::<HashMap<String, AttributeValue>>();
+            .map(|(k, v)| (Attribute::new(k.as_str()), v.clone().into()))
+            .collect::<Attributes>();
         AttributeValue::Map(map)
     }
 }
@@ -286,9 +286,9 @@ impl From<AttributeValue> for ObjectListValue {
 
 impl From<ObjectListValue> for AttributeValue {
     fn from(value: ObjectListValue) -> Self {
-        let mut map = HashMap::<String, AttributeValue>::new();
+        let mut map = Attributes::new();
         map.insert(
-            "required".to_string(),
+            Attribute::new("required"),
             AttributeValue::Array(
                 value
                     .required
@@ -298,7 +298,7 @@ impl From<ObjectListValue> for AttributeValue {
             ),
         );
         map.insert(
-            "target".to_string(),
+            Attribute::new("target"),
             AttributeValue::Array(
                 value
                     .target
@@ -308,7 +308,7 @@ impl From<ObjectListValue> for AttributeValue {
             ),
         );
         map.insert(
-            "conditional".to_string(),
+            Attribute::new("conditional"),
             AttributeValue::Array(
                 value
                     .conditional

--- a/engine/runtime/action-plateau-processor/src/plateau3/attribute_flattener.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/attribute_flattener.rs
@@ -10,7 +10,7 @@ use reearth_flow_runtime::{
     forwarder::ProcessorChannelForwarder,
     node::{Port, Processor, ProcessorFactory, FEATURES_PORT},
 };
-use reearth_flow_types::{Attribute, AttributeValue};
+use reearth_flow_types::{Attribute, AttributeValue, Attributes};
 use serde_json::Value;
 
 use super::errors::PlateauProcessorError;
@@ -104,7 +104,7 @@ impl Flattener {
 
     fn extract_fld_risk_attribute(
         &mut self,
-        city_gml_attribute: &HashMap<String, AttributeValue>,
+        city_gml_attribute: &Attributes,
     ) -> HashMap<Attribute, AttributeValue> {
         let disaster_risks = match city_gml_attribute.get("uro:buildingDisasterRiskAttribute") {
             Some(AttributeValue::Array(disaster_risks)) => disaster_risks,
@@ -159,7 +159,7 @@ impl Flattener {
 
     pub fn extract_tnm_htd_ifld_risk_attribute(
         &mut self,
-        city_gml_attribute: &HashMap<String, AttributeValue>,
+        city_gml_attribute: &Attributes,
     ) -> HashMap<Attribute, AttributeValue> {
         let mut result = HashMap::new();
         let src = vec![
@@ -224,7 +224,7 @@ impl Flattener {
 
     pub fn extract_lsld_risk_attribute(
         &mut self,
-        city_gml_attribute: &HashMap<String, AttributeValue>,
+        city_gml_attribute: &Attributes,
     ) -> HashMap<Attribute, AttributeValue> {
         let mut result = HashMap::new();
         let disaster_risks = match city_gml_attribute.get("uro:buildingLandSlideRiskAttribute") {
@@ -281,13 +281,13 @@ struct CommonAttributeProcessor {
 }
 
 impl CommonAttributeProcessor {
-    fn flatten_attribute(key: &str, attribute: &AttributeValue) -> HashMap<String, AttributeValue> {
+    fn flatten_attribute(key: &str, attribute: &AttributeValue) -> Attributes {
         if !FLATTEN_PREFIXES.contains(key) {
-            return HashMap::from([(key.to_string(), attribute.clone())]);
+            return Attributes::from([(Attribute::new(key), attribute.clone())]);
         }
         match attribute {
             AttributeValue::Array(value) => {
-                let mut result = HashMap::new();
+                let mut result = Attributes::new();
                 for (i, v) in value.iter().enumerate() {
                     let new_key = if value.len() == 1 {
                         key.to_string()
@@ -300,7 +300,7 @@ impl CommonAttributeProcessor {
                 result
             }
             AttributeValue::Map(value) => {
-                let mut result = HashMap::new();
+                let mut result = Attributes::new();
                 for (k, v) in value {
                     let new_key = format!("{key}{DELIM}{k}");
                     let new_value = Self::flatten_attribute(new_key.as_str(), v);
@@ -308,13 +308,13 @@ impl CommonAttributeProcessor {
                 }
                 result
             }
-            v => HashMap::from([(key.to_string(), v.clone())]),
+            v => Attributes::from([(Attribute::new(key), v.clone())]),
         }
     }
 
     fn flatten_generic_attributes(
         &mut self,
-        attrib: &HashMap<String, AttributeValue>,
+        attrib: &Attributes,
     ) -> HashMap<Attribute, AttributeValue> {
         if let Some(AttributeValue::Map(obj_map)) = attrib.get("gen:genericAttribute") {
             obj_map
@@ -355,7 +355,7 @@ impl CommonAttributeProcessor {
 
     fn extract_lod_types(
         &self,
-        attrib: &HashMap<String, AttributeValue>,
+        attrib: &Attributes,
         parent_tag: &str,
     ) -> HashMap<Attribute, AttributeValue> {
         let mut result = HashMap::new();
@@ -494,11 +494,11 @@ impl Processor for AttributeFlattener {
                 _ =>
                 // default to empty
                 {
-                    HashMap::new()
+                    Attributes::new()
                 }
             };
             for (name, vroot) in &root_city_gml_attribute {
-                let v = flattened.get(&Attribute::new(name));
+                let v = flattened.get(name);
 
                 let value = if v.is_none() || v == Some(vroot) {
                     vroot.clone()
@@ -509,7 +509,7 @@ impl Processor for AttributeFlattener {
                         v.and_then(|v| v.as_string()).unwrap_or_default()
                     ))
                 };
-                flattened.insert(Attribute::new(name), value.clone());
+                flattened.insert(name.clone(), value.clone());
             }
 
             if ftype == "bldg:BuildingPart" {
@@ -542,18 +542,13 @@ impl Processor for AttributeFlattener {
             self.common_processor.update_max_lod(&feature.attributes);
         }
         // フラットにする属性の設定
-        let mut new_city_gml_attribute = IndexMap::new();
+        let mut new_city_gml_attribute = Attributes::new();
         for (k, v) in city_gml_attribute.iter() {
-            let new_value = CommonAttributeProcessor::flatten_attribute(k, v);
+            let new_value = CommonAttributeProcessor::flatten_attribute(k.as_str(), v);
             new_city_gml_attribute.extend(new_value);
         }
         let mut feature = feature.clone();
-        feature.attributes_mut().extend(
-            new_city_gml_attribute
-                .iter()
-                .map(|(k, v)| (Attribute::new(k.clone()), v.clone()))
-                .collect::<IndexMap<Attribute, AttributeValue>>(),
-        );
+        feature.attributes_mut().extend(new_city_gml_attribute);
         feature.remove("cityGmlAttributes");
         feature.extend(flattened);
         let keys = feature.attributes.keys().cloned().collect_vec();

--- a/engine/runtime/action-plateau-processor/src/plateau3/domain_of_definition_validator.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/domain_of_definition_validator.rs
@@ -566,8 +566,13 @@ fn process_feature(
             response
                 .invalid_feature_types
                 .iter()
-                .map(|(k, v)| (k.clone(), AttributeValue::Number(Number::from(*v))))
-                .collect::<HashMap<_, _>>(),
+                .map(|(k, v)| {
+                    (
+                        Attribute::new(k.as_str()),
+                        AttributeValue::Number(Number::from(*v)),
+                    )
+                })
+                .collect::<Attributes>(),
         ),
     );
     result_feature.insert(

--- a/engine/runtime/action-plateau-processor/src/plateau3/xml_attribute_extractor.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/xml_attribute_extractor.rs
@@ -889,9 +889,11 @@ fn create_feature_response(
         attributes: feature
             .get(&Attribute::new("attributes"))
             .map(|v| match v {
-                AttributeValue::Map(v) => {
-                    v.clone().into_iter().map(|(k, v)| (k, v.into())).collect()
-                }
+                AttributeValue::Map(v) => v
+                    .clone()
+                    .into_iter()
+                    .map(|(k, v)| (k.into_inner(), v.into()))
+                    .collect(),
                 _ => HashMap::new(),
             })
             .unwrap_or_default(),

--- a/engine/runtime/action-plateau-processor/src/plateau4/attribute_flattener/flattener.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau4/attribute_flattener/flattener.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use indexmap::IndexMap;
-use reearth_flow_types::{Attribute, AttributeValue};
+use reearth_flow_types::{Attribute, AttributeValue, Attributes};
 
 /// Sort key for flooding risk schema attributes, matching FME's fldAttrsSorter.
 /// Sorted by (desc_code, admin_code, scale_code, order) where desc_code
@@ -48,7 +48,7 @@ pub(super) struct Flattener {
 impl Flattener {
     pub(super) fn extract_fld_risk_attribute(
         &mut self,
-        attributes: &HashMap<String, AttributeValue>,
+        attributes: &Attributes,
     ) -> IndexMap<Attribute, AttributeValue> {
         let Some(disaster_risks) = attributes.get("uro:RiverFloodingRiskAttribute") else {
             return IndexMap::new();
@@ -141,7 +141,7 @@ impl Flattener {
 
     pub(super) fn extract_tnm_htd_ifld_risk_attribute(
         &mut self,
-        attributes: &HashMap<String, AttributeValue>,
+        attributes: &Attributes,
     ) -> IndexMap<Attribute, AttributeValue> {
         let src = [
             ("uro:TsunamiRiskAttribute", "津波浸水想定", "tnm"),
@@ -219,7 +219,7 @@ impl Flattener {
 
     pub(super) fn extract_lsld_risk_attribute(
         &mut self,
-        attributes: &HashMap<String, AttributeValue>,
+        attributes: &Attributes,
     ) -> IndexMap<Attribute, AttributeValue> {
         let Some(disaster_risks) = attributes.get("uro:LandSlideRiskAttribute") else {
             return IndexMap::new();
@@ -295,9 +295,7 @@ impl Flattener {
 
     /// Extract bldg:address from core:Address nested structure
     /// core:Address[0].xAL:AddressDetails[0].xAL:Country[0].xAL:Locality -> bldg:address
-    pub(super) fn extract_address(
-        attributes: &HashMap<String, AttributeValue>,
-    ) -> Option<AttributeValue> {
+    pub(super) fn extract_address(attributes: &Attributes) -> Option<AttributeValue> {
         let address_array = attributes.get("core:Address")?;
         let address_list = address_array.as_vec()?;
         let address_obj = address_list.first()?.as_map()?;
@@ -360,7 +358,7 @@ impl CommonAttributeProcessor {
     }
     fn flatten_generic_attribute(
         &mut self,
-        attribute: &HashMap<String, AttributeValue>,
+        attribute: &Attributes,
         prefix: &str,
     ) -> IndexMap<Attribute, AttributeValue> {
         let mut result = IndexMap::new();
@@ -399,7 +397,7 @@ impl CommonAttributeProcessor {
 
     pub(super) fn flatten_generic_attributes(
         &mut self,
-        attributes: &HashMap<String, AttributeValue>,
+        attributes: &Attributes,
     ) -> IndexMap<Attribute, AttributeValue> {
         let mut result = IndexMap::new();
 
@@ -431,7 +429,7 @@ impl CommonAttributeProcessor {
     #[allow(dead_code)]
     fn extract_lod_types(
         &self,
-        attrib: &HashMap<String, AttributeValue>,
+        attrib: &Attributes,
         parent_tag: &str,
     ) -> HashMap<Attribute, AttributeValue> {
         let mut result = HashMap::new();
@@ -467,7 +465,7 @@ impl CommonAttributeProcessor {
 
 pub(super) fn get_value_from_json_path(
     paths: &[&str],
-    attrib: &HashMap<String, AttributeValue>,
+    attrib: &Attributes,
 ) -> Option<AttributeValue> {
     let key = paths.first()?;
     let value = attrib.get(*key)?;

--- a/engine/runtime/action-plateau-processor/src/plateau4/attribute_flattener/processor.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau4/attribute_flattener/processor.rs
@@ -131,8 +131,6 @@ impl ProcessorFactory for AttributeFlattenerFactory {
     }
 }
 
-type AttributeMap = HashMap<String, AttributeValue>;
-
 #[derive(Debug, Clone, Default)]
 pub(super) struct AttributeFlattener {
     filter_existing_flatten_attributes: bool,
@@ -142,13 +140,13 @@ pub(super) struct AttributeFlattener {
     common_attribute_processor: super::flattener::CommonAttributeProcessor,
     // storing processed features' citygml attributes for ancestor lookup
     // does not include pending features in children_buffer
-    gmlid_to_citygml_attributes: HashMap<String, AttributeMap>,
+    gmlid_to_citygml_attributes: HashMap<String, Attributes>,
     // storing processed features' citygml attributes for subfeature auto-inheriting toplevel attributes
     // corresponding to two-round processing in FME:
     // 1. PythonCaller produces toplevel attributes
     // 2. The toplevel attributes are copied to all its subfeatures
     // 3. These subfeatures are then processed by PythonCaller2 without toplevel as ancestor
-    gmlid_to_subfeature_inherited: HashMap<String, AttributeMap>,
+    gmlid_to_subfeature_inherited: HashMap<String, Attributes>,
     // blocking ancestor gml_id -> children features
     children_buffer: HashMap<String, Vec<Feature>>,
     // LOD4 feature_type_key -> ancestor feature_type_key mapping for schema generation
@@ -158,9 +156,9 @@ pub(super) struct AttributeFlattener {
 }
 
 // remove parentId and parentType created by FeatureCitygmlReader's FlattenTreeTransform
-fn strip_parent_info(map: &mut HashMap<String, AttributeValue>) {
-    map.remove("parentId");
-    map.remove("parentType");
+fn strip_parent_info(map: &mut Attributes) {
+    map.shift_remove("parentId");
+    map.shift_remove("parentType");
 }
 
 // GYear fields that should be converted from string to number
@@ -180,11 +178,9 @@ static GYEAR_FIELDS: &[&str] = &[
 ];
 
 /// Convert GYear string fields to numbers recursively in the attribute map
-fn convert_gyear_fields(
-    mut map: HashMap<String, AttributeValue>,
-) -> HashMap<String, AttributeValue> {
+fn convert_gyear_fields(mut map: Attributes) -> Attributes {
     for (key, value) in map.iter_mut() {
-        *value = convert_gyear_value(key, std::mem::take(value));
+        *value = convert_gyear_value(key.as_str(), std::mem::take(value));
     }
     map
 }
@@ -211,9 +207,7 @@ fn convert_gyear_value(key: &str, value: AttributeValue) -> AttributeValue {
 /// Recursively filters skippable keys from citygml attributes.
 /// Skippable keys are PLATEAU-specific sub-features and geometry boundaries
 /// that shouldn't be included as simple attributes.
-fn filter_skippable_keys(
-    mut map: HashMap<String, AttributeValue>,
-) -> HashMap<String, AttributeValue> {
+fn filter_skippable_keys(mut map: Attributes) -> Attributes {
     map.retain(|key, value| {
         // Skip known skippable keys
         if SKIPPABLE_KEYS.contains(key.as_str()) {
@@ -250,17 +244,12 @@ impl AttributeFlattener {
     fn process_and_add_risk_attributes(
         &mut self,
         feature: &mut Feature,
-        citygml_attributes: &HashMap<String, AttributeValue>,
+        citygml_attributes: &Attributes,
     ) -> HashSet<String> {
-        let edit_citygml_attributes = citygml_attributes
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.clone()))
-            .collect::<HashMap<String, AttributeValue>>();
-
         if self.should_flatten_generic_attributes(feature) {
             feature.extend(
                 self.common_attribute_processor
-                    .flatten_generic_attributes(&edit_citygml_attributes),
+                    .flatten_generic_attributes(citygml_attributes),
             );
         }
 
@@ -268,26 +257,26 @@ impl AttributeFlattener {
 
         let fld = self
             .flattener
-            .extract_fld_risk_attribute(&edit_citygml_attributes);
+            .extract_fld_risk_attribute(citygml_attributes);
         risk_keys.extend(fld.keys().map(|k| k.to_string()));
         feature.extend(fld);
 
         let tnm = self
             .flattener
-            .extract_tnm_htd_ifld_risk_attribute(&edit_citygml_attributes);
+            .extract_tnm_htd_ifld_risk_attribute(citygml_attributes);
         risk_keys.extend(tnm.keys().map(|k| k.to_string()));
         feature.extend(tnm);
 
         let lsld = self
             .flattener
-            .extract_lsld_risk_attribute(&edit_citygml_attributes);
+            .extract_lsld_risk_attribute(citygml_attributes);
         risk_keys.extend(lsld.keys().map(|k| k.to_string()));
         feature.extend(lsld);
 
         risk_keys
     }
 
-    fn get_parent_attr(&self, citygml_attributes: &AttributeMap) -> AttributeMap {
+    fn get_parent_attr(&self, citygml_attributes: &Attributes) -> Attributes {
         if let Some(AttributeValue::String(parent_id)) = citygml_attributes.get("parentId") {
             if let Some(parent_attr) = self.gmlid_to_citygml_attributes.get(parent_id) {
                 // use parent attributes as inner attributes for DmGeometricAttribute
@@ -296,7 +285,7 @@ impl AttributeFlattener {
         }
         // should be unreachable since parentId lookup and error handling is handled in process()
         tracing::error!("Unreachable code: parent ID not found for DmGeometricAttribute");
-        AttributeMap::new()
+        Attributes::new()
     }
 
     // LOD4 subfeatures inherit top-level ancestor's extracted attributes
@@ -395,10 +384,10 @@ impl AttributeFlattener {
             let mut attrs = toplevel_citygml.clone();
             strip_parent_info(&mut attrs);
             if let Some(v) = own_feature_type {
-                attrs.insert("feature_type".to_string(), v);
+                attrs.insert(Attribute::new("feature_type"), v);
             }
             if let Some(v) = own_gml_id {
-                attrs.insert("gml:id".to_string(), v);
+                attrs.insert(Attribute::new("gml:id"), v);
             }
             let attrs = convert_gyear_fields(attrs);
             let json = serde_json::to_string(&serde_json::Value::from(AttributeValue::Map(attrs)))
@@ -427,21 +416,17 @@ impl AttributeFlattener {
         let toplevel_risk_keys = self.gmlid_to_risk_attr_keys.get(&toplevel_id);
         if let Some(toplevel_attrs) = toplevel_attrs {
             for (key, value) in toplevel_attrs.iter() {
-                if toplevel_risk_keys.is_some_and(|keys| keys.contains(key)) {
+                if toplevel_risk_keys.is_some_and(|keys| keys.contains(key.as_str())) {
                     continue;
                 }
-                let attr_key = Attribute::new(key.clone());
-                if !feature.attributes.contains_key(&attr_key) {
+                if !feature.attributes.contains_key(key) {
                     feature.insert(key.clone(), value.clone());
                 }
             }
         }
     }
 
-    fn insert_common_attributes(
-        feature: &Feature,
-        citygml_attributes: &mut HashMap<String, AttributeValue>,
-    ) {
+    fn insert_common_attributes(feature: &Feature, citygml_attributes: &mut Attributes) {
         // Check if this is a risk feature type that should exclude gml_id and meshcode
         let is_risk_package = feature
             .get("package")
@@ -455,7 +440,7 @@ impl AttributeFlattener {
                 .or_else(|| feature.get("gmlId"))
                 .or_else(|| feature.get("__citygml_gml_id"))
             {
-                citygml_attributes.insert("gml:id".to_string(), gml_id.clone());
+                citygml_attributes.insert(Attribute::new("gml:id"), gml_id.clone());
             }
 
             // meshcode: extract from path attribute (e.g., "55371111_bldg_6697_op.gml" -> 55371111)
@@ -463,7 +448,7 @@ impl AttributeFlattener {
                 if let Some(filename) = path.rsplit('/').next() {
                     if let Some(meshcode_str) = filename.split('_').next() {
                         citygml_attributes.insert(
-                            "meshcode".to_string(),
+                            Attribute::new("meshcode"),
                             AttributeValue::String(meshcode_str.to_string()),
                         );
                     }
@@ -476,14 +461,14 @@ impl AttributeFlattener {
             .get("featureType")
             .or_else(|| feature.get("__citygml_feature_type"))
         {
-            citygml_attributes.insert("feature_type".to_string(), feature_type.clone());
+            citygml_attributes.insert(Attribute::new("feature_type"), feature_type.clone());
         }
     }
 
     fn process_inner_attributes(
         &mut self,
         feature: &mut Feature,
-        mut citygml_attributes: HashMap<String, AttributeValue>,
+        mut citygml_attributes: Attributes,
         lookup_key: &str,
     ) {
         let mut ancestors = vec![];
@@ -497,7 +482,7 @@ impl AttributeFlattener {
                 if !DM_GEOMETRIC_ATTRS.contains(&key.as_str()) {
                     continue;
                 }
-                let key = key.replace("uro:", "dm_");
+                let key = key.as_str().replace("uro:", "dm_");
                 feature.insert(key.clone(), value.clone());
             }
             let dm_attributes_value = AttributeValue::Map(citygml_attributes);
@@ -559,7 +544,7 @@ impl AttributeFlattener {
 
         if !ancestors.is_empty() {
             citygml_attributes.insert(
-                "ancestors".to_string(),
+                Attribute::new("ancestors"),
                 AttributeValue::Array(ancestors.iter().rev().cloned().collect()),
             );
         }
@@ -618,11 +603,7 @@ impl AttributeFlattener {
         let is_lod4 = matches!(feature.get("lod"), Some(AttributeValue::String(lod)) if lod == "4");
         if let Some(feature_id) = feature.feature_id() {
             if is_toplevel || is_lod4 {
-                let flattened_attrs: AttributeMap = feature
-                    .attributes
-                    .iter()
-                    .map(|(k, v)| (k.to_string(), v.clone()))
-                    .collect();
+                let flattened_attrs = (*feature.attributes).clone();
                 self.gmlid_to_subfeature_inherited
                     .insert(feature_id, flattened_attrs);
             }
@@ -643,14 +624,14 @@ impl AttributeFlattener {
         self.inherit_lod4_attributes_v2(feature, lookup_key);
     }
 
-    fn get_parent_id(map: &AttributeMap) -> Option<String> {
+    fn get_parent_id(map: &Attributes) -> Option<String> {
         if let Some(AttributeValue::String(parent_id)) = map.get("parentId") {
             return Some(parent_id.clone());
         }
         None
     }
 
-    fn build_ancestors_attribute(&self, attr: &AttributeMap) -> Vec<AttributeValue> {
+    fn build_ancestors_attribute(&self, attr: &Attributes) -> Vec<AttributeValue> {
         let mut ancestors = Vec::new();
         let mut parent_id: Option<String> = Self::get_parent_id(attr);
         let mut seen_ids = HashSet::new();
@@ -790,10 +771,10 @@ impl AttributeFlattener {
         if !citygml_attributes.contains_key("bldg:address") {
             if let Some(address) = super::flattener::Flattener::extract_address(&citygml_attributes)
             {
-                citygml_attributes.insert("bldg:address".to_string(), address);
+                citygml_attributes.insert(Attribute::new("bldg:address"), address);
             }
         }
-        citygml_attributes.remove("core:Address");
+        citygml_attributes.shift_remove("core:Address");
 
         // Build lookup key from package and attribute feature type
         // for example dmGeometricAttribute should find attributes from their parent feature type
@@ -968,7 +949,7 @@ mod tests {
     use super::*;
 
     /// Helper to create a citygml_attributes map from JSON
-    fn citygml_attrs_from_json(json: &str) -> HashMap<String, AttributeValue> {
+    fn citygml_attrs_from_json(json: &str) -> Attributes {
         let value: serde_json::Value = serde_json::from_str(json).unwrap();
         match AttributeValue::from(value) {
             AttributeValue::Map(map) => map,
@@ -981,7 +962,7 @@ mod tests {
         gml_id: &str,
         feature_type: &str,
         package: &str,
-        citygml_attributes: HashMap<String, AttributeValue>,
+        citygml_attributes: Attributes,
         path: &str,
     ) -> Feature {
         let mut feature = Feature::new_with_attributes(Attributes::new());

--- a/engine/runtime/action-plateau-processor/src/plateau4/building_usage_attribute_strategy.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau4/building_usage_attribute_strategy.rs
@@ -12,7 +12,7 @@
 use std::collections::HashMap;
 
 use reearth_flow_runtime::errors::BoxedError;
-use reearth_flow_types::{Attribute, AttributeValue, Feature};
+use reearth_flow_types::{Attribute, AttributeValue, Attributes, Feature};
 
 use crate::common::building_usage_attribute_validator::{
     classify_city_code, usage_violation_messages, BuildingUsageAttributeStrategy, UsageAnalysis,
@@ -26,7 +26,7 @@ pub(crate) struct Plateau4BuildingUsageStrategy;
 
 /// The map content of a value that is either a map or an array whose first
 /// element is a map.
-fn first_map(value: &AttributeValue) -> Option<&HashMap<String, AttributeValue>> {
+fn first_map(value: &AttributeValue) -> Option<&Attributes> {
     match value {
         AttributeValue::Map(map) => Some(map),
         AttributeValue::Array(array) => match array.first() {
@@ -40,10 +40,10 @@ fn first_map(value: &AttributeValue) -> Option<&HashMap<String, AttributeValue>>
 /// Steps from the property wrapper `attrs[wrapper]` into its type element
 /// `type_name`, tolerating a repeated wrapper or type element.
 fn type_element<'a>(
-    attrs: &'a HashMap<String, AttributeValue>,
+    attrs: &'a Attributes,
     wrapper: &str,
     type_name: &str,
-) -> Option<&'a HashMap<String, AttributeValue>> {
+) -> Option<&'a Attributes> {
     first_map(attrs.get(wrapper)?)
         .and_then(|wrapper_map| wrapper_map.get(type_name))
         .and_then(first_map)

--- a/engine/runtime/action-plateau-processor/src/plateau6/building_usage_attribute_strategy.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau6/building_usage_attribute_strategy.rs
@@ -10,7 +10,7 @@
 use std::collections::HashMap;
 
 use reearth_flow_runtime::errors::BoxedError;
-use reearth_flow_types::{Attribute, AttributeValue, Feature};
+use reearth_flow_types::{Attribute, AttributeValue, Attributes, Feature};
 
 use crate::common::building_usage_attribute_validator::{
     classify_city_code, usage_violation_messages, BuildingUsageAttributeStrategy, UsageAnalysis,
@@ -65,10 +65,7 @@ impl BuildingUsageAttributeStrategy for Plateau6BuildingUsageStrategy {
 /// `bldg:adeOfAbstractBuilding`, which may itself be a single Map or an Array of
 /// Maps depending on how many ADE hooks the building carries. When the attribute
 /// is stored as an Array, the first Map element is used.
-fn ade_child_map<'a>(
-    ade: Option<&'a AttributeValue>,
-    key: &str,
-) -> Option<&'a HashMap<String, AttributeValue>> {
+fn ade_child_map<'a>(ade: Option<&'a AttributeValue>, key: &str) -> Option<&'a Attributes> {
     let child = match ade? {
         AttributeValue::Map(map) => map.get(key),
         AttributeValue::Array(items) => items.iter().find_map(|item| match item {

--- a/engine/runtime/action-processor/src/attribute/bulk_array_joiner.rs
+++ b/engine/runtime/action-processor/src/attribute/bulk_array_joiner.rs
@@ -153,15 +153,15 @@ mod test {
     use crate::tests::utils::create_default_execute_context;
     use indexmap::IndexMap;
     use reearth_flow_runtime::forwarder::NoopChannelForwarder;
-    use reearth_flow_types::Feature;
+    use reearth_flow_types::{Attributes, Feature};
 
     use super::*;
     #[test]
     fn test_attribute_map_array_joiner() {
         let noop = NoopChannelForwarder::default();
         let fw = ProcessorChannelForwarder::Noop(noop);
-        let flattener: HashMap<String, AttributeValue> = vec![(
-            "hoge".to_string(),
+        let flattener: Attributes = vec![(
+            Attribute::new("hoge"),
             AttributeValue::String("hogehoge".to_string()),
         )]
         .into_iter()

--- a/engine/runtime/action-processor/src/attribute/flattener.rs
+++ b/engine/runtime/action-processor/src/attribute/flattener.rs
@@ -101,11 +101,7 @@ impl Processor for AttributeFlattener {
         for attribute in &self.params.attributes {
             if feature.get(attribute).is_some() {
                 if let Some(AttributeValue::Map(value)) = feature.get(attribute).cloned() {
-                    let new_attributes = value
-                        .iter()
-                        .map(|(k, v)| (Attribute::new(k.clone()), v.clone()))
-                        .collect::<HashMap<_, _>>();
-                    feature.extend(new_attributes);
+                    feature.extend(value);
                     feature.remove(attribute);
                 } else {
                     continue;
@@ -135,15 +131,15 @@ mod test {
     use crate::tests::utils::create_default_execute_context;
     use indexmap::IndexMap;
     use reearth_flow_runtime::forwarder::NoopChannelForwarder;
-    use reearth_flow_types::Feature;
+    use reearth_flow_types::{Attributes, Feature};
 
     use super::*;
     #[test]
     fn test_attribute_flattener() {
         let noop = NoopChannelForwarder::default();
         let fw = ProcessorChannelForwarder::Noop(noop);
-        let flattener: HashMap<String, AttributeValue> = vec![(
-            "hoge".to_string(),
+        let flattener: Attributes = vec![(
+            Attribute::new("hoge"),
             AttributeValue::String("hogehoge".to_string()),
         )]
         .into_iter()

--- a/engine/runtime/action-processor/src/attribute/mapper.rs
+++ b/engine/runtime/action-processor/src/attribute/mapper.rs
@@ -251,7 +251,7 @@ impl Processor for AttributeMapper {
                         (&mapper.parent_attribute, &mapper.child_attribute)
                     {
                         if let Some(AttributeValue::Map(parent)) = feature.get(parent_attribute) {
-                            if let Some(child) = parent.get(child_attribute) {
+                            if let Some(child) = parent.get(child_attribute.as_str()) {
                                 attributes.insert(Attribute::new(attribute.clone()), child.clone());
                             }
                         }
@@ -264,11 +264,7 @@ impl Processor for AttributeMapper {
                                 tracing::error!("Failed to evaluate multiple_expr: {e:?}");
                             }
                             Ok(AttributeValue::Map(new_value)) => {
-                                attributes.extend(
-                                    new_value
-                                        .iter()
-                                        .map(|(k, v)| (Attribute::new(k.clone()), v.clone())),
-                                );
+                                attributes.extend(new_value);
                             }
                             Ok(other) => {
                                 tracing::error!(

--- a/engine/runtime/action-processor/src/attribute/table_extractor.rs
+++ b/engine/runtime/action-processor/src/attribute/table_extractor.rs
@@ -9,7 +9,7 @@ use reearth_flow_runtime::{
     forwarder::ProcessorChannelForwarder,
     node::{Port, Processor, ProcessorFactory, FEATURES_PORT},
 };
-use reearth_flow_types::{Attribute, AttributeValue, Code, Feature};
+use reearth_flow_types::{Attribute, AttributeValue, Attributes, Code, Feature};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -262,7 +262,7 @@ fn write_path(feature: &mut Feature, segments: &[&str], value: AttributeValue) {
     let mut top = feature
         .get(*first)
         .cloned()
-        .unwrap_or_else(|| AttributeValue::Map(HashMap::new()));
+        .unwrap_or_else(|| AttributeValue::Map(Attributes::new()));
     set_nested(&mut top, rest, value);
     feature.insert(Attribute::new(*first), top);
 }
@@ -272,17 +272,17 @@ fn set_nested(current: &mut AttributeValue, segments: &[&str], value: AttributeV
         .split_first()
         .expect("segments is never empty: caller only recurses while rest is non-empty");
     if !matches!(current, AttributeValue::Map(_)) {
-        *current = AttributeValue::Map(HashMap::new());
+        *current = AttributeValue::Map(Attributes::new());
     }
     let AttributeValue::Map(map) = current else {
         unreachable!()
     };
     if rest.is_empty() {
-        map.insert((*first).to_string(), value);
+        map.insert(Attribute::new(*first), value);
     } else {
         let child = map
-            .entry((*first).to_string())
-            .or_insert_with(|| AttributeValue::Map(HashMap::new()));
+            .entry(Attribute::new(*first))
+            .or_insert_with(|| AttributeValue::Map(Attributes::new()));
         set_nested(child, rest, value);
     }
 }
@@ -312,21 +312,21 @@ fn coerce(value: AttributeValue, data_type: Option<ExtractDataType>) -> Attribut
 mod tests {
     use super::*;
 
-    fn feature_with(attrs: HashMap<String, AttributeValue>) -> Feature {
-        Feature::from(attrs.into_iter().collect::<indexmap::IndexMap<_, _>>())
+    fn feature_with(attrs: Attributes) -> Feature {
+        Feature::from(attrs)
     }
 
     #[test]
     fn resolves_through_list_wrapper() {
-        let inner = HashMap::from([(
-            "uro:BuildingIDAttribute".to_string(),
-            AttributeValue::Map(HashMap::from([(
-                "uro:city".to_string(),
+        let inner = Attributes::from([(
+            Attribute::new("uro:BuildingIDAttribute"),
+            AttributeValue::Map(Attributes::from([(
+                Attribute::new("uro:city"),
                 AttributeValue::String("Tokyo".to_string()),
             )])),
         )]);
-        let feature = feature_with(HashMap::from([(
-            "bldg:adeOfAbstractBuilding".to_string(),
+        let feature = feature_with(Attributes::from([(
+            Attribute::new("bldg:adeOfAbstractBuilding"),
             AttributeValue::Array(vec![AttributeValue::Map(inner)]),
         )]));
         let segments = [
@@ -342,15 +342,15 @@ mod tests {
 
     #[test]
     fn resolves_through_direct_map() {
-        let inner = HashMap::from([(
-            "uro:BuildingIDAttribute".to_string(),
-            AttributeValue::Map(HashMap::from([(
-                "uro:city".to_string(),
+        let inner = Attributes::from([(
+            Attribute::new("uro:BuildingIDAttribute"),
+            AttributeValue::Map(Attributes::from([(
+                Attribute::new("uro:city"),
                 AttributeValue::String("Osaka".to_string()),
             )])),
         )]);
-        let feature = feature_with(HashMap::from([(
-            "bldg:adeOfAbstractBuilding".to_string(),
+        let feature = feature_with(Attributes::from([(
+            Attribute::new("bldg:adeOfAbstractBuilding"),
             AttributeValue::Map(inner),
         )]));
         let segments = [
@@ -366,13 +366,13 @@ mod tests {
 
     #[test]
     fn missing_path_yields_none() {
-        let feature = feature_with(HashMap::new());
+        let feature = feature_with(Attributes::new());
         assert_eq!(resolve_path(&feature, &["bldg:class"]), None);
     }
 
     #[test]
     fn write_path_creates_nested_map() {
-        let mut feature = feature_with(HashMap::new());
+        let mut feature = feature_with(Attributes::new());
         write_path(
             &mut feature,
             &["attributes", "bldg:usage"],
@@ -398,7 +398,7 @@ mod tests {
 
     #[test]
     fn write_path_single_segment_writes_top_level() {
-        let mut feature = feature_with(HashMap::new());
+        let mut feature = feature_with(Attributes::new());
         write_path(
             &mut feature,
             &["bldg:class"],

--- a/engine/runtime/action-processor/src/citygml_parser/parser.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/parser.rs
@@ -308,16 +308,21 @@ pub fn node_to_attribute_value(
         return AttributeValue::String(text_parts.join(""));
     }
 
-    // currently unordered because AttributeValue::Map is unordered
-    let mut map: HashMap<String, AttributeValue> = HashMap::new();
+    let mut map = Attributes::new();
 
     if keep_attributes {
         for ((qname, _), v) in &node.attrs {
-            map.insert(format!("@{qname}"), AttributeValue::String(v.clone()));
+            map.insert(
+                Attribute::new(format!("@{qname}")),
+                AttributeValue::String(v.clone()),
+            );
         }
     }
     if !text_parts.is_empty() {
-        map.insert("$".into(), AttributeValue::String(text_parts.join("")));
+        map.insert(
+            Attribute::new("$"),
+            AttributeValue::String(text_parts.join("")),
+        );
     }
     for (name, values) in elem_groups {
         let av = if values.len() == 1 {
@@ -333,10 +338,10 @@ pub fn node_to_attribute_value(
         } else {
             AttributeValue::Array(values)
         };
-        map.insert(name, av);
+        map.insert(Attribute::new(name), av);
     }
     for (key, val) in leaf_attr_entries {
-        map.insert(key, AttributeValue::String(val));
+        map.insert(Attribute::new(key), AttributeValue::String(val));
     }
 
     AttributeValue::Map(map)
@@ -586,9 +591,7 @@ fn build_feature(
         }
         None => {
             if let AttributeValue::Map(map) = content {
-                for (k, v) in map {
-                    attrs.insert(Attribute::new(k), v);
-                }
+                attrs.extend(map);
             }
         }
     }

--- a/engine/runtime/action-processor/src/citygml_parser/parser_next.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/parser_next.rs
@@ -374,19 +374,24 @@ pub fn node_to_attribute_value(
         return AttributeValue::String(text_parts.join(""));
     }
 
-    // currently unordered because AttributeValue::Map is unordered
-    let mut map: HashMap<String, AttributeValue> = HashMap::new();
+    let mut map = Attributes::new();
 
     if keep_attributes {
         for ((qname, _), v) in &node.attrs {
-            map.insert(format!("@{qname}"), AttributeValue::String(v.clone()));
+            map.insert(
+                Attribute::new(format!("@{qname}")),
+                AttributeValue::String(v.clone()),
+            );
         }
     }
     if !text_parts.is_empty() {
-        map.insert("$".into(), AttributeValue::String(text_parts.join("")));
+        map.insert(
+            Attribute::new("$"),
+            AttributeValue::String(text_parts.join("")),
+        );
     }
     for (key, val) in leaf_attr_entries {
-        map.insert(key, AttributeValue::String(val));
+        map.insert(Attribute::new(key), AttributeValue::String(val));
     }
     for (name, mut values) in elem_groups {
         let av = if values.len() == 1 {
@@ -394,7 +399,7 @@ pub fn node_to_attribute_value(
         } else {
             AttributeValue::Array(values)
         };
-        map.insert(name, av);
+        map.insert(Attribute::new(name), av);
     }
 
     AttributeValue::Map(map)

--- a/engine/runtime/action-processor/src/feature/duplicate_filter.rs
+++ b/engine/runtime/action-processor/src/feature/duplicate_filter.rs
@@ -129,11 +129,10 @@ impl FeatureDuplicateFilter {
 /// The same value with every object's keys in a fixed order, so that equal content always
 /// serializes to an equal string.
 ///
-/// Two containers make this necessary. `Attributes` is an `IndexMap`, so its order is the order
-/// the attributes were added, and `AttributeValue::Map` is a `std::collections::HashMap`, whose
-/// iteration order differs between instances holding identical entries. Without this, two
-/// features with the same content can produce different keys and escape comparison. Sorting is
-/// applied to objects only — array order is part of the value, not an artifact of the container.
+/// `Attributes`, at the top level and nested inside an `AttributeValue::Map` alike, is an
+/// `IndexMap`, so its order is the order the attributes were added. Without this, two features
+/// with the same content can produce different keys and escape comparison. Sorting is applied to
+/// objects only: array order is part of the value, not an artifact of the container.
 fn canonical(value: Value) -> Value {
     match value {
         Value::Object(object) => {
@@ -193,7 +192,7 @@ mod tests {
     use crate::tests::utils::create_default_execute_context;
     use pretty_assertions::assert_eq;
     use reearth_flow_runtime::forwarder::NoopChannelForwarder;
-    use reearth_flow_types::AttributeValue;
+    use reearth_flow_types::{AttributeValue, Attributes};
 
     /// A feature carrying `attributes`, with an id of its own.
     fn feature(attributes: &[(&str, &str)]) -> Feature {
@@ -306,17 +305,16 @@ mod tests {
         assert_eq!(sent, ["features", "duplicate"]);
     }
 
-    /// `AttributeValue::Map` is a `std::collections::HashMap`, whose iteration order differs
-    /// between instances holding identical entries. Enough keys are used here that an
-    /// uncanonicalized key would be very unlikely to match.
+    /// A nested `AttributeValue::Map` keeps the order its entries were added, so two maps
+    /// holding the same pairs in different orders must still compare equal.
     #[test]
     fn a_nested_map_compares_by_content_not_by_iteration_order() {
         let nested = |pairs: &[(&str, &str)]| {
             let mut feature = Feature::new_with_attributes(Default::default());
             let map = pairs
                 .iter()
-                .map(|(k, v)| ((*k).to_string(), AttributeValue::String((*v).to_string())))
-                .collect::<std::collections::HashMap<_, _>>();
+                .map(|(k, v)| (Attribute::new(*k), AttributeValue::String((*v).to_string())))
+                .collect::<Attributes>();
             feature.insert("nested", AttributeValue::Map(map));
             feature
         };

--- a/engine/runtime/action-processor/src/feature/list_concatenator.rs
+++ b/engine/runtime/action-processor/src/feature/list_concatenator.rs
@@ -125,7 +125,7 @@ impl Processor for ListConcatenator {
             // Each element should be a Map containing attributes
             if let AttributeValue::Map(element_attributes) = element {
                 // Try to get the specified attribute from this element
-                if let Some(value) = element_attributes.get(&attribute_key) {
+                if let Some(value) = element_attributes.get(attribute_key.as_str()) {
                     // Convert the value to string
                     values.push(value.to_string());
                 }

--- a/engine/runtime/action-processor/src/feature/list_exploder.rs
+++ b/engine/runtime/action-processor/src/feature/list_exploder.rs
@@ -118,7 +118,7 @@ impl Processor for ListExploder {
             let mut exploded = feature.clone();
             exploded.refresh_id();
             exploded.remove(&self.source_attribute);
-            exploded.extend_attributes(attributes.clone());
+            exploded.extend(attributes.clone());
             fw.send(ctx.new_with_feature_and_port(exploded, FEATURES_PORT.clone()));
         }
         Ok(())
@@ -141,7 +141,7 @@ impl Processor for ListExploder {
 mod tests {
     use indexmap::IndexMap;
     use reearth_flow_runtime::forwarder::{NoopChannelForwarder, ProcessorChannelForwarder};
-    use reearth_flow_types::Feature;
+    use reearth_flow_types::{Attributes, Feature};
 
     use super::*;
     use crate::tests::utils;
@@ -170,8 +170,11 @@ mod tests {
     }
 
     fn element(key: &str, value: &str) -> AttributeValue {
-        let mut map = HashMap::new();
-        map.insert(key.to_string(), AttributeValue::String(value.to_string()));
+        let mut map = Attributes::new();
+        map.insert(
+            Attribute::new(key),
+            AttributeValue::String(value.to_string()),
+        );
         AttributeValue::Map(map)
     }
 

--- a/engine/runtime/action-processor/src/feature/list_indexer.rs
+++ b/engine/runtime/action-processor/src/feature/list_indexer.rs
@@ -137,7 +137,7 @@ impl Processor for ListIndexer {
         // If we have valid element attributes, copy them to the feature
         if let Some(element_attributes) = element_attributes {
             for (key, value) in element_attributes {
-                let mut new_key = key;
+                let mut new_key = key.into_inner();
 
                 // Apply prefix if specified
                 if let Some(ref prefix) = self.copied_attribute_prefix {

--- a/engine/runtime/action-processor/src/feature/writer/csv.rs
+++ b/engine/runtime/action-processor/src/feature/writer/csv.rs
@@ -22,14 +22,7 @@ pub(super) fn write_csv(
         .from_writer(vec![]);
     let rows: Vec<AttributeValue> = features
         .iter()
-        .map(|f| {
-            AttributeValue::Map(
-                f.attributes
-                    .iter()
-                    .map(|(k, v)| (k.clone().into_inner(), v.clone()))
-                    .collect(),
-            )
-        })
+        .map(|f| AttributeValue::Map((*f.attributes).clone()))
         .collect();
     let mut fields = if let Some(first_row) = rows.first() {
         get_fields(first_row)
@@ -95,7 +88,7 @@ pub(super) fn write_csv(
 
 fn get_fields(row: &AttributeValue) -> Option<Vec<String>> {
     match row {
-        AttributeValue::Map(row) => Some(row.keys().cloned().collect::<Vec<_>>()),
+        AttributeValue::Map(row) => Some(row.keys().map(|k| k.to_string()).collect::<Vec<_>>()),
         _ => None,
     }
 }
@@ -107,9 +100,13 @@ fn get_row_values(
     fields
         .iter()
         .map(|field| match row {
-            AttributeValue::Map(row) => row.get(field).map(|v| v.to_string()).ok_or_else(|| {
-                FeatureProcessorError::FeatureWriter(format!("Field not found: {field}"))
-            }),
+            AttributeValue::Map(row) => {
+                row.get(field.as_str())
+                    .map(|v| v.to_string())
+                    .ok_or_else(|| {
+                        FeatureProcessorError::FeatureWriter(format!("Field not found: {field}"))
+                    })
+            }
             _ => Err(FeatureProcessorError::FeatureWriter(
                 "Unsupported input".to_string(),
             )),

--- a/engine/runtime/action-processor/src/geometry/area_on_area_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/area_on_area_overlayer.rs
@@ -1110,11 +1110,7 @@ fn from_midpolygons_disk<W: Write>(
                     let list_items: Vec<AttributeValue> = parents
                         .iter()
                         .map(|&parent_index| {
-                            let mut map = HashMap::new();
-                            for (attr, value) in &*attributes_cache[&parent_index] {
-                                map.insert(attr.as_ref().to_string(), value.clone());
-                            }
-                            AttributeValue::Map(map)
+                            AttributeValue::Map((*attributes_cache[&parent_index]).clone())
                         })
                         .collect();
 
@@ -1147,11 +1143,8 @@ fn from_midpolygons_disk<W: Write>(
                 );
 
                 if let Some(list_name) = list_attribute {
-                    let mut map = HashMap::new();
-                    for (attr, value) in &*attributes_cache[&parent] {
-                        map.insert(attr.as_ref().to_string(), value.clone());
-                    }
-                    let list_items = vec![AttributeValue::Map(map)];
+                    let list_items =
+                        vec![AttributeValue::Map((*attributes_cache[&parent]).clone())];
 
                     feature.attributes_mut().insert(
                         Attribute::new(list_name.clone()),

--- a/engine/runtime/action-processor/src/geometry/coordinate_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/coordinate_extractor.rs
@@ -12,7 +12,7 @@ use reearth_flow_runtime::{
     forwarder::ProcessorChannelForwarder,
     node::{Port, Processor, ProcessorFactory, FEATURES_PORT, REJECTED_PORT},
 };
-use reearth_flow_types::{Attribute, AttributeValue, CityGmlGeometry, GeometryValue};
+use reearth_flow_types::{Attribute, AttributeValue, Attributes, CityGmlGeometry, GeometryValue};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -189,17 +189,17 @@ impl Processor for CoordinateExtractor {
                 let array: Vec<AttributeValue> = coords
                     .iter()
                     .map(|&(x, y, z)| {
-                        let mut map = HashMap::new();
+                        let mut map = Attributes::new();
                         map.insert(
-                            "x".to_string(),
+                            Attribute::new("x"),
                             AttributeValue::try_from(x).unwrap_or(AttributeValue::Null),
                         );
                         map.insert(
-                            "y".to_string(),
+                            Attribute::new("y"),
                             AttributeValue::try_from(y).unwrap_or(AttributeValue::Null),
                         );
                         map.insert(
-                            "z".to_string(),
+                            Attribute::new("z"),
                             z.and_then(|v| AttributeValue::try_from(v).ok())
                                 .unwrap_or(AttributeValue::Null),
                         );
@@ -341,7 +341,7 @@ mod tests {
     use reearth_flow_geometry::types::point::{Point2D, Point3D};
     use reearth_flow_geometry::types::polygon::{Polygon2D, Polygon3D};
     use reearth_flow_runtime::forwarder::NoopChannelForwarder;
-    use reearth_flow_types::{feature::Attributes, Feature, Geometry};
+    use reearth_flow_types::{Feature, Geometry};
 
     #[cfg(not(feature = "new-geometry"))]
     #[test]

--- a/engine/runtime/action-processor/src/geometry/csg/csg_builder.rs
+++ b/engine/runtime/action-processor/src/geometry/csg/csg_builder.rs
@@ -438,14 +438,7 @@ impl CSGBuilder {
         let attr_name = self.list_attribute.as_ref()?;
         let attribute_objects = [left, right]
             .into_iter()
-            .map(|feature| {
-                let attrs: HashMap<String, AttributeValue> = feature
-                    .attributes
-                    .iter()
-                    .map(|(k, v)| (k.to_string(), v.clone()))
-                    .collect();
-                AttributeValue::Map(attrs)
-            })
+            .map(|feature| AttributeValue::Map((*feature.attributes).clone()))
             .collect();
         Some((
             Attribute::new(attr_name.clone()),

--- a/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
@@ -792,12 +792,7 @@ fn process_group<W: Write>(
                 Vec::with_capacity(source_feature_idxs.len());
             for &fi in source_feature_idxs {
                 let attrs = &attributes_by_feature[fi];
-                let attrs_map: HashMap<String, AttributeValue> = attrs
-                    .as_ref()
-                    .iter()
-                    .map(|(k, v)| (k.clone().inner(), v.clone()))
-                    .collect();
-                overlaid_list.push(AttributeValue::Map(attrs_map));
+                overlaid_list.push(AttributeValue::Map((**attrs).clone()));
             }
             attributes.insert(
                 Attribute::new(list_attribute),

--- a/engine/runtime/action-processor/src/http/response.rs
+++ b/engine/runtime/action-processor/src/http/response.rs
@@ -1,11 +1,10 @@
 use base64::{engine::general_purpose, Engine as _};
 use bytes::Bytes;
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use reearth_flow_common::uri::Uri;
 use reearth_flow_storage::resolve::StorageResolver;
-use reearth_flow_types::{Attribute, AttributeValue, Feature};
+use reearth_flow_types::{Attribute, AttributeValue, Attributes, Feature};
 
 use super::client::HttpResponse;
 use super::errors::{HttpProcessorError, Result};
@@ -39,10 +38,15 @@ pub(crate) fn process_response(
         AttributeValue::Number(response.status_code.into()),
     );
 
-    let headers_map: HashMap<String, AttributeValue> = response
+    let headers_map: Attributes = response
         .headers
         .iter()
-        .map(|(k, v)| (k.clone(), AttributeValue::String(v.clone())))
+        .map(|(k, v)| {
+            (
+                Attribute::new(k.as_str()),
+                AttributeValue::String(v.clone()),
+            )
+        })
         .collect();
     attributes.insert(
         Attribute::new(HEADERS_ATTRIBUTE.to_string()),
@@ -193,7 +197,6 @@ fn save_response_to_file(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reearth_flow_types::Attributes;
     use std::str::FromStr;
 
     fn make_env() -> Arc<serde_json::Map<String, serde_json::Value>> {

--- a/engine/runtime/action-processor/src/xml/types.rs
+++ b/engine/runtime/action-processor/src/xml/types.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
-
-use reearth_flow_types::{Attribute, AttributeValue};
+use reearth_flow_types::{Attribute, AttributeValue, Attributes};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -38,23 +36,23 @@ impl ValidationResult {
     }
 }
 
-impl From<ValidationResult> for HashMap<String, AttributeValue> {
+impl From<ValidationResult> for Attributes {
     fn from(result: ValidationResult) -> Self {
-        let mut map = HashMap::new();
+        let mut map = Attributes::new();
         map.insert(
-            "errorType".to_string(),
+            Attribute::new("errorType"),
             AttributeValue::String(result.error_type),
         );
         map.insert(
-            "message".to_string(),
+            Attribute::new("message"),
             AttributeValue::String(result.message),
         );
         map.insert(
-            "line".to_string(),
+            Attribute::new("line"),
             AttributeValue::String(result.line.unwrap_or_default().to_string()),
         );
         map.insert(
-            "col".to_string(),
+            Attribute::new("col"),
             AttributeValue::String(result.col.unwrap_or_default().to_string()),
         );
         map

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/cost.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/cost.rs
@@ -117,7 +117,7 @@ fn attribute_value_bytes(value: &AttributeValue) -> u64 {
         AttributeValue::Array(items) => items.iter().map(attribute_value_bytes).sum(),
         AttributeValue::Map(items) => items
             .iter()
-            .map(|(k, v)| k.len() as u64 + attribute_value_bytes(v))
+            .map(|(k, v)| k.as_str().len() as u64 + attribute_value_bytes(v))
             .sum(),
         AttributeValue::Bytes(b) => b.len() as u64,
     }

--- a/engine/runtime/action-sink/src/file/csv.rs
+++ b/engine/runtime/action-sink/src/file/csv.rs
@@ -221,14 +221,7 @@ fn write_records<W: std::io::Write>(
 
     let rows: Vec<AttributeValue> = features
         .iter()
-        .map(|f| {
-            AttributeValue::Map(
-                f.attributes
-                    .iter()
-                    .map(|(k, v)| (k.to_string(), v.clone()))
-                    .collect(),
-            )
-        })
+        .map(|f| AttributeValue::Map((*f.attributes).clone()))
         .collect();
     let mut attribute_fields = get_fields(rows.first().unwrap());
 
@@ -350,7 +343,7 @@ fn write_records<W: std::io::Write>(
 
 fn get_fields(row: &AttributeValue) -> Option<Vec<String>> {
     match row {
-        AttributeValue::Map(row) => Some(row.keys().cloned().collect::<Vec<_>>()),
+        AttributeValue::Map(row) => Some(row.keys().map(|k| k.to_string()).collect::<Vec<_>>()),
         _ => None,
     }
 }
@@ -362,9 +355,13 @@ fn get_row_values(
     fields
         .iter()
         .map(|field| match row {
-            AttributeValue::Map(row) => row.get(field).map(|v| v.to_string()).ok_or_else(|| {
-                crate::errors::SinkError::CsvWriter(format!("Field not found: {field}"))
-            }),
+            AttributeValue::Map(row) => {
+                row.get(field.as_str())
+                    .map(|v| v.to_string())
+                    .ok_or_else(|| {
+                        crate::errors::SinkError::CsvWriter(format!("Field not found: {field}"))
+                    })
+            }
             _ => Err(crate::errors::SinkError::CsvWriter(
                 "Unsupported input".to_string(),
             )),

--- a/engine/runtime/action-sink/src/file/mvt/tags.rs
+++ b/engine/runtime/action-sink/src/file/mvt/tags.rs
@@ -32,7 +32,7 @@ pub fn convert_properties(tags_enc: &mut TagsEncoder, name: &str, tree: &Attribu
         }
         AttributeValue::Map(obj) => {
             for (key, value) in obj {
-                convert_properties(tags_enc, key, value);
+                convert_properties(tags_enc, key.as_str(), value);
             }
         }
         AttributeValue::DateTime(v) => {

--- a/engine/runtime/action-sink/src/file/obj.rs
+++ b/engine/runtime/action-sink/src/file/obj.rs
@@ -436,7 +436,7 @@ fn extract_material_name(
             let mut first_material_name: Option<String> = None;
 
             for (mat_name, mat_value) in props_map {
-                if !materials.contains_key(&mat_name) {
+                if !materials.contains_key(mat_name.as_str()) {
                     let mut material = Material {
                         ambient: None,
                         diffuse: None,
@@ -496,12 +496,12 @@ fn extract_material_name(
                         }
                     }
 
-                    materials.insert(mat_name.clone(), material);
+                    materials.insert(mat_name.to_string(), material);
                 }
 
                 // Remember the first material name
                 if first_material_name.is_none() {
-                    first_material_name = Some(mat_name.clone());
+                    first_material_name = Some(mat_name.to_string());
                 }
             }
 

--- a/engine/runtime/action-source/src/feature_creator.rs
+++ b/engine/runtime/action-source/src/feature_creator.rs
@@ -1,13 +1,12 @@
 use std::collections::HashMap;
 
-use indexmap::IndexMap;
 use reearth_flow_runtime::{
     errors::BoxedError,
     event::EventHub,
     executor_operation::NodeContext,
     node::{IngestionMessage, Port, Source, SourceFactory, FEATURES_PORT},
 };
-use reearth_flow_types::{Attribute, AttributeValue, Code, CodeType, Feature};
+use reearth_flow_types::{AttributeValue, Code, CodeType, Feature};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -120,11 +119,7 @@ impl Source for FeatureCreatorSource {
         sender: Sender<(Port, IngestionMessage)>,
     ) -> Result<(), BoxedError> {
         match self.params.creator.clone() {
-            AttributeValue::Map(map) => {
-                let attributes = map
-                    .into_iter()
-                    .map(|(k, v)| (Attribute::new(k), v))
-                    .collect::<IndexMap<Attribute, AttributeValue>>();
+            AttributeValue::Map(attributes) => {
                 let feature = Feature::from(attributes);
                 sender
                     .send((
@@ -136,11 +131,7 @@ impl Source for FeatureCreatorSource {
             }
             AttributeValue::Array(arr) => {
                 for item in arr {
-                    if let AttributeValue::Map(map) = item {
-                        let attributes = map
-                            .into_iter()
-                            .map(|(k, v)| (Attribute::new(k), v))
-                            .collect::<IndexMap<Attribute, AttributeValue>>();
+                    if let AttributeValue::Map(attributes) = item {
                         let feature = Feature::from(attributes);
                         sender
                             .send((

--- a/engine/runtime/action-source/src/file/obj.rs
+++ b/engine/runtime/action-source/src/file/obj.rs
@@ -20,7 +20,7 @@ use reearth_flow_runtime::{
     node::{IngestionMessage, Port, Source, SourceFactory, FEATURES_PORT},
 };
 use reearth_flow_types::{
-    Attribute, AttributeValue, Code, CompiledCode, Feature, Geometry, GeometryValue,
+    Attribute, AttributeValue, Attributes, Code, CompiledCode, Feature, Geometry, GeometryValue,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -272,14 +272,14 @@ fn extract_material_properties(
             .collect(),
     );
 
-    let mut material_details = HashMap::new();
+    let mut material_details = Attributes::new();
     for mat_name in used_materials {
         if let Some(mat) = materials.get(mat_name) {
-            let mut mat_props = HashMap::new();
+            let mut mat_props = Attributes::new();
 
             if let Some(ambient) = mat.ambient {
                 mat_props.insert(
-                    "ambient".to_string(),
+                    Attribute::new("ambient"),
                     AttributeValue::Array(vec![
                         AttributeValue::Number(safe_f64_to_number(ambient[0] as f64)),
                         AttributeValue::Number(safe_f64_to_number(ambient[1] as f64)),
@@ -290,7 +290,7 @@ fn extract_material_properties(
 
             if let Some(diffuse) = mat.diffuse {
                 mat_props.insert(
-                    "diffuse".to_string(),
+                    Attribute::new("diffuse"),
                     AttributeValue::Array(vec![
                         AttributeValue::Number(safe_f64_to_number(diffuse[0] as f64)),
                         AttributeValue::Number(safe_f64_to_number(diffuse[1] as f64)),
@@ -301,7 +301,7 @@ fn extract_material_properties(
 
             if let Some(specular) = mat.specular {
                 mat_props.insert(
-                    "specular".to_string(),
+                    Attribute::new("specular"),
                     AttributeValue::Array(vec![
                         AttributeValue::Number(safe_f64_to_number(specular[0] as f64)),
                         AttributeValue::Number(safe_f64_to_number(specular[1] as f64)),
@@ -312,40 +312,43 @@ fn extract_material_properties(
 
             if let Some(shininess) = mat.shininess {
                 mat_props.insert(
-                    "shininess".to_string(),
+                    Attribute::new("shininess"),
                     AttributeValue::Number(safe_f64_to_number(shininess as f64)),
                 );
             }
 
             if let Some(transparency) = mat.transparency {
                 mat_props.insert(
-                    "transparency".to_string(),
+                    Attribute::new("transparency"),
                     AttributeValue::Number(safe_f64_to_number(transparency as f64)),
                 );
             }
 
             if let Some(illumination) = mat.illumination {
                 mat_props.insert(
-                    "illumination".to_string(),
+                    Attribute::new("illumination"),
                     AttributeValue::Number(serde_json::Number::from(illumination)),
                 );
             }
 
             if let Some(texture_map) = &mat.texture_map {
                 mat_props.insert(
-                    "textureMap".to_string(),
+                    Attribute::new("textureMap"),
                     AttributeValue::String(texture_map.clone()),
                 );
             }
 
-            material_details.insert(mat_name.clone(), AttributeValue::Map(mat_props));
+            material_details.insert(
+                Attribute::new(mat_name.as_str()),
+                AttributeValue::Map(mat_props),
+            );
         }
     }
 
     let material_properties = if !material_details.is_empty() {
         AttributeValue::Map(material_details)
     } else {
-        AttributeValue::Map(HashMap::new())
+        AttributeValue::Map(Attributes::new())
     };
 
     (materials_array, material_properties)

--- a/engine/runtime/common/src/attribute.rs
+++ b/engine/runtime/common/src/attribute.rs
@@ -1,5 +1,6 @@
+use std::borrow::Borrow;
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
 use std::fmt::Display;
 use std::hash::{Hash, Hasher};
 
@@ -14,7 +15,8 @@ use crate::str::base64_encode;
 use crate::uri::Uri;
 use crate::xml::{xpath_value_to_json, XmlXpathValue};
 
-/// Type alias for feature attributes to reduce verbosity
+/// An ordered set of attributes, held both by a feature and by a nested
+/// [`AttributeValue::Map`].
 pub type Attributes = IndexMap<Attribute, AttributeValue>;
 
 #[nutype(
@@ -40,6 +42,25 @@ impl Attribute {
     pub fn inner(&self) -> String {
         self.clone().into_inner()
     }
+
+    /// Borrowed view of the key.
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
+}
+
+/// Lets an `Attributes` map be looked up by `&str`, as a `HashMap<String, _>` can be.
+impl Borrow<str> for Attribute {
+    fn borrow(&self) -> &str {
+        self.as_ref()
+    }
+}
+
+/// Unwraps the key back into its string.
+impl From<Attribute> for String {
+    fn from(value: Attribute) -> Self {
+        value.into_inner()
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -51,7 +72,7 @@ pub enum AttributeValue {
     String(String),
     DateTime(DateTime),
     Array(Vec<AttributeValue>),
-    Map(HashMap<String, AttributeValue>),
+    Map(Attributes),
     Bytes(Bytes),
 }
 
@@ -85,7 +106,7 @@ impl AttributeValue {
     }
 
     pub fn default_map() -> Self {
-        Self::Map(HashMap::new())
+        Self::Map(Attributes::new())
     }
 
     pub fn as_bool(&self) -> Option<bool> {
@@ -137,7 +158,7 @@ impl AttributeValue {
         }
     }
 
-    pub fn as_map(&self) -> Option<HashMap<String, AttributeValue>> {
+    pub fn as_map(&self) -> Option<Attributes> {
         match self {
             Self::Map(v) => Some(v.clone()),
             _ => None,
@@ -213,7 +234,7 @@ impl AttributeValue {
     }
 
     pub fn flatten(self) -> Self {
-        let mut result = HashMap::new();
+        let mut result = Attributes::new();
         match self {
             AttributeValue::Array(map) => {
                 for value in map {
@@ -286,8 +307,8 @@ impl From<serde_json::Value> for AttributeValue {
             }
             serde_json::Value::Object(v) => AttributeValue::Map(
                 v.into_iter()
-                    .map(|(k, v)| (k, AttributeValue::from(v)))
-                    .collect::<HashMap<_, _>>(),
+                    .map(|(k, v)| (Attribute::new(k), AttributeValue::from(v)))
+                    .collect::<Attributes>(),
             ),
         }
     }
@@ -309,7 +330,7 @@ impl From<AttributeValue> for serde_json::Value {
             AttributeValue::Bytes(v) => serde_json::Value::String(base64_encode(v.as_ref())),
             AttributeValue::Map(v) => serde_json::Value::Object(
                 v.into_iter()
-                    .map(|(k, v)| (k, serde_json::Value::from(v)))
+                    .map(|(k, v)| (k.into_inner(), serde_json::Value::from(v)))
                     .collect::<serde_json::Map<_, _>>(),
             ),
         }
@@ -357,11 +378,17 @@ impl Hash for AttributeValue {
                 b.hash(state);
             }
             AttributeValue::Map(map) => {
+                // Two maps holding the same entries are equal whatever order they were built
+                // in, so the entries are folded together commutatively rather than in order.
                 "Map".hash(state);
-                for (k, v) in map {
-                    k.hash(state);
-                    v.hash(state);
+                let mut entries: u64 = 0;
+                for entry in map {
+                    let mut hasher = DefaultHasher::new();
+                    entry.hash(&mut hasher);
+                    entries = entries.wrapping_add(hasher.finish());
                 }
+                map.len().hash(state);
+                entries.hash(state);
             }
             AttributeValue::DateTime(dt) => {
                 "DateTime".hash(state);
@@ -385,7 +412,7 @@ fn compare_numbers(n1: &Number, n2: &Number) -> Option<Ordering> {
     None
 }
 
-pub fn all_attribute_keys(items: &HashMap<String, AttributeValue>) -> Vec<String> {
+pub fn all_attribute_keys(items: &Attributes) -> Vec<Attribute> {
     let mut keys = Vec::new();
     for (key, value) in items {
         keys.push(key.clone());
@@ -397,13 +424,10 @@ pub fn all_attribute_keys(items: &HashMap<String, AttributeValue>) -> Vec<String
 }
 
 impl AttributeValue {
-    pub fn get_recursive<T: AsRef<str>>(
-        key: T,
-        items: &HashMap<String, AttributeValue>,
-    ) -> Vec<AttributeValue> {
+    pub fn get_recursive<T: AsRef<str>>(key: T, items: &Attributes) -> Vec<AttributeValue> {
         let mut values = Vec::new();
         for (k, v) in items {
-            if k.as_str() == key.as_ref() {
+            if k.as_ref() == key.as_ref() {
                 values.push(v.clone());
             }
             if let AttributeValue::Array(array) = v {
@@ -448,7 +472,7 @@ mod tests {
 
         let map1 = AttributeValue::Map(
             vec![(
-                "key".to_string(),
+                Attribute::new("key"),
                 AttributeValue::String("value".to_string()),
             )]
             .into_iter()
@@ -456,7 +480,7 @@ mod tests {
         );
         let map2 = AttributeValue::Map(
             vec![(
-                "key".to_string(),
+                Attribute::new("key"),
                 AttributeValue::String("value".to_string()),
             )]
             .into_iter()
@@ -482,41 +506,83 @@ mod tests {
 
     #[test]
     fn test_all_attribute_keys() {
-        let mut map = HashMap::new();
+        let mut map = Attributes::new();
         map.insert(
-            "key1".to_string(),
+            Attribute::new("key1"),
             AttributeValue::String("value1".to_string()),
         );
-        let mut nested_map = HashMap::new();
+        let mut nested_map = Attributes::new();
         nested_map.insert(
-            "key2".to_string(),
+            Attribute::new("key2"),
             AttributeValue::String("value2".to_string()),
         );
-        map.insert("nested".to_string(), AttributeValue::Map(nested_map));
+        map.insert(Attribute::new("nested"), AttributeValue::Map(nested_map));
 
         let mut keys = all_attribute_keys(&map);
         keys.sort();
         assert_eq!(
             keys,
-            vec!["key1".to_string(), "key2".to_string(), "nested".to_string()]
+            vec![
+                Attribute::new("key1"),
+                Attribute::new("key2"),
+                Attribute::new("nested")
+            ]
         );
     }
 
     #[test]
     fn test_get_recursive() {
-        let mut map = HashMap::new();
+        let mut map = Attributes::new();
         map.insert(
-            "key1".to_string(),
+            Attribute::new("key1"),
             AttributeValue::String("value1".to_string()),
         );
-        let mut nested_map = HashMap::new();
+        let mut nested_map = Attributes::new();
         nested_map.insert(
-            "key2".to_string(),
+            Attribute::new("key2"),
             AttributeValue::String("value2".to_string()),
         );
-        map.insert("nested".to_string(), AttributeValue::Map(nested_map));
+        map.insert(Attribute::new("nested"), AttributeValue::Map(nested_map));
 
         let values = AttributeValue::get_recursive("key2", &map);
         assert_eq!(values, vec![AttributeValue::String("value2".to_string())]);
+    }
+
+    #[test]
+    fn a_nested_map_round_trips_through_json() {
+        let value = AttributeValue::Map(Attributes::from([
+            (
+                Attribute::new("outer"),
+                AttributeValue::Map(Attributes::from([(
+                    Attribute::new("inner"),
+                    AttributeValue::String("v".to_string()),
+                )])),
+            ),
+            (Attribute::new("n"), AttributeValue::Number(1.into())),
+        ]));
+        let json = serde_json::to_string(&value).unwrap();
+        assert_eq!(json, r#"{"outer":{"inner":"v"},"n":1}"#);
+        let back: AttributeValue = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, value);
+    }
+
+    #[test]
+    fn a_nested_map_hashes_the_same_whatever_order_it_was_built_in() {
+        let entries = [
+            (Attribute::new("a"), AttributeValue::Number(1.into())),
+            (Attribute::new("b"), AttributeValue::Number(2.into())),
+            (Attribute::new("c"), AttributeValue::Number(3.into())),
+        ];
+        let forward = AttributeValue::Map(entries.iter().cloned().collect());
+        let reversed = AttributeValue::Map(entries.iter().rev().cloned().collect());
+
+        assert_eq!(forward, reversed);
+        assert_eq!(hash_of(&forward), hash_of(&reversed));
+    }
+
+    fn hash_of(value: &AttributeValue) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        value.hash(&mut hasher);
+        hasher.finish()
     }
 }

--- a/engine/runtime/common/src/attribute.rs
+++ b/engine/runtime/common/src/attribute.rs
@@ -279,7 +279,10 @@ impl Display for AttributeValue {
                 Ok(())
             }
             AttributeValue::Bytes(v) => write!(f, "{v:?}"),
-            AttributeValue::Map(v) => write!(f, "{v:?}"),
+            AttributeValue::Map(v) => match serde_json::to_string(v) {
+                Ok(json) => write!(f, "{json}"),
+                Err(_) => Err(std::fmt::Error),
+            },
             AttributeValue::DateTime(v) => write!(f, "{}", v.to_rfc3339()),
         }
     }

--- a/engine/runtime/gltf/src/next/metadata.rs
+++ b/engine/runtime/gltf/src/next/metadata.rs
@@ -309,6 +309,7 @@ mod tests {
     use indexmap::IndexMap;
 
     use super::*;
+    use reearth_flow_types::Attribute;
 
     fn feature_with_nested() -> Feature {
         let mut attrs: IndexMap<String, AttributeValue> = IndexMap::new();
@@ -316,9 +317,12 @@ mod tests {
         attrs.insert(
             "addr".to_string(),
             AttributeValue::Map(
-                [("city".to_string(), AttributeValue::String("X".to_string()))]
-                    .into_iter()
-                    .collect(),
+                [(
+                    Attribute::new("city"),
+                    AttributeValue::String("X".to_string()),
+                )]
+                .into_iter()
+                .collect(),
             ),
         );
         attrs.insert(

--- a/engine/runtime/types/src/conversion/nusamai.rs
+++ b/engine/runtime/types/src/conversion/nusamai.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use nusamai_citygml::GeometryRef;
 use nusamai_citygml::{object::ObjectStereotype, GeometryType, Value};
 use nusamai_plateau::Entity;
@@ -9,7 +7,9 @@ use reearth_flow_geometry::types::multi_polygon::MultiPolygon2D;
 use reearth_flow_geometry::types::polygon::Polygon3D;
 
 use crate::error::Error;
-use crate::{AttributeValue, CityGmlGeometry, Geometry, GeometryValue, GmlGeometry};
+use crate::{
+    Attribute, AttributeValue, Attributes, CityGmlGeometry, Geometry, GeometryValue, GmlGeometry,
+};
 
 // Convert nusamai geometry to reearth_flow_geometry Geometry
 // Expect well-formed geometries parsed by nusamai_citygml:
@@ -333,23 +333,19 @@ pub fn entity_to_geometry(
     ))
 }
 
-pub fn from_nusamai_citygml_value(
-    value: &nusamai_citygml::object::Value,
-) -> HashMap<String, AttributeValue> {
+pub fn from_nusamai_citygml_value(value: &nusamai_citygml::object::Value) -> Attributes {
     match value {
         nusamai_citygml::object::Value::Object(obj) => process_object_attributes(&obj.attributes),
         nusamai_citygml::object::Value::Array(_arr) => {
             // Arrays at top level are not expected in typical CityGML
-            HashMap::new()
+            Attributes::new()
         }
-        _ => HashMap::new(),
+        _ => Attributes::new(),
     }
 }
 
-fn process_object_attributes(
-    attributes: &nusamai_citygml::object::Map,
-) -> HashMap<String, AttributeValue> {
-    let mut result = HashMap::new();
+fn process_object_attributes(attributes: &nusamai_citygml::object::Map) -> Attributes {
+    let mut result = Attributes::new();
     for (key, value) in attributes {
         let attrs = process_attribute(key, value);
         result.extend(attrs);
@@ -357,32 +353,35 @@ fn process_object_attributes(
     result
 }
 
-fn process_attribute(key: &str, value: &nusamai_citygml::Value) -> HashMap<String, AttributeValue> {
-    let mut result = HashMap::new();
+fn process_attribute(key: &str, value: &nusamai_citygml::Value) -> Attributes {
+    let mut result = Attributes::new();
     match value {
         nusamai_citygml::Value::Code(v) => {
             result.insert(
-                key.to_string(),
+                Attribute::new(key),
                 AttributeValue::String(v.value().to_owned()),
             );
             if let Some(code) = v.code() {
                 result.insert(
-                    format!("{key}_code"),
+                    Attribute::new(format!("{key}_code")),
                     AttributeValue::String(code.to_owned()),
                 );
             }
         }
         nusamai_citygml::Value::Measure(v) => {
             let value = serde_json::Number::from_string_unchecked(v.value().to_string());
-            result.insert(key.to_string(), AttributeValue::Number(value));
+            result.insert(Attribute::new(key), AttributeValue::Number(value));
             if let Some(uom) = v.uom() {
-                result.insert(format!("{key}_uom"), AttributeValue::String(uom.to_owned()));
+                result.insert(
+                    Attribute::new(format!("{key}_uom")),
+                    AttributeValue::String(uom.to_owned()),
+                );
             }
         }
         nusamai_citygml::Value::Date(v) => {
             // preserve plateau date format
             let string = v.format("%Y-%m-%d").to_string();
-            result.insert(key.to_string(), AttributeValue::String(string));
+            result.insert(Attribute::new(key), AttributeValue::String(string));
         }
         nusamai_citygml::Value::Array(arr) => {
             process_array_attribute(&mut result, key, arr);
@@ -392,7 +391,7 @@ fn process_attribute(key: &str, value: &nusamai_citygml::Value) -> HashMap<Strin
         }
         _ => {
             result.insert(
-                key.to_string(),
+                Attribute::new(key),
                 citygml_value_to_attribute_value(value.clone()),
             );
         }
@@ -401,7 +400,7 @@ fn process_attribute(key: &str, value: &nusamai_citygml::Value) -> HashMap<Strin
 }
 
 fn process_array_attribute(
-    result: &mut HashMap<String, AttributeValue>,
+    result: &mut Attributes,
     key: &str,
     arr: &[nusamai_citygml::object::Value],
 ) {
@@ -441,38 +440,38 @@ fn process_array_attribute(
 
         if has_codes {
             // unzip resolved values and the code
-            result.insert(key.to_string(), AttributeValue::Array(values));
-            result.insert(format!("{key}_code"), AttributeValue::Array(codes));
+            result.insert(Attribute::new(key), AttributeValue::Array(values));
+            result.insert(
+                Attribute::new(format!("{key}_code")),
+                AttributeValue::Array(codes),
+            );
         } else if !values.is_empty() {
-            result.insert(key.to_string(), AttributeValue::Array(values));
+            result.insert(Attribute::new(key), AttributeValue::Array(values));
         }
     }
 }
 
-fn process_object_value(
-    result: &mut HashMap<String, AttributeValue>,
-    obj: &nusamai_citygml::object::Object,
-) {
+fn process_object_value(result: &mut Attributes, obj: &nusamai_citygml::object::Object) {
     // Special handling for gen:genericAttribute to match reference implementation format
     if obj.typename == "gen:genericAttribute" {
         let generic_attrs = convert_generic_attributes(&obj.attributes);
         // Append to existing array if key exists, otherwise create new
-        append_to_array(result, obj.typename.to_string(), generic_attrs);
+        append_to_array(result, Attribute::new(obj.typename.as_ref()), generic_attrs);
     } else {
         // recursive process for other objects
         let attrs = process_object_attributes(&obj.attributes);
         let new_value = AttributeValue::Map(attrs);
         // Append to existing array if key exists (e.g., multiple KeyValuePairAttribute)
-        append_to_array(result, obj.typename.to_string(), vec![new_value]);
+        append_to_array(
+            result,
+            Attribute::new(obj.typename.as_ref()),
+            vec![new_value],
+        );
     }
 }
 
 /// Helper to append values to an existing array or create a new one
-fn append_to_array(
-    result: &mut HashMap<String, AttributeValue>,
-    key: String,
-    new_values: Vec<AttributeValue>,
-) {
+fn append_to_array(result: &mut Attributes, key: Attribute, new_values: Vec<AttributeValue>) {
     match result.get_mut(&key) {
         Some(AttributeValue::Array(existing)) => {
             // Append to existing array
@@ -497,8 +496,8 @@ fn convert_generic_attributes(attributes: &nusamai_citygml::object::Map) -> Vec<
     let mut result = Vec::new();
 
     for (name, value) in attributes {
-        let mut attr_map = HashMap::new();
-        attr_map.insert("name".to_string(), AttributeValue::String(name.clone()));
+        let mut attr_map = Attributes::new();
+        attr_map.insert(Attribute::new("name"), AttributeValue::String(name.clone()));
 
         // Determine type and value based on the Value discriminant
         let (type_str, value_attr) = match value {
@@ -532,10 +531,10 @@ fn convert_generic_attributes(attributes: &nusamai_citygml::object::Map) -> Vec<
         };
 
         attr_map.insert(
-            "type".to_string(),
+            Attribute::new("type"),
             AttributeValue::String(type_str.to_string()),
         );
-        attr_map.insert("value".to_string(), value_attr);
+        attr_map.insert(Attribute::new("value"), value_attr);
 
         result.push(AttributeValue::Map(attr_map));
     }
@@ -566,11 +565,11 @@ fn citygml_value_to_attribute_value(value: nusamai_citygml::Value) -> AttributeV
         nusamai_citygml::Value::Point(v) => AttributeValue::Map(
             vec![
                 (
-                    "type".to_string(),
+                    Attribute::new("type"),
                     AttributeValue::String("Point".to_string()),
                 ),
                 (
-                    "coordinates".to_string(),
+                    Attribute::new("coordinates"),
                     AttributeValue::Array(
                         v.coordinates()
                             .iter()
@@ -591,7 +590,12 @@ fn citygml_value_to_attribute_value(value: nusamai_citygml::Value) -> AttributeV
             let m = v
                 .attributes
                 .iter()
-                .map(|(k, v)| (k.into(), citygml_value_to_attribute_value(v.clone())))
+                .map(|(k, v)| {
+                    (
+                        Attribute::new(k.as_str()),
+                        citygml_value_to_attribute_value(v.clone()),
+                    )
+                })
                 .collect();
             AttributeValue::Map(m)
         }

--- a/engine/runtime/types/src/expr.rs
+++ b/engine/runtime/types/src/expr.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -13,7 +12,7 @@ use reearth_flow_expr::{
     Result as ExprResult, TypeValue as ExprTypeValue, Value as ExprValue,
 };
 
-use crate::attribute::{Attribute, AttributeValue};
+use crate::attribute::{Attribute, AttributeValue, Attributes};
 use crate::error::{Error as TypesError, Result as TypesResult};
 use crate::feature::Feature;
 
@@ -59,8 +58,8 @@ impl FromValue for FlowValue {
     fn from_dict(map: IndexMap<String, Self>) -> TypesResult<Self> {
         Ok(FlowValue(AttributeValue::Map(
             map.into_iter()
-                .map(|(k, FlowValue(v))| (k, v))
-                .collect::<HashMap<_, _>>(),
+                .map(|(k, FlowValue(v))| (Attribute::new(k), v))
+                .collect::<Attributes>(),
         )))
     }
     fn on_cycle() -> TypesResult<Self> {

--- a/engine/runtime/types/src/feature.rs
+++ b/engine/runtime/types/src/feature.rs
@@ -124,12 +124,8 @@ impl From<AttributeValue> for Feature {
     fn from(v: AttributeValue) -> Self {
         let attributes = match v {
             AttributeValue::Map(v) => v,
-            _ => HashMap::new(),
+            _ => Attributes::new(),
         };
-        let attributes = attributes
-            .into_iter()
-            .map(|(k, v)| (Attribute::new(k), v))
-            .collect::<Attributes>();
         Self {
             id: uuid::Uuid::new_v4(),
             attributes: Arc::new(attributes),
@@ -424,17 +420,16 @@ impl Feature {
         self.attributes.iter()
     }
 
-    pub fn as_map(&self) -> HashMap<String, AttributeValue> {
-        self.attributes
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.clone()))
-            .collect()
+    /// Clone of the feature's attributes.
+    pub fn as_map(&self) -> Attributes {
+        (*self.attributes).clone()
     }
 
-    pub fn all_attribute_keys(&self) -> Vec<String> {
+    /// Every attribute key of the feature, including the keys of nested maps.
+    pub fn all_attribute_keys(&self) -> Vec<Attribute> {
         let mut keys = Vec::new();
         for (key, value) in self.attributes.iter() {
-            keys.push(key.clone().to_string());
+            keys.push(key.clone());
             if let AttributeValue::Map(map) = value {
                 keys.extend(all_attribute_keys(map));
             }
@@ -447,14 +442,7 @@ pub fn create_batch_feature(features: &[Feature]) -> Feature {
     let packed = AttributeValue::Array(
         features
             .iter()
-            .map(|f| {
-                AttributeValue::Map(
-                    f.attributes
-                        .iter()
-                        .map(|(k, v)| (k.clone().into_inner().to_string(), v.clone()))
-                        .collect(),
-                )
-            })
+            .map(|f| AttributeValue::Map((*f.attributes).clone()))
             .collect(),
     );
     Feature::from(IndexMap::from([(

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.171"
+version = "0.2.172"
 edition = "2021"
 
 [features]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.361"
+version = "0.1.362"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
# Overview
The attributes use `IndexMap<Attribute, AttributeValue>` though a nested attribute uses `HashMap<String, AttributeValue>`. This PR fixes the nested attribute type to be `IndexMap<Attribute, AttributeValue>`.